### PR TITLE
Move debug statement after checking error to avoid segfault

### DIFF
--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -341,9 +341,6 @@ func (fc *followerController) processCommittedEntries(maxInclusive int64) error 
 
 	for reader.HasNext() {
 		entry, err := reader.ReadNext()
-		fc.log.Debug().
-			Int64("offset", entry.Offset).
-			Msg("Reading entry")
 
 		if err == wal.ErrorReaderClosed {
 			fc.log.Info().Msg("Stopped reading committed entries")
@@ -352,6 +349,10 @@ func (fc *followerController) processCommittedEntries(maxInclusive int64) error 
 			fc.log.Err(err).Msg("Error reading committed entry")
 			return err
 		}
+
+		fc.log.Debug().
+			Int64("offset", entry.Offset).
+			Msg("Reading entry")
 
 		if entry.Offset > maxInclusive {
 			// We read up to the max point


### PR DESCRIPTION
Got this segfault during maelstrom test execution. 

While we're closing the follower, if there's a pending reader it might get an error and a `nil` entry. We should first check the error instead of trying to print the debug log.

```
Dec 22 10:03:29.059066 DBG Process committed entries component=follower-controller epoch=0 head-index=5 max-inclusive=4 min-exclusive=-1 shard=0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x1012f1a2c]

goroutine 118 [running]:
oxia/server.(*followerController).processCommittedEntries(0x1400044c340, 0x4)
	/Users/mmerli/prg/oxia/server/follower_controller.go:356 +0x1dc
oxia/server.(*followerController).addEntry(0x1400044c340, 0x1400033e940)
	/Users/mmerli/prg/oxia/server/follower_controller.go:322 +0x1bc
oxia/server.(*followerController).handleServerStream(0x140003e8df8?, {0x1019b7600, 0x140003ba520})
	/Users/mmerli/prg/oxia/server/follower_controller.go:282 +0x50
oxia/server.(*followerController).AddEntries.func1()
	/Users/mmerli/prg/oxia/server/follower_controller.go:269 +0x28
oxia/common.DoWithLabels.func1({0x1019b17b8?, 0x14000595b00?})
	/Users/mmerli/prg/oxia/common/pprof.go:29 +0x24
runtime/pprof.Do({0x1019b1748?, 0x140000c2000?}, {{0x14000528d00?, 0x0?, 0x0?}}, 0x140003e8f38)
	/opt/homebrew/Cellar/go/1.19.3/libexec/src/runtime/pprof/runtime.go:40 +0x80
oxia/common.DoWithLabels(0x0?, 0x140003ba700)
	/Users/mmerli/prg/oxia/common/pprof.go:25 +0x2cc
created by oxia/server.(*followerController).AddEntries
	/Users/mmerli/prg/oxia/server/follower_controller.go:266 +0x370
```