### PR TITLE
Rename operator → coordinator

### DIFF
--- a/tlaplus/MessagePassing.tla
+++ b/tlaplus/MessagePassing.tla
@@ -77,11 +77,11 @@ IsEarliestReceivableEntryMessage(msgs, msg, type) ==
         /\ msg2.dest_node = msg.dest_node
         /\ msg2.source_node = msg.source_node
         
-OperatorMessagesLost(o) ==
+CoordinatorMessagesLost(o) ==
     messages' = [msg \in DOMAIN messages |->
                     IF /\ msg.type \in {BECOME_LEADER_REQUEST,
                                         BECOME_LEADER_RESPONSE}
-                       /\ msg.operator = o
+                       /\ msg.coordinator = o
                     THEN 0
                     ELSE messages[msg]]
 

--- a/tlaplus/OxiaReplication.cfg
+++ b/tlaplus/OxiaReplication.cfg
@@ -1,12 +1,12 @@
 CONSTANTS
-    Operators = {operator1, operator2}
+    Coordinators = {coordinator1, coordinator2}
     Nodes = {node1, node2, node3, node4}
     Values = {v0, v1, v2, v3, v4}
     RepFactor = 3
 
 CONSTANTS
     MaxEpochs = 4
-    MaxOperatorStops = 3
+    MaxCoordinatorStops = 3
 
 CONSTANTS
     LEADER_ELECTED = LEADER_ELECTED


### PR DESCRIPTION
# Motivation
Use technology agnostic naming.

# Changes
* Rename 'operator' → 'coordinator' in TLA