### PR TITLE
Missing return when exiting assignment dispatcher

### DIFF
--- a/server/assignment_dispatcher.go
+++ b/server/assignment_dispatcher.go
@@ -99,7 +99,7 @@ func (s *shardAssignmentDispatcher) RegisterForUpdates(clientStream Client) erro
 
 		case <-s.ctx.Done():
 			// the server is closing
-			return ErrorAlreadyClosed
+			return nil
 		}
 	}
 }
@@ -127,7 +127,7 @@ func (s *shardAssignmentDispatcher) ShardAssignment(stream proto.OxiaControl_Sha
 
 	case <-s.ctx.Done():
 		// Server is closing
-		return ErrorAlreadyClosed
+		return nil
 	}
 }
 

--- a/server/assignment_dispatcher_test.go
+++ b/server/assignment_dispatcher_test.go
@@ -34,7 +34,9 @@ func TestShardAssignmentDispatcher_Initialized(t *testing.T) {
 		},
 		ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,
 	})
-	assert.Eventually(t, func() bool { return dispatcher.Initialized() }, 1*time.Second, 10*time.Millisecond)
+	assert.Eventually(t, func() bool {
+		return dispatcher.Initialized()
+	}, 10*time.Second, 10*time.Millisecond)
 	mockClient := newMockShardAssignmentClientStream()
 
 	wg := sync.WaitGroup{}


### PR DESCRIPTION
The go routine could get stuck when handling error in sending updates to the client