### PR TITLE
Use Go 1.19 in CI

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -39,6 +39,7 @@ jobs:
         uses: golangci/golangci-lint-action@0ad9a0988b3973e851ab0a07adf248ec2e100376 #v3.3.1
         with:
           version: v1.50.1
+          args: --verbose
 
       - name: Build
         run: make build


### PR DESCRIPTION
There are better types for `atomic` in Go 1.19. E.g. `atomic.Bool`, `atomic.Uint32`, etc..