### PR TITLE
Use path for wal similar to kv store

### DIFF
--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -18,7 +18,7 @@ type WalFactoryOptions struct {
 }
 
 var DefaultWalFactoryOptions = &WalFactoryOptions{
-	LogDir: "wal",
+	LogDir: "data/wal",
 }
 
 type WalFactory interface {

--- a/server/wal/wal_tidwall.go
+++ b/server/wal/wal_tidwall.go
@@ -5,8 +5,8 @@ import (
 	"github.com/pkg/errors"
 	tidwall "github.com/tidwall/wal"
 	pb "google.golang.org/protobuf/proto"
-	"os"
 	"oxia/proto"
+	"path/filepath"
 	"sync"
 )
 
@@ -38,7 +38,8 @@ type tidwallWal struct {
 
 func newTidwallWal(shard uint32, dir string) (Wal, error) {
 	opts := tidwall.DefaultOptions
-	log, err := tidwall.Open(fmt.Sprintf("%s%c%06d", dir, os.PathSeparator, shard), opts)
+	walPath := filepath.Join(dir, fmt.Sprint("shard-", shard))
+	log, err := tidwall.Open(walPath, opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Path for WAL should be consistent with the path for DB files. 

eg: `data/db/shard-X` and should be `data/wal/shard-X`