### PR TITLE
Cleanup standalone

### DIFF
--- a/cmd/client/cmd_test.go
+++ b/cmd/client/cmd_test.go
@@ -9,24 +9,16 @@ import (
 	"oxia/cmd/client/get"
 	"oxia/cmd/client/list"
 	"oxia/cmd/client/put"
-	"oxia/server/kv"
-	"oxia/server/wal"
 	"oxia/standalone"
 	"testing"
 )
 
 func TestClientCmd(t *testing.T) {
 	zerolog.SetGlobalLevel(zerolog.Disabled)
-	kvOptions := kv.KVFactoryOptions{InMemory: true}
-	kvFactory, err := kv.NewPebbleKVFactory(&kvOptions)
-	assert.NoError(t, err)
-	defer kvFactory.Close()
-	walFactory := wal.NewInMemoryWalFactory()
-	defer walFactory.Close()
-	server, err := standalone.NewStandaloneRpcServer("localhost:0", "localhost", 1, walFactory, kvFactory)
+	server, err := standalone.New(standalone.NewTestConfig())
 	assert.NoError(t, err)
 
-	serviceAddress := fmt.Sprintf("localhost:%d", server.Port())
+	serviceAddress := fmt.Sprintf("localhost:%d", server.RpcPort())
 
 	stdin := bytes.NewBufferString("")
 	stdout := bytes.NewBufferString("")
@@ -191,5 +183,5 @@ func TestClientCmd(t *testing.T) {
 			stderr.Reset()
 		})
 	}
-	server.Close()
+	_ = server.Close()
 }

--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -18,7 +18,8 @@ type PrometheusMetrics struct {
 }
 
 func Start(bindAddress string) (*PrometheusMetrics, error) {
-	http.Handle("/metrics", promhttp.Handler())
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
 
 	listener, err := net.Listen("tcp", bindAddress)
 	if err != nil {
@@ -26,7 +27,7 @@ func Start(bindAddress string) (*PrometheusMetrics, error) {
 	}
 
 	p := &PrometheusMetrics{
-		server: &http.Server{},
+		server: &http.Server{Handler: mux},
 		port:   listener.Addr().(*net.TCPAddr).Port,
 	}
 

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -60,7 +60,7 @@ func NewConfig() Config {
 type Coordinator struct {
 	coordinator impl.Coordinator
 	clientPool  common.ClientPool
-	rpcServer   *CoordinatorRpcServer
+	rpcServer   *rpcServer
 	metrics     *metrics.PrometheusMetrics
 }
 
@@ -90,7 +90,7 @@ func New(config Config) (*Coordinator, error) {
 		return nil, err
 	}
 
-	if s.rpcServer, err = NewCoordinatorRpcServer(fmt.Sprintf("%s:%d", config.BindHost, config.InternalServicePort)); err != nil {
+	if s.rpcServer, err = newRpcServer(fmt.Sprintf("%s:%d", config.BindHost, config.InternalServicePort)); err != nil {
 		return nil, err
 	}
 

--- a/coordinator/coordinator_rpc_server.go
+++ b/coordinator/coordinator_rpc_server.go
@@ -7,13 +7,13 @@ import (
 	"oxia/common/container"
 )
 
-type CoordinatorRpcServer struct {
+type rpcServer struct {
 	grpcServer   container.GrpcServer
 	healthServer *health.Server
 }
 
-func NewCoordinatorRpcServer(bindAddress string) (*CoordinatorRpcServer, error) {
-	server := &CoordinatorRpcServer{
+func newRpcServer(bindAddress string) (*rpcServer, error) {
+	server := &rpcServer{
 		healthServer: health.NewServer(),
 	}
 
@@ -28,7 +28,7 @@ func NewCoordinatorRpcServer(bindAddress string) (*CoordinatorRpcServer, error) 
 	return server, nil
 }
 
-func (s *CoordinatorRpcServer) Close() error {
+func (s *rpcServer) Close() error {
 	s.healthServer.Shutdown()
 	return s.grpcServer.Close()
 }

--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"oxia/common"
-	"oxia/server/kv"
-	"oxia/server/wal"
 	"oxia/standalone"
 	"testing"
 	"time"
@@ -20,16 +18,10 @@ func init() {
 }
 
 func TestAsyncClientImpl(t *testing.T) {
-	kvOptions := kv.KVFactoryOptions{InMemory: true}
-	kvFactory, err := kv.NewPebbleKVFactory(&kvOptions)
-	assert.NoError(t, err)
-	defer kvFactory.Close()
-	walFactory := wal.NewInMemoryWalFactory()
-	defer walFactory.Close()
-	server, err := standalone.NewStandaloneRpcServer("localhost:0", "localhost", 1, walFactory, kvFactory)
+	server, err := standalone.New(standalone.NewTestConfig())
 	assert.NoError(t, err)
 
-	serviceAddress := fmt.Sprintf("localhost:%d", server.Port())
+	serviceAddress := fmt.Sprintf("localhost:%d", server.RpcPort())
 	client, err := NewAsyncClient(serviceAddress, WithBatchLinger(0))
 	assert.NoError(t, err)
 
@@ -77,16 +69,10 @@ func TestAsyncClientImpl(t *testing.T) {
 }
 
 func TestAsyncClientImpl_Notifications(t *testing.T) {
-	kvOptions := kv.KVFactoryOptions{InMemory: true}
-	kvFactory, _ := kv.NewPebbleKVFactory(&kvOptions)
-	defer kvFactory.Close()
-	walFactory := wal.NewInMemoryWalFactory()
-	defer walFactory.Close()
-
-	server, err := standalone.NewStandaloneRpcServer("localhost:0", "localhost", 3, walFactory, kvFactory)
+	server, err := standalone.New(standalone.NewTestConfig())
 	assert.NoError(t, err)
 
-	serviceAddress := fmt.Sprintf("localhost:%d", server.Port())
+	serviceAddress := fmt.Sprintf("localhost:%d", server.RpcPort())
 	client, err := NewSyncClient(serviceAddress, WithBatchLinger(0))
 	assert.NoError(t, err)
 

--- a/oxia/internal/shard_manager_test.go
+++ b/oxia/internal/shard_manager_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"oxia/common"
-	"oxia/server/kv"
-	"oxia/server/wal"
 	"oxia/standalone"
 	"testing"
 	"time"
@@ -21,17 +19,11 @@ func (s *testShardStrategy) Get(key string) func(Shard) bool {
 }
 
 func TestWithStandalone(t *testing.T) {
-	kvOptions := kv.KVFactoryOptions{InMemory: true}
-	kvFactory, err := kv.NewPebbleKVFactory(&kvOptions)
-	assert.NoError(t, err)
-	defer kvFactory.Close()
-	walFactory := wal.NewInMemoryWalFactory()
-	defer walFactory.Close()
-	server, err := standalone.NewStandaloneRpcServer("localhost:0", "localhost", 2, walFactory, kvFactory)
+	server, err := standalone.New(standalone.NewTestConfig())
 	assert.NoError(t, err)
 
 	clientPool := common.NewClientPool()
-	serviceAddress := fmt.Sprintf("localhost:%d", server.Port())
+	serviceAddress := fmt.Sprintf("localhost:%d", server.RpcPort())
 	shardManager, err := NewShardManager(&testShardStrategy{}, clientPool, serviceAddress, 30*time.Second)
 	assert.NoError(t, err)
 

--- a/server/internal_rpc_server.go
+++ b/server/internal_rpc_server.go
@@ -33,7 +33,7 @@ type internalRpcServer struct {
 	log                  zerolog.Logger
 }
 
-func newCoordinationRpcServer(grpcProvider container.GrpcProvider, bindAddress string, shardsDirector ShardsDirector, assignmentDispatcher ShardAssignmentsDispatcher) (*internalRpcServer, error) {
+func newInternalRpcServer(grpcProvider container.GrpcProvider, bindAddress string, shardsDirector ShardsDirector, assignmentDispatcher ShardAssignmentsDispatcher) (*internalRpcServer, error) {
 	server := &internalRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,

--- a/server/internal_rpc_server_test.go
+++ b/server/internal_rpc_server_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestInternalHealthCheck(t *testing.T) {
-	server, err := newCoordinationRpcServer(container.Default, "localhost:0", nil, NewShardAssignmentDispatcher())
+	server, err := newInternalRpcServer(container.Default, "localhost:0", nil, NewShardAssignmentDispatcher())
 	assert.NoError(t, err)
 
 	target := fmt.Sprintf("localhost:%d", server.grpcServer.Port())

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -11,7 +11,7 @@ import (
 	"oxia/proto"
 )
 
-type PublicRpcServer struct {
+type publicRpcServer struct {
 	proto.UnimplementedOxiaClientServer
 
 	shardsDirector       ShardsDirector
@@ -20,8 +20,8 @@ type PublicRpcServer struct {
 	log                  zerolog.Logger
 }
 
-func NewPublicRpcServer(provider container.GrpcProvider, bindAddress string, shardsDirector ShardsDirector, assignmentDispatcher ShardAssignmentsDispatcher) (*PublicRpcServer, error) {
-	server := &PublicRpcServer{
+func newPublicRpcServer(provider container.GrpcProvider, bindAddress string, shardsDirector ShardsDirector, assignmentDispatcher ShardAssignmentsDispatcher) (*publicRpcServer, error) {
+	server := &publicRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,
 		log: log.With().
@@ -40,7 +40,7 @@ func NewPublicRpcServer(provider container.GrpcProvider, bindAddress string, sha
 	return server, nil
 }
 
-func (s *PublicRpcServer) ShardAssignments(_ *proto.ShardAssignmentsRequest, srv proto.OxiaClient_ShardAssignmentsServer) error {
+func (s *publicRpcServer) ShardAssignments(_ *proto.ShardAssignmentsRequest, srv proto.OxiaClient_ShardAssignmentsServer) error {
 	s.log.Debug().
 		Str("peer", common.GetPeer(srv.Context())).
 		Msg("Shard assignments requests")
@@ -54,7 +54,7 @@ func (s *PublicRpcServer) ShardAssignments(_ *proto.ShardAssignmentsRequest, srv
 	return err
 }
 
-func (s *PublicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
+func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
 	s.log.Debug().
 		Str("peer", common.GetPeer(ctx)).
 		Interface("req", write).
@@ -78,7 +78,7 @@ func (s *PublicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) 
 	return wr, err
 }
 
-func (s *PublicRpcServer) Read(ctx context.Context, read *proto.ReadRequest) (*proto.ReadResponse, error) {
+func (s *publicRpcServer) Read(ctx context.Context, read *proto.ReadRequest) (*proto.ReadResponse, error) {
 	s.log.Debug().
 		Str("peer", common.GetPeer(ctx)).
 		Interface("req", read).
@@ -102,7 +102,7 @@ func (s *PublicRpcServer) Read(ctx context.Context, read *proto.ReadRequest) (*p
 	return rr, err
 }
 
-func (s *PublicRpcServer) GetNotifications(req *proto.NotificationsRequest, stream proto.OxiaClient_GetNotificationsServer) error {
+func (s *publicRpcServer) GetNotifications(req *proto.NotificationsRequest, stream proto.OxiaClient_GetNotificationsServer) error {
 	s.log.Debug().
 		Str("peer", common.GetPeer(stream.Context())).
 		Interface("req", req).
@@ -125,6 +125,6 @@ func (s *PublicRpcServer) GetNotifications(req *proto.NotificationsRequest, stre
 	return err
 }
 
-func (s *PublicRpcServer) Close() error {
+func (s *publicRpcServer) Close() error {
 	return s.grpcServer.Close()
 }

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ type Config struct {
 
 type Server struct {
 	*internalRpcServer
-	*PublicRpcServer
+	*publicRpcServer
 
 	replicationRpcProvider    ReplicationRpcProvider
 	shardAssignmentDispatcher ShardAssignmentsDispatcher
@@ -59,14 +59,14 @@ func NewWithGrpcProvider(config Config, provider container.GrpcProvider, replica
 	s.shardsDirector = NewShardsDirector(s.walFactory, s.kvFactory, replicationRpcProvider)
 	s.shardAssignmentDispatcher = NewShardAssignmentDispatcher()
 
-	s.internalRpcServer, err = newCoordinationRpcServer(provider,
+	s.internalRpcServer, err = newInternalRpcServer(provider,
 		fmt.Sprintf("%s:%d", config.BindHost, config.InternalServicePort),
 		s.shardsDirector, s.shardAssignmentDispatcher)
 	if err != nil {
 		return nil, err
 	}
 
-	s.PublicRpcServer, err = NewPublicRpcServer(provider,
+	s.publicRpcServer, err = newPublicRpcServer(provider,
 		fmt.Sprintf("%s:%d", config.BindHost, config.PublicServicePort), s.shardsDirector, s.shardAssignmentDispatcher)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func NewWithGrpcProvider(config Config, provider container.GrpcProvider, replica
 }
 
 func (s *Server) PublicPort() int {
-	return s.PublicRpcServer.grpcServer.Port()
+	return s.publicRpcServer.grpcServer.Port()
 }
 
 func (s *Server) InternalPort() int {
@@ -93,7 +93,7 @@ func (s *Server) Close() error {
 	err := multierr.Combine(
 		s.shardAssignmentDispatcher.Close(),
 		s.shardsDirector.Close(),
-		s.PublicRpcServer.Close(),
+		s.publicRpcServer.Close(),
 		s.internalRpcServer.Close(),
 		s.kvFactory.Close(),
 		s.walFactory.Close(),

--- a/standalone/standalone_rpc_server.go
+++ b/standalone/standalone_rpc_server.go
@@ -16,7 +16,7 @@ import (
 	"oxia/server/wal"
 )
 
-type StandaloneRpcServer struct {
+type rpcServer struct {
 	proto.UnimplementedOxiaClientServer
 
 	advertisedPublicAddress string
@@ -31,8 +31,8 @@ type StandaloneRpcServer struct {
 	log zerolog.Logger
 }
 
-func NewStandaloneRpcServer(bindAddress string, advertisedPublicAddress string, numShards uint32, walFactory wal.WalFactory, kvFactory kv.KVFactory) (*StandaloneRpcServer, error) {
-	res := &StandaloneRpcServer{
+func newRpcServer(bindAddress string, advertisedPublicAddress string, numShards uint32, walFactory wal.WalFactory, kvFactory kv.KVFactory) (*rpcServer, error) {
+	res := &rpcServer{
 		advertisedPublicAddress: advertisedPublicAddress,
 		numShards:               numShards,
 		walFactory:              walFactory,
@@ -86,7 +86,7 @@ func NewStandaloneRpcServer(bindAddress string, advertisedPublicAddress string, 
 	return res, nil
 }
 
-func (s *StandaloneRpcServer) Close() error {
+func (s *rpcServer) Close() error {
 	var err error
 	for _, c := range s.controllers {
 		err = multierr.Append(err, c.Close())
@@ -98,15 +98,15 @@ func (s *StandaloneRpcServer) Close() error {
 	)
 }
 
-func (s *StandaloneRpcServer) ShardAssignments(_ *proto.ShardAssignmentsRequest, stream proto.OxiaClient_ShardAssignmentsServer) error {
+func (s *rpcServer) ShardAssignments(_ *proto.ShardAssignmentsRequest, stream proto.OxiaClient_ShardAssignmentsServer) error {
 	return s.assignmentDispatcher.RegisterForUpdates(stream)
 }
 
-func (s *StandaloneRpcServer) Port() int {
+func (s *rpcServer) Port() int {
 	return s.grpcServer.Port()
 }
 
-func (s *StandaloneRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
+func (s *rpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
 	lc, ok := s.controllers[*write.ShardId]
 	if !ok {
 		return nil, errors.New("shard not found")
@@ -115,7 +115,7 @@ func (s *StandaloneRpcServer) Write(ctx context.Context, write *proto.WriteReque
 	return lc.Write(write)
 }
 
-func (s *StandaloneRpcServer) Read(ctx context.Context, read *proto.ReadRequest) (*proto.ReadResponse, error) {
+func (s *rpcServer) Read(ctx context.Context, read *proto.ReadRequest) (*proto.ReadResponse, error) {
 	lc, ok := s.controllers[*read.ShardId]
 	if !ok {
 		return nil, errors.New("shard not found")
@@ -124,7 +124,7 @@ func (s *StandaloneRpcServer) Read(ctx context.Context, read *proto.ReadRequest)
 	return lc.Read(read)
 }
 
-func (s *StandaloneRpcServer) GetNotifications(req *proto.NotificationsRequest, stream proto.OxiaClient_GetNotificationsServer) error {
+func (s *rpcServer) GetNotifications(req *proto.NotificationsRequest, stream proto.OxiaClient_GetNotificationsServer) error {
 	s.log.Debug().
 		Str("peer", common.GetPeer(stream.Context())).
 		Interface("req", req).


### PR DESCRIPTION
Cleanup standalone so it's more consistent with the other components in terms of visibility, and to make it easier to use for testing - i.e. no longer a need to create WAL, KV etc