### PR TITLE
Change workflow name

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -1,4 +1,4 @@
-name: PR check
+name: Build
 
 on:
   pull_request:


### PR DESCRIPTION
The workflow name is what is used in the build badge in the README. This is clearer as `Build`.