### PR TITLE
Disconnect leader stream after fencing

### DIFF
--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -201,6 +201,7 @@ func (fc *followerController) Fence(req *proto.FenceRequest) (*proto.FenceRespon
 	fc.epoch = req.Epoch
 	fc.log = fc.log.With().Int64("epoch", fc.epoch).Logger()
 	fc.status = Fenced
+	fc.closeChannelNoMutex(nil)
 
 	lastEntryId, err := getLastEntryIdInWal(fc.wal)
 	if err != nil {

--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"oxia/server/wal"
 	"sync"
 	"testing"
+	"time"
 )
 
 var testKVOptions = &kv.KVFactoryOptions{
@@ -600,6 +601,43 @@ func TestFollower_HandleSnapshot(t *testing.T) {
 	}
 
 	assert.Equal(t, wal.InvalidOffset, fc.(*followerController).wal.LastOffset())
+
+	assert.NoError(t, fc.Close())
+	assert.NoError(t, kvFactory.Close())
+	assert.NoError(t, walFactory.Close())
+}
+
+func TestFollower_DisconnectLeader(t *testing.T) {
+	var shardId uint32
+	kvFactory, err := kv.NewPebbleKVFactory(testKVOptions)
+	assert.NoError(t, err)
+	walFactory := wal.NewInMemoryWalFactory()
+
+	fc, _ := NewFollowerController(shardId, walFactory, kvFactory)
+	_, _ = fc.Fence(&proto.FenceRequest{Epoch: 1})
+
+	stream := newMockServerAddEntriesStream()
+
+	go func() { assert.NoError(t, fc.AddEntries(stream)) }()
+
+	assert.Eventually(t, func() bool {
+		return fc.(*followerController).closeCh != nil
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// It's not possible to add a new leader stream
+	assert.ErrorIs(t, fc.AddEntries(stream), ErrorLeaderAlreadyConnected)
+
+	// When we fence again, the leader should have been cutoff
+	_, err = fc.Fence(&proto.FenceRequest{Epoch: 2})
+	assert.NoError(t, err)
+
+	assert.Nil(t, fc.(*followerController).closeCh)
+
+	go func() { assert.NoError(t, fc.AddEntries(stream)) }()
+
+	assert.Eventually(t, func() bool {
+		return fc.(*followerController).closeCh != nil
+	}, 10*time.Second, 10*time.Millisecond)
 
 	assert.NoError(t, fc.Close())
 	assert.NoError(t, kvFactory.Close())


### PR DESCRIPTION
When a follower is fenced it should immediately disconnect the replication stream from the previous leader (even though it has not crashed) so that we are ready to receive the stream from the new leader.