### PR TITLE
Use uint32 for shard-id everywhere

### DIFF
--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -80,7 +80,7 @@ func NewFollowerController(shardId uint32, wal Wal, kvFactory kv.KVFactory) (Fol
 			Logger(),
 	}
 
-	if db, err := kv.NewDB(int32(shardId), kvFactory); err != nil {
+	if db, err := kv.NewDB(shardId, kvFactory); err != nil {
 		return nil, err
 	} else {
 		fc.db = db

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -20,7 +20,7 @@ type DB interface {
 	ProcessRead(b *proto.ReadRequest) (*proto.ReadResponse, error)
 }
 
-func NewDB(shardId int32, factory KVFactory) (DB, error) {
+func NewDB(shardId uint32, factory KVFactory) (DB, error) {
 	kv, err := factory.NewKV(shardId)
 	if err != nil {
 		return nil, err

--- a/server/kv/kv.go
+++ b/server/kv/kv.go
@@ -65,5 +65,5 @@ var DefaultKVFactoryOptions = &KVFactoryOptions{
 type KVFactory interface {
 	io.Closer
 
-	NewKV(shardId int32) (KV, error)
+	NewKV(shardId uint32) (KV, error)
 }

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -48,7 +48,7 @@ func (p *PebbleFactory) Close() error {
 	return nil
 }
 
-func (p *PebbleFactory) NewKV(shardId int32) (KV, error) {
+func (p *PebbleFactory) NewKV(shardId uint32) (KV, error) {
 	return newKVPebble(p, shardId)
 }
 
@@ -58,7 +58,7 @@ type Pebble struct {
 	db *pebble.DB
 }
 
-func newKVPebble(factory *PebbleFactory, shardId int32) (KV, error) {
+func newKVPebble(factory *PebbleFactory, shardId uint32) (KV, error) {
 	pb := &Pebble{}
 
 	dbPath := filepath.Join(factory.dataDir, fmt.Sprint("shard-", shardId))

--- a/standalone/standalone_rpc_server.go
+++ b/standalone/standalone_rpc_server.go
@@ -20,7 +20,7 @@ type StandaloneRpcServer struct {
 
 	identityAddr string
 	numShards    uint32
-	dbs          map[int32]kv.DB
+	dbs          map[uint32]kv.DB
 
 	grpcServer *grpc.Server
 	log        zerolog.Logger
@@ -30,14 +30,14 @@ func NewStandaloneRpcServer(port int, identityAddr string, numShards uint32, kvF
 	// Assuming 1 single shard
 	res := &StandaloneRpcServer{
 		numShards: numShards,
-		dbs:       make(map[int32]kv.DB),
+		dbs:       make(map[uint32]kv.DB),
 		log: log.With().
 			Str("component", "standalone-rpc-server").
 			Logger(),
 	}
 
 	var err error
-	for i := int32(0); i < int32(numShards); i++ {
+	for i := uint32(0); i < numShards; i++ {
 		if res.dbs[i], err = kv.NewDB(i, kvFactory); err != nil {
 			return nil, err
 		}
@@ -98,9 +98,9 @@ func (s *StandaloneRpcServer) ShardAssignments(_ *proto.ShardAssignmentsRequest,
 }
 
 func (s *StandaloneRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
-	return s.dbs[int32(*write.ShardId)].ProcessWrite(write)
+	return s.dbs[*write.ShardId].ProcessWrite(write)
 }
 
 func (s *StandaloneRpcServer) Read(ctx context.Context, read *proto.ReadRequest) (*proto.ReadResponse, error) {
-	return s.dbs[int32(*read.ShardId)].ProcessRead(read)
+	return s.dbs[*read.ShardId].ProcessRead(read)
 }


### PR DESCRIPTION
KV and DB interfaces were still using `int32` instead of `uint32` for shard id. Changing it to use uniform type.