### PR TITLE
Add `oxia_cluster` labels to metrics in Prometheus

### DIFF
--- a/deploy/charts/oxia-cluster/templates/coordinator-service.yaml
+++ b/deploy/charts/oxia-cluster/templates/coordinator-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    oxia_cluster: {{ .Release.Name }}
     {{- include "oxia-cluster.coordinator.labels" . | nindent 4 }}
   name: {{ .Release.Name }}-coordinator
 spec:

--- a/deploy/charts/oxia-cluster/templates/coordinator-servicemonitor.yaml
+++ b/deploy/charts/oxia-cluster/templates/coordinator-servicemonitor.yaml
@@ -11,4 +11,6 @@ spec:
   selector:
     matchLabels:
       {{- include "oxia-cluster.coordinator.selectorLabels" . | nindent 6 }}
+  targetLabels:
+    - oxia_cluster
 {{- end }}

--- a/deploy/charts/oxia-cluster/templates/server-service.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    oxia_cluster: {{ .Release.Name }}
     {{- include "oxia-cluster.server.labels" . | nindent 4 }}
   name: {{ .Release.Name }}
 spec:

--- a/deploy/charts/oxia-cluster/templates/server-servicemonitor.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-servicemonitor.yaml
@@ -11,4 +11,6 @@ spec:
   selector:
     matchLabels:
       {{- include "oxia-cluster.server.selectorLabels" . | nindent 6 }}
+  targetLabels:
+    - oxia_cluster
 {{- end }}


### PR DESCRIPTION
Tag all metrics with cluster name so that we can select the cluster in Grafana