### PR TITLE
Ensure all subcommands have the logger configured

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,10 +17,10 @@ import (
 var (
 	logLevelStr string
 	rootCmd     = &cobra.Command{
-		Use:     "oxia",
-		Short:   "Short description",
-		Long:    `Long description`,
-		PreRunE: configureLogLevel,
+		Use:               "oxia",
+		Short:             "Oxia root command",
+		Long:              `Oxia root command`,
+		PersistentPreRunE: configureLogLevel,
 	}
 )
 
@@ -49,6 +49,7 @@ func configureLogLevel(cmd *cobra.Command, args []string) error {
 		return LogLevelError(logLevelStr)
 	}
 	common.LogLevel = logLevel
+	common.ConfigureLogger()
 	return nil
 }
 

--- a/common/run.go
+++ b/common/run.go
@@ -6,8 +6,6 @@ import (
 )
 
 func RunProcess(startProcess func() (io.Closer, error)) {
-	ConfigureLogger()
-
 	process, err := startProcess()
 	if err != nil {
 		log.Fatal().Err(err).


### PR DESCRIPTION
The `oxia client` subcommand was not having the logger configured. 

Moving the `common.ConfigureLogger()` call into the `PreRun` hook so it applies to all the commands.