### PR TITLE
Fixed Pebble initialization

### DIFF
--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -77,6 +77,7 @@ func newKVPebble(factory *PebbleFactory, shardId uint32) (KV, error) {
 			ImmediateSuccessor: pebble.DefaultComparer.ImmediateSuccessor,
 			Name:               "oxia-slash-spans",
 		},
+		FS:         vfs.Default,
 		DisableWAL: true,
 		Logger: &PebbleLogger{
 			log.With().
@@ -90,7 +91,7 @@ func newKVPebble(factory *PebbleFactory, shardId uint32) (KV, error) {
 
 	db, err := pebble.Open(dbPath, pbOptions)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to open database at %s", dbPath)
 	}
 
 	pb.db = db

--- a/server/kv/kv_pebble_test.go
+++ b/server/kv/kv_pebble_test.go
@@ -429,3 +429,19 @@ func TestPebbbleDeleteRangeInBatch(t *testing.T) {
 	assert.NoError(t, kv.Close())
 	assert.NoError(t, factory.Close())
 }
+
+func TestPebbbleDoubleOpen(t *testing.T) {
+	factory := NewPebbleKVFactory(&KVFactoryOptions{
+		DataDir:   t.TempDir(),
+		CacheSize: 1024,
+		InMemory:  false,
+	})
+	kv, err := factory.NewKV(1)
+	assert.NoError(t, err)
+
+	kv2, err2 := factory.NewKV(1)
+	assert.Error(t, err2)
+	assert.Nil(t, kv2)
+
+	assert.NoError(t, kv.Close())
+}


### PR DESCRIPTION
We're missing the required `FS` argument in the Pebble options. 
Because of that, if there is an error in the `Open()` call, we're getting a panic error:

```
panic({0x103734260, 0x10380e938})
	/opt/homebrew/Cellar/go/1.19.3/libexec/src/runtime/panic.go:884 +0x204
github.com/cockroachdb/pebble.Open.func1()
	/Users/mmerli/go/pkg/mod/github.com/cockroachdb/pebble@v0.0.0-20221104214247-8dc60b62ebbf/open.go:111 +0x158
panic({0x103734260, 0x10380e938})
	/opt/homebrew/Cellar/go/1.19.3/libexec/src/runtime/panic.go:890 +0x258
github.com/cockroachdb/pebble/vfs.(*diskHealthCheckingFile).stopTicker(...)
	/Users/mmerli/go/pkg/mod/github.com/cockroachdb/pebble@v0.0.0-20221104214247-8dc60b62ebbf/vfs/disk_health.go:95
github.com/cockroachdb/pebble/vfs.(*diskHealthCheckingFile).Close(0x14000143cc0)
	/Users/mmerli/go/pkg/mod/github.com/cockroachdb/pebble@v0.0.0-20221104214247-8dc60b62ebbf/vfs/disk_health.go:108 +0x28
github.com/cockroachdb/pebble.Open.func2()
	/Users/mmerli/go/pkg/mod/github.com/cockroachdb/pebble@v0.0.0-20221104214247-8dc60b62ebbf/open.go:165 +0x40
github.com/cockroachdb/pebble.Open({0x1400007ef00, 0x5c}, 0x14000310a00)
	/Users/mmerli/go/pkg/mod/github.com/cockroachdb/pebble@v0.0.0-20221104214247-8dc60b62ebbf/open.go:207 +0xc10
oxia/server/kv.newKVPebble(0x1400007ce00, 0x7cde0?)
	/Users/mmerli/prg/oxia/server/kv/kv_pebble.go:92 +0x624
```

Also, wrapping the error to provide more context around the db path that is failing.