### PR TITLE
Configure gRPC frame size to 256 MB

### DIFF
--- a/common/container/container.go
+++ b/common/container/container.go
@@ -10,6 +10,10 @@ import (
 	"oxia/common"
 )
 
+const (
+	maxGrpcFrameSize = 256 * 1024 * 1024
+)
+
 type GrpcServer interface {
 	io.Closer
 
@@ -41,6 +45,7 @@ func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.Ser
 		server: grpc.NewServer(
 			grpc.ChainStreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 			grpc.ChainUnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+			grpc.MaxRecvMsgSize(maxGrpcFrameSize),
 		),
 	}
 	registerFunc(c.server)


### PR DESCRIPTION
The default limit is 4MB. 

We need a higher limit to send snapshot files (currently set in Pebble at 4MB though we'll need to increase to ~64MB) and to send responses to read-batches.

For the long term, we should probably try to improve the snapshot streaming to break single chunks into multiple frames, and figure out a solution for responses to read-batches.