### PR TITLE
Fix flaky TestFollowerCursor

### DIFF
--- a/server/follower_cursor_test.go
+++ b/server/follower_cursor_test.go
@@ -41,14 +41,13 @@ func TestFollowerCursor(t *testing.T) {
 	assert.NoError(t, err)
 	log.Logger.Info().Msg("Appended entry 0 to the log")
 
-	assert.Equal(t, wal.InvalidOffset, fc.LastPushed())
-	assert.Equal(t, wal.InvalidOffset, fc.AckIndex())
-
-	ackTracker.AdvanceHeadIndex(0)
-
 	assert.Eventually(t, func() bool {
 		return fc.LastPushed() == 0
 	}, 10*time.Second, 100*time.Millisecond)
+
+	assert.Equal(t, wal.InvalidOffset, fc.AckIndex())
+
+	ackTracker.AdvanceHeadIndex(0)
 
 	assert.Equal(t, wal.InvalidOffset, fc.AckIndex())
 


### PR DESCRIPTION
The `fc.LastPushed()` is updated by a background go-routine as the entry in the WAL is already visible.

Seen failing in  https://github.com/streamnative/oxia/actions/runs/3857418385/jobs/6575409902

```
Jan  6 18:55:11.432544 INF Successfully attached cursor follower ack-index=-1 component=follower-cursor epoch=1 follower=f1 shard=2
Jan  6 18:55:11.432758 DBG Sending entries to follower component=follower-cursor epoch=1 follower=f1 offset=0 shard=2
Jan  6 18:55:11.432468 INF Appended entry 0 to the log
Jan  6 18:55:11.533444 DBG Received ack component=follower-cursor epoch=1 follower=f1 offset=0 shard=2
Jan  6 18:55:11.635342 DBG Sending entries to follower component=follower-cursor epoch=1 follower=f1 offset=1 shard=2
--- FAIL: TestFollowerCursor (0.31s)
    follower_cursor_test.go:44: 
        	Error Trace:	/home/runner/work/oxia/oxia/server/follower_cursor_test.go:44
        	Error:      	Not equal: 
        	            	expected: -1
        	            	actual  : 0
        	Test:       	TestFollowerCursor
```