### PR TITLE
Use time.Duration for CLI arguments

### DIFF
--- a/cmd/client/cmd.go
+++ b/cmd/client/cmd.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"github.com/spf13/cobra"
 	"oxia/cmd/client/common"
 	"oxia/cmd/client/delete"
 	"oxia/cmd/client/get"
@@ -9,9 +10,6 @@ import (
 	"oxia/cmd/client/put"
 	"oxia/kubernetes"
 	"oxia/oxia"
-	"time"
-
-	"github.com/spf13/cobra"
 )
 
 var (
@@ -25,9 +23,9 @@ var (
 func init() {
 	defaultServiceAddress := fmt.Sprintf("localhost:%d", kubernetes.PublicPort.Port)
 	Cmd.PersistentFlags().StringVarP(&common.Config.ServiceAddr, "service-address", "a", defaultServiceAddress, "Service address")
-	Cmd.PersistentFlags().IntVar(&common.Config.BatchLingerMs, "batch-linger", int(oxia.DefaultBatchLinger/time.Millisecond), "Batch linger in milliseconds")
+	Cmd.PersistentFlags().DurationVar(&common.Config.BatchLinger, "batch-linger", oxia.DefaultBatchLinger, "Max time requests will be staged to be included in a batch")
 	Cmd.PersistentFlags().IntVar(&common.Config.MaxRequestsPerBatch, "max-requests-per-batch", oxia.DefaultMaxRequestsPerBatch, "Maximum requests per batch")
-	Cmd.PersistentFlags().IntVar(&common.Config.BatchRequestTimeoutSec, "batch-request-timeout", int(oxia.DefaultBatchRequestTimeout/time.Second), "Batch timeout in seconds")
+	Cmd.PersistentFlags().DurationVar(&common.Config.BatchRequestTimeout, "batch-request-timeout", oxia.DefaultBatchRequestTimeout, "Batch timeout in seconds")
 	Cmd.PersistentFlags().IntVar(&common.Config.BatcherBufferSize, "batcher-buffer-size", oxia.DefaultBatcherBufferSize, "Batcher buffer size")
 
 	Cmd.AddCommand(put.Cmd)

--- a/cmd/client/common/client.go
+++ b/cmd/client/common/client.go
@@ -10,17 +10,17 @@ var (
 )
 
 type ClientConfig struct {
-	ServiceAddr            string
-	BatchLingerMs          int
-	MaxRequestsPerBatch    int
-	BatchRequestTimeoutSec int
-	BatcherBufferSize      int
+	ServiceAddr         string
+	BatchLinger         time.Duration
+	MaxRequestsPerBatch int
+	BatchRequestTimeout time.Duration
+	BatcherBufferSize   int
 }
 
 func (config *ClientConfig) NewClient() (oxia.AsyncClient, error) {
 	options, err := oxia.NewClientOptions(Config.ServiceAddr,
-		oxia.WithBatchLinger(time.Duration(Config.BatchLingerMs)*time.Millisecond),
-		oxia.WithBatchRequestTimeout(time.Duration(Config.BatchRequestTimeoutSec)*time.Second),
+		oxia.WithBatchLinger(Config.BatchLinger),
+		oxia.WithBatchRequestTimeout(Config.BatchRequestTimeout),
 		oxia.WithMaxRequestsPerBatch(Config.MaxRequestsPerBatch),
 	)
 	if err != nil {


### PR DESCRIPTION
Cobra is able to handle `time.Duration` types as arguments and will accept time units on CLI: eg: `5ms`, `30s` and so on.