### PR TITLE
Move generated oxia binary into `bin` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea
-oxia/cmd
-oxia-client
+bin/oxia
 **/*.pb.go
 .DS_Store
 **/*.toolbox

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ FROM alpine:3.16.1
 RUN mkdir /oxia
 WORKDIR /oxia
 
-COPY --from=build /oxia-src/oxia /oxia/bin/oxia
+COPY --from=build /oxia-src/bin/oxia /oxia/bin/oxia
 ENV PATH=$PATH:/oxia/bin
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 
 .PHONY: build
 build: proto
-	go build -v -o oxia ./cmd
+	go build -v -o bin/oxia ./cmd
 
 test: build
 	go test -cover -race ./...
 
 clean:
-	rm -f oxia
+	rm -f bin/oxia
 	rm -f */*.pb.go
 
 docker:


### PR DESCRIPTION
Since we now have the `oxia` directory for client API, moving the binary into `bin/` folder