### PR TITLE
Moved grpc connection created message to debug level

### DIFF
--- a/common/client_pool.go
+++ b/common/client_pool.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
@@ -106,7 +107,7 @@ func (cp *clientPool) getConnection(target string) (grpc.ClientConnInterface, er
 		return cnx, nil
 	}
 
-	cp.log.Info().
+	cp.log.Debug().
 		Str("server_address", target).
 		Msg("Creating new GRPC connection")
 
@@ -116,7 +117,7 @@ func (cp *clientPool) getConnection(target string) (grpc.ClientConnInterface, er
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 	)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error connecting to %s", target)
 	}
 
 	cp.connections[target] = cnx


### PR DESCRIPTION
Moving the log `Creating new GRPC connection` to debug level, so that we don't spam client logs when there are no issues.