### PR TITLE
The `defer lc.Unlock()` doesn't work in a scope within a function

### DIFF
--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -453,8 +453,6 @@ func (lc *leaderController) appendToWal(request *proto.WriteRequest, timestamp u
 		Timestamp: timestamp,
 	}
 
-	timestamp = logEntry.Timestamp
-
 	if err = lc.wal.Append(logEntry); err != nil {
 		return wal.InvalidOffset, err
 	}


### PR DESCRIPTION
doing: 


```go

	{
		lc.Lock()
		defer lc.Unlock()
                 // do something while holding lock
        }
        // Do something without lock
```

doesn't work because the `defer` is executed at the end of the function, not at the end of the scope. 

In this case, we're keeping the mutex on the leader controller while we're waiting for the followers to ack the messages.