### PR TITLE
Pass token to GH actions protoc install

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -25,10 +25,10 @@ jobs:
         with:
           go-version: 1.19
 
-      - name: Install deps
-        run: |
-          sudo apt-get update -y &&           \
-          sudo apt-get install -y protobuf-compiler
+      - name: Install protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Installing protoc-gen-go
         run: |


### PR DESCRIPTION
The action `arduino/setup-protoc@v1` is failing very often in PR validations for rate limiting (eg: https://github.com/streamnative/oxia/actions/runs/3856618954/jobs/6573044493). 

We need to pass the repo token to avoid the rate limiting. ref: https://github.com/arduino/setup-protoc/issues/6