### PR TITLE
Fixed notification manager initialization

### DIFF
--- a/oxia/notifications.go
+++ b/oxia/notifications.go
@@ -36,6 +36,8 @@ func newNotifications(options clientOptions, ctx context.Context, clientPool com
 
 	// Create a notification manager for each shard
 	shards := shardManager.GetAll()
+	nm.initWaitGroup = common.NewWaitGroup(len(shards))
+
 	for _, shard := range shards {
 		newShardNotificationsManager(shard, nm)
 	}
@@ -51,8 +53,6 @@ func newNotifications(options clientOptions, ctx context.Context, clientPool com
 
 		close(nm.multiplexCh)
 	})
-
-	nm.initWaitGroup = common.NewWaitGroup(len(shards))
 
 	// Wait for the notifications on all the shards to be initialized
 	timeoutCtx, cancel := context.WithTimeout(nm.ctx, options.requestTimeout)


### PR DESCRIPTION
The wait group needs to be initialized before the per-shard managers, or we can have nil references.

```
Jan 10 00:18:35.252230 DBG Initialized the notification manager component=oxia-notifications-manager shard=0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1198b9e]

goroutine [168](https://github.com/streamnative/oxia/actions/runs/3878912894/jobs/6615553403#step:8:169) [running]:
oxia/oxia.(*shardNotificationsManager).getNotifications(0xc0001ff2c0)
	/home/runner/work/oxia/oxia/oxia/notifications.go:182 +0x73e
github.com/cenkalti/backoff/v4.RetryNotifyWithTimer.func1()
	/home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.0/retry.go:18 +0x31
github.com/cenkalti/backoff/v4.doRetryNotify[...](0xc0001d9ce0, {0x7fa0443959a0, 0xc0001aaa20}, 0xc0001d9d40, {0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.0/retry.go:88 +0x1bb
github.com/cenkalti/backoff/v4.RetryNotifyWithTimer(0xc00021dd30, {0x7fa0443959a0, 0xc0001aaa20}, 0x1259c40?, {0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.0/retry.go:61 +0x98
github.com/cenkalti/backoff/v4.RetryNotify(...)
	/home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.0/retry.go:49
oxia/oxia.(*shardNotificationsManager).getNotificationsWithRetries(0xc0001ff2c0?)
	/home/runner/work/oxia/oxia/oxia/notifications.go:112 +0xa5
oxia/common.DoWithLabels.func1({0x1638ff8?, 0xc000426de0?})
	/home/runner/work/oxia/oxia/common/pprof.go:29 +0x31
runtime/pprof.Do({0x1638f88, 0xc00013a008}, {{0xc000128f00?, 0xb4d1e0?, 0x4?}}, 0xc00021df30)
	/opt/hostedtoolcache/go/1.19.4/x64/src/runtime/pprof/runtime.go:40 +0x123
oxia/common.DoWithLabels(0xf?, 0xc0003f4e00)
	/home/runner/work/oxia/oxia/common/pprof.go:25 +0x4f1
created by oxia/oxia.newShardNotificationsManager
	/home/runner/work/oxia/oxia/oxia/notifications.go:103 +0xaa6
```