### PR TITLE
Fixed the max value for the last hash range

### DIFF
--- a/coordinator/impl/coordinator.go
+++ b/coordinator/impl/coordinator.go
@@ -101,7 +101,7 @@ func (c *coordinator) initialAssignment() error {
 	serverIdx := uint32(0)
 
 	for i := uint32(0); i < cc.ShardCount; i++ {
-		cs.Shards[i] = model.ShardMetadata{
+		shard := model.ShardMetadata{
 			Status:   model.ShardStatusUnknown,
 			Epoch:    -1,
 			Leader:   nil,
@@ -112,6 +112,14 @@ func (c *coordinator) initialAssignment() error {
 			},
 		}
 
+		if i == cc.ShardCount-1 {
+			// Last shard should always be set at the max of 32bit. Depending on the
+			// shard count, the division might fell few numbers earlier. It's OK in
+			// this case to have a (tinily) bigger last-shard range.
+			shard.Int32HashRange.Max = math.MaxUint32
+		}
+
+		cs.Shards[i] = shard
 		serverIdx += cc.ReplicationFactor
 	}
 


### PR DESCRIPTION
The last shard needs to be assigned with the max values set to `math.MaxUint32` even when the number of shards does not lead to a possible even split.