### PR TITLE
Added wait group with ctx and error

### DIFF
--- a/common/wait_group.go
+++ b/common/wait_group.go
@@ -1,0 +1,56 @@
+package common
+
+import "context"
+
+// WaitGroup is similar to sync.WaitGroup but adds 2 capabilities:
+//  1. Returning an error if any operation fails
+//  2. Accept a context to cancel the Wait
+type WaitGroup interface {
+
+	// Wait until all the parties in the group are either done or if there is any failure
+	// You should only call wait once
+	Wait(ctx context.Context) error
+
+	// Done Signals that one party in the group is done
+	Done()
+
+	// Fail Signal that one party has failed in the operation
+	Fail(err error)
+}
+
+type waitGroup struct {
+	parties   int
+	responses chan error
+}
+
+func NewWaitGroup(parties int) WaitGroup {
+	return &waitGroup{
+		parties:   parties,
+		responses: make(chan error, parties),
+	}
+}
+
+func (g *waitGroup) Wait(ctx context.Context) error {
+	for i := 0; i < g.parties; i++ {
+		select {
+		case err := <-g.responses:
+			if err != nil {
+				return err
+			}
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	// Everyone has completed successfully
+	return nil
+}
+
+func (g *waitGroup) Done() {
+	g.responses <- nil
+}
+
+func (g *waitGroup) Fail(err error) {
+	g.responses <- err
+}

--- a/common/wait_group_test.go
+++ b/common/wait_group_test.go
@@ -1,0 +1,101 @@
+package common
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+	"time"
+)
+
+func assertNotReady(t *testing.T, wg WaitGroup) {
+	done := make(chan bool, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	go func() {
+		assert.ErrorIs(t, wg.Wait(ctx), context.Canceled)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+		assert.Fail(t, "should have timed out")
+
+	case <-time.After(100 * time.Millisecond):
+		// OK
+	}
+}
+
+func TestWaitGroup(t *testing.T) {
+	wg := NewWaitGroup(3)
+	assertNotReady(t, wg)
+
+	wg = NewWaitGroup(1)
+	assertNotReady(t, wg)
+	wg.Done()
+	assert.NoError(t, wg.Wait(context.Background()))
+
+	wg = NewWaitGroup(3)
+	wg.Done()
+	wg.Done()
+	assertNotReady(t, wg)
+
+	wg = NewWaitGroup(3)
+	assertNotReady(t, wg)
+	wg.Done()
+	wg.Done()
+	wg.Done()
+	assert.NoError(t, wg.Wait(context.Background()))
+
+	wg = NewWaitGroup(3)
+	wg.Fail(io.EOF)
+	assert.ErrorIs(t, wg.Wait(context.Background()), io.EOF)
+
+	wg = NewWaitGroup(3)
+	wg.Done()
+	wg.Fail(io.EOF)
+	assert.ErrorIs(t, wg.Wait(context.Background()), io.EOF)
+}
+
+func TestWaitGroup_Cancel(t *testing.T) {
+	wg := NewWaitGroup(3)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan bool)
+
+	go func() {
+		assert.ErrorIs(t, wg.Wait(ctx), context.Canceled)
+		done <- true
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	// Ok
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "shouldn't have timed out")
+	}
+}
+
+func TestWaitGroup_Timeout(t *testing.T) {
+	wg := NewWaitGroup(3)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan bool)
+
+	go func() {
+		assert.ErrorIs(t, wg.Wait(ctx), context.DeadlineExceeded)
+		done <- true
+	}()
+
+	select {
+	case <-done:
+	// Ok
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "shouldn't have timed out")
+	}
+}


### PR DESCRIPTION
Encapsulate the logic of waiting for multiple operations that are being performed in parallel by using a `WaitGroup` that returns an error and can be cancelled through a context object