### PR TITLE
Improved logic for epoch checking in follower controller

### DIFF
--- a/proto/coordination.proto
+++ b/proto/coordination.proto
@@ -77,5 +77,4 @@ message AddEntryRequest {
 message AddEntryResponse {
   int64 epoch = 1;
   int64 offset = 2;
-  bool invalid_epoch = 3;
 }

--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -4,6 +4,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	pb "google.golang.org/protobuf/proto"
 	"io"
 	"math"
@@ -13,10 +15,16 @@ import (
 	"sync"
 )
 
-const MaxEpoch = math.MaxInt64
+const (
+	MaxEpoch = math.MaxInt64
 
-var ErrorInvalidEpoch = errors.New("oxia: invalid epoch")
-var ErrorInvalidStatus = errors.New("oxia: invalid status")
+	CodeInvalidEpoch codes.Code = 100
+)
+
+var (
+	ErrorInvalidEpoch  = errors.New("oxia: invalid epoch")
+	ErrorInvalidStatus = errors.New("oxia: invalid status")
+)
 
 // FollowerController handles all the operations of a given shard's follower
 type FollowerController interface {
@@ -138,12 +146,12 @@ func (fc *followerController) Fence(req *proto.FenceRequest) (*proto.FenceRespon
 	fc.Lock()
 	defer fc.Unlock()
 
-	if err := checkEpochLaterIn(req, fc.epoch); err != nil {
-		fc.log.Warn().Err(err).
+	if req.Epoch <= fc.epoch {
+		fc.log.Warn().
 			Int64("follower-epoch", fc.epoch).
 			Int64("fence-epoch", req.Epoch).
 			Msg("Failed to fence with invalid epoch")
-		return nil, err
+		return nil, status.Errorf(CodeInvalidEpoch, "invalid epoch - current epoch %d - request epoch %d", fc.epoch, req.Epoch)
 	}
 
 	if err := fc.db.UpdateEpoch(req.Epoch); err != nil {
@@ -178,8 +186,9 @@ func (fc *followerController) Truncate(req *proto.TruncateRequest) (*proto.Trunc
 	if err := checkStatus(Fenced, fc.status); err != nil {
 		return nil, err
 	}
-	if err := checkEpochEqualIn(req, fc.epoch); err != nil {
-		return nil, err
+
+	if req.Epoch != fc.epoch {
+		return nil, status.Errorf(CodeInvalidEpoch, "invalid epoch - current epoch %d - request epoch %d", fc.epoch, req.Epoch)
 	}
 
 	fc.status = Follower
@@ -212,6 +221,8 @@ func (fc *followerController) AddEntries(stream proto.OxiaLogReplication_AddEntr
 	for {
 		if addEntryReq, err := stream.Recv(); err != nil {
 			return err
+		} else if addEntryReq == nil {
+			return nil
 		} else if res, err := fc.addEntry(addEntryReq); err != nil {
 			return err
 		} else if err = stream.Send(res); err != nil {
@@ -223,26 +234,9 @@ func (fc *followerController) AddEntries(stream proto.OxiaLogReplication_AddEntr
 func (fc *followerController) addEntry(req *proto.AddEntryRequest) (*proto.AddEntryResponse, error) {
 	fc.Lock()
 	defer fc.Unlock()
-	if fc.status != Follower && fc.status != Fenced {
-		return nil, errors.Wrapf(ErrorInvalidStatus, "AddEntry request when status = %+v", fc.status)
-	}
-	if req.Epoch < fc.epoch {
-		/*
-		 A follower node rejects an entry from the leader.
 
-
-		  If the leader has a lower epoch than the follower then the
-		  follower must reject it with an INVALID_EPOCH response.
-
-		  Key points:
-		  - The epoch of the response should be the epoch of the
-		    request so that the leader will not ignore the response.
-		*/
-		return &proto.AddEntryResponse{
-			Epoch:        req.Entry.Epoch,
-			Offset:       wal.InvalidOffset,
-			InvalidEpoch: true,
-		}, nil
+	if req.Epoch != fc.epoch {
+		return nil, status.Errorf(CodeInvalidEpoch, "invalid epoch - current epoch %d - request epoch %d", fc.epoch, req.Epoch)
 	}
 
 	// A follower node confirms an entry to the leader
@@ -251,16 +245,6 @@ func (fc *followerController) addEntry(req *proto.AddEntryRequest) (*proto.AddEn
 	// and updates its commit index with the commit index of
 	// the request.
 	fc.status = Follower
-
-	if req.Epoch > fc.epoch {
-		if err := fc.db.UpdateEpoch(req.Epoch); err != nil {
-			return nil, err
-		}
-		fc.epoch = req.Epoch
-		fc.log = fc.log.With().Int64("epoch", fc.epoch).Logger()
-		fc.log.Info().
-			Msg("Follower upgraded the epoch")
-	}
 
 	if err := fc.wal.Append(req.GetEntry()); err != nil {
 		return nil, err
@@ -273,9 +257,8 @@ func (fc *followerController) addEntry(req *proto.AddEntryRequest) (*proto.AddEn
 		return nil, err
 	}
 	return &proto.AddEntryResponse{
-		Epoch:        fc.epoch,
-		Offset:       req.Entry.Offset,
-		InvalidEpoch: false,
+		Epoch:  fc.epoch,
+		Offset: req.Entry.Offset,
 	}, nil
 
 }

--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/status"
 	pb "google.golang.org/protobuf/proto"
+	"oxia/common"
 	"oxia/proto"
 	"oxia/server/kv"
 	"oxia/server/wal"
@@ -12,6 +14,10 @@ import (
 var testKVOptions = &kv.KVFactoryOptions{
 	InMemory:  true,
 	CacheSize: 10 * 1024,
+}
+
+func init() {
+	common.ConfigureLogger()
 }
 
 func TestFollower(t *testing.T) {
@@ -35,7 +41,7 @@ func TestFollower(t *testing.T) {
 	truncateResp, err := fc.Truncate(&proto.TruncateRequest{
 		Epoch: 1,
 		HeadIndex: &proto.EntryId{
-			Epoch:  0,
+			Epoch:  1,
 			Offset: 0,
 		},
 	})
@@ -59,31 +65,17 @@ func TestFollower(t *testing.T) {
 
 	assert.EqualValues(t, 1, response.Epoch)
 	assert.EqualValues(t, 0, response.Offset)
-	assert.False(t, response.InvalidEpoch)
 
-	// Try to add entry with lower epoch
-	stream.AddRequest(createAddRequest(t, 0, 0, map[string]string{"a": "2", "b": "3"}, wal.InvalidOffset))
+	// Write next entry
+	stream.AddRequest(createAddRequest(t, 1, 1, map[string]string{"a": "4", "b": "5"}, wal.InvalidOffset))
 
 	// Wait for response
 	response = stream.GetResponse()
-	assert.EqualValues(t, 0, response.Epoch)
-	assert.Equal(t, wal.InvalidOffset, response.Offset)
-	assert.True(t, response.InvalidEpoch)
+	assert.EqualValues(t, 1, response.Epoch)
+	assert.EqualValues(t, 1, response.Offset)
 
 	assert.Equal(t, Follower, fc.Status())
 	assert.EqualValues(t, 1, fc.Epoch())
-
-	// Try to add entry with higher epoch. This should succeed
-	stream.AddRequest(createAddRequest(t, 3, 1, map[string]string{"a": "4", "b": "5"}, wal.InvalidOffset))
-
-	// Wait for response
-	response = stream.GetResponse()
-	assert.EqualValues(t, 3, response.Epoch)
-	assert.EqualValues(t, 1, response.Offset)
-	assert.False(t, response.InvalidEpoch)
-
-	assert.Equal(t, Follower, fc.Status())
-	assert.EqualValues(t, 3, fc.Epoch())
 
 	// Double-check the values in the DB
 	dbRes, err := fc.(*followerController).db.ProcessRead(&proto.ReadRequest{Gets: []*proto.GetRequest{{
@@ -117,13 +109,6 @@ func TestReadingUpToCommitIndex(t *testing.T) {
 	assert.Equal(t, Fenced, fc.Status())
 	assert.EqualValues(t, 1, fc.Epoch())
 
-	// Second fence should fail, because we're already in epoch 1
-	fr, err := fc.Fence(&proto.FenceRequest{Epoch: 1})
-	assert.Nil(t, fr)
-	assert.ErrorIs(t, err, ErrorInvalidEpoch)
-	assert.Equal(t, Fenced, fc.Status())
-	assert.EqualValues(t, 1, fc.Epoch())
-
 	_, err = fc.Truncate(&proto.TruncateRequest{
 		Epoch: 1,
 		HeadIndex: &proto.EntryId{
@@ -150,13 +135,11 @@ func TestReadingUpToCommitIndex(t *testing.T) {
 
 	assert.EqualValues(t, 1, r1.Epoch)
 	assert.EqualValues(t, 0, r1.Offset)
-	assert.False(t, r1.InvalidEpoch)
 
 	r2 := stream.GetResponse()
 
 	assert.EqualValues(t, 1, r2.Epoch)
 	assert.EqualValues(t, 1, r2.Offset)
-	assert.False(t, r2.InvalidEpoch)
 
 	dbRes, err := fc.(*followerController).db.ProcessRead(&proto.ReadRequest{Gets: []*proto.GetRequest{{
 		Key:            "a",
@@ -178,7 +161,7 @@ func TestReadingUpToCommitIndex(t *testing.T) {
 	assert.NoError(t, walFactory.Close())
 }
 
-func TestEpochInStateChanges(t *testing.T) {
+func TestFollower_FenceEpoch(t *testing.T) {
 	var shardId uint32
 	kvFactory := kv.NewPebbleKVFactory(testKVOptions)
 	walFactory := wal.NewWalFactory(&wal.WalFactoryOptions{LogDir: t.TempDir()})
@@ -186,40 +169,30 @@ func TestEpochInStateChanges(t *testing.T) {
 	fc, err := NewFollowerController(shardId, walFactory, kvFactory)
 	assert.NoError(t, err)
 
-	stream := newMockServerAddEntriesStream()
-	stream.AddRequest(createAddRequest(t, 1, 0, map[string]string{"a": "0", "b": "1"}, wal.InvalidOffset))
-
-	// Follower will not accept any new entries unless it's in Fenced or Follower states
-	err = fc.AddEntries(stream)
-	assert.ErrorIs(t, err, ErrorInvalidStatus)
-
 	_, err = fc.Fence(&proto.FenceRequest{Epoch: 1})
 	assert.NoError(t, err)
 	assert.Equal(t, Fenced, fc.Status())
 	assert.EqualValues(t, 1, fc.Epoch())
 
-	tr, err := fc.Truncate(&proto.TruncateRequest{
-		Epoch: 2,
-		HeadIndex: &proto.EntryId{
-			Epoch:  0,
-			Offset: 0,
-		},
-	})
-	assert.Nil(t, tr)
-	assert.ErrorIs(t, err, ErrorInvalidEpoch)
-	assert.EqualValues(t, 1, fc.Epoch())
+	// We cannot fence with earlier epoch
+	fr, err := fc.Fence(&proto.FenceRequest{Epoch: 0})
+	assert.Nil(t, fr)
+	assert.Equal(t, CodeInvalidEpoch, status.Code(err))
 	assert.Equal(t, Fenced, fc.Status())
-
-	_, err = fc.Truncate(&proto.TruncateRequest{
-		Epoch: 1,
-		HeadIndex: &proto.EntryId{
-			Epoch:  0,
-			Offset: 0,
-		},
-	})
-	assert.NoError(t, err)
 	assert.EqualValues(t, 1, fc.Epoch())
-	assert.Equal(t, Follower, fc.Status())
+
+	// We cannot fence with same epoch
+	fr, err = fc.Fence(&proto.FenceRequest{Epoch: 1})
+	assert.Nil(t, fr)
+	assert.Equal(t, CodeInvalidEpoch, status.Code(err))
+	assert.Equal(t, Fenced, fc.Status())
+	assert.EqualValues(t, 1, fc.Epoch())
+
+	// Higher epoch will work
+	_, err = fc.Fence(&proto.FenceRequest{Epoch: 3})
+	assert.NoError(t, err)
+	assert.Equal(t, Fenced, fc.Status())
+	assert.EqualValues(t, 3, fc.Epoch())
 
 	assert.NoError(t, fc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -286,6 +259,111 @@ func TestFollower_PersistentEpoch(t *testing.T) {
 
 	assert.NoError(t, kvFactory.Close())
 	assert.NoError(t, walFactory.Close())
+}
+
+func TestFollowerController_RejectEntriesWithDifferentEpoch(t *testing.T) {
+	var shardId uint32
+	kvFactory := kv.NewPebbleKVFactory(&kv.KVFactoryOptions{
+		DataDir:   t.TempDir(),
+		CacheSize: 10 * 1024,
+	})
+
+	db, err := kv.NewDB(shardId, kvFactory)
+	assert.NoError(t, err)
+	// Force a new epoch in the DB before opening
+	assert.NoError(t, db.UpdateEpoch(5))
+	assert.NoError(t, db.Close())
+
+	walFactory := wal.NewWalFactory(&wal.WalFactoryOptions{LogDir: t.TempDir()})
+
+	fc, err := NewFollowerController(shardId, walFactory, kvFactory)
+	assert.NoError(t, err)
+
+	assert.Equal(t, NotMember, fc.Status())
+	assert.EqualValues(t, 5, fc.Epoch())
+
+	stream := newMockServerAddEntriesStream()
+	stream.AddRequest(createAddRequest(t, 1, 0, map[string]string{"a": "1", "b": "1"}, wal.InvalidOffset))
+
+	// Follower will reject the entry because it's from an earlier epoch
+	err = fc.AddEntries(stream)
+	assert.Equal(t, CodeInvalidEpoch, status.Code(err))
+	assert.Equal(t, NotMember, fc.Status())
+	assert.EqualValues(t, 5, fc.Epoch())
+
+	// If we send an entry of same epoch, it will be accepted
+	stream.AddRequest(createAddRequest(t, 5, 0, map[string]string{"a": "2", "b": "2"}, wal.InvalidOffset))
+
+	go func() { assert.NoError(t, fc.AddEntries(stream)) }()
+
+	// Wait for addEntryResponses
+	r1 := stream.GetResponse()
+
+	assert.Equal(t, Follower, fc.Status())
+	assert.EqualValues(t, 5, r1.Epoch)
+	assert.EqualValues(t, 0, r1.Offset)
+	assert.NoError(t, fc.Close())
+	close(stream.requests)
+
+	//// A higher epoch will also be rejected
+	fc, err = NewFollowerController(shardId, walFactory, kvFactory)
+	assert.NoError(t, err)
+
+	stream = newMockServerAddEntriesStream()
+	stream.AddRequest(createAddRequest(t, 6, 0, map[string]string{"a": "2", "b": "2"}, wal.InvalidOffset))
+	err = fc.AddEntries(stream)
+	assert.Equal(t, CodeInvalidEpoch, status.Code(err))
+	assert.Equal(t, NotMember, fc.Status())
+	assert.EqualValues(t, 5, fc.Epoch())
+
+	assert.NoError(t, fc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
+func TestFollower_RejectTruncateInvalidEpoch(t *testing.T) {
+	var shardId uint32
+	kvFactory := kv.NewPebbleKVFactory(testKVOptions)
+	walFactory := wal.NewInMemoryWalFactory()
+
+	fc, err := NewFollowerController(shardId, walFactory, kvFactory)
+	assert.NoError(t, err)
+
+	assert.Equal(t, NotMember, fc.Status())
+
+	fenceRes, err := fc.Fence(&proto.FenceRequest{Epoch: 5})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 5, fenceRes.Epoch)
+	assert.Equal(t, &proto.EntryId{Epoch: wal.InvalidEpoch, Offset: wal.InvalidOffset}, fenceRes.HeadIndex)
+
+	assert.Equal(t, Fenced, fc.Status())
+	assert.EqualValues(t, 5, fc.Epoch())
+
+	// Lower epoch should be rejected
+	truncateResp, err := fc.Truncate(&proto.TruncateRequest{
+		Epoch: 4,
+		HeadIndex: &proto.EntryId{
+			Epoch:  1,
+			Offset: 0,
+		},
+	})
+	assert.Nil(t, truncateResp)
+	assert.Equal(t, CodeInvalidEpoch, status.Code(err))
+	assert.Equal(t, Fenced, fc.Status())
+	assert.EqualValues(t, 5, fc.Epoch())
+
+	// Truncate with higher epoch should also fail
+	truncateResp, err = fc.Truncate(&proto.TruncateRequest{
+		Epoch: 6,
+		HeadIndex: &proto.EntryId{
+			Epoch:  1,
+			Offset: 0,
+		},
+	})
+	assert.Nil(t, truncateResp)
+	assert.Equal(t, CodeInvalidEpoch, status.Code(err))
+	assert.Equal(t, Fenced, fc.Status())
+	assert.EqualValues(t, 5, fc.Epoch())
 }
 
 func createAddRequest(t *testing.T, epoch int64, offset int64,

--- a/server/follower_cursor.go
+++ b/server/follower_cursor.go
@@ -218,16 +218,6 @@ func (fc *followerCursor) receiveAcks(stream proto.OxiaLogReplication_AddEntries
 			return
 		}
 
-		if res.InvalidEpoch {
-			fc.log.Error().Err(err).
-				Msg("Invalid epoch")
-			if err := stream.CloseSend(); err != nil {
-				fc.log.Warn().Err(err).
-					Msg("Error while closing stream")
-			}
-			return
-		}
-
 		fc.cursorAcker.Ack(res.Offset)
 
 		fc.Lock()

--- a/server/follower_cursor_test.go
+++ b/server/follower_cursor_test.go
@@ -48,9 +48,8 @@ func TestFollowerCursor(t *testing.T) {
 	assert.Equal(t, wal.InvalidOffset, req.CommitIndex)
 
 	stream.addEntryResps <- &proto.AddEntryResponse{
-		Epoch:        1,
-		Offset:       0,
-		InvalidEpoch: false,
+		Epoch:  1,
+		Offset: 0,
 	}
 
 	assert.Eventually(t, func() bool {

--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -203,9 +203,8 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 		req := <-rpc.addEntryReqs
 
 		rpc.addEntryResps <- &proto.AddEntryResponse{
-			Epoch:        req.Epoch,
-			Offset:       req.Entry.Offset,
-			InvalidEpoch: false,
+			Epoch:  req.Epoch,
+			Offset: req.Entry.Offset,
 		}
 	}()
 


### PR DESCRIPTION
 * Added explicit tests for epoch checking for AddEntries, Fence and Truncate operations
 * Disallow automatic epoch upgrade in AddEntries. The follower will only accept entries from the leader in the same epoch. If a new leader is elected (with a new epoch), the follower will first wait to get the Fence request from the coordinator, and then will accept the writes. 
     - This is required otherwise the leader will not know the starting head index of that follower
 * Removed `invalid_epoch` from `AddEntryResponse`. Instead close stream and use a specific error code in the Grpc response. 