### PR TITLE
Wait for all nodes to be up for cluster initialization

### DIFF
--- a/coordinator/impl/coordinator.go
+++ b/coordinator/impl/coordinator.go
@@ -13,6 +13,7 @@ import (
 	"oxia/coordinator/model"
 	"oxia/proto"
 	"sync"
+	"time"
 )
 
 type ShardAssignmentsProvider interface {
@@ -50,6 +51,9 @@ type coordinator struct {
 	metadataVersion  Version
 	rpc              RpcProvider
 	log              zerolog.Logger
+
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func NewCoordinator(metadataProvider MetadataProvider, clusterConfig model.ClusterConfig, rpc RpcProvider) (Coordinator, error) {
@@ -64,6 +68,8 @@ func NewCoordinator(metadataProvider MetadataProvider, clusterConfig model.Clust
 			Logger(),
 	}
 
+	c.ctx, c.cancel = context.WithCancel(context.Background())
+
 	c.assignmentsChanged = common.NewConditionContext(c)
 
 	var err error
@@ -72,7 +78,17 @@ func NewCoordinator(metadataProvider MetadataProvider, clusterConfig model.Clust
 		return nil, err
 	}
 
+	for _, sa := range clusterConfig.Servers {
+		c.nodeControllers[sa.Internal] = NewNodeController(sa, c, c, c.rpc)
+	}
+
 	if c.clusterStatus == nil {
+		// Before initializing the cluster, it's better to make sure we
+		// have all the nodes available, otherwise the coordinator might be
+		// the first component in getting started and will print out a lot
+		// of error logs regarding failed leader elections
+		c.waitForAllNodesToBeAvailable()
+
 		if err = c.initialAssignment(); err != nil {
 			return nil, err
 		}
@@ -82,11 +98,32 @@ func NewCoordinator(metadataProvider MetadataProvider, clusterConfig model.Clust
 		c.shardControllers[shard] = NewShardController(shard, shardMetadata, c.rpc, c)
 	}
 
-	for _, sa := range clusterConfig.Servers {
-		c.nodeControllers[sa.Internal] = NewNodeController(sa, c, c, c.rpc)
-	}
-
 	return c, nil
+}
+
+func (c *coordinator) waitForAllNodesToBeAvailable() {
+	c.log.Info().Msg("Waiting for all the nodes to be available")
+	for {
+
+		select {
+
+		case <-time.After(1 * time.Second):
+			allNodesAvailable := true
+			for _, n := range c.nodeControllers {
+				if n.Status() != Running {
+					allNodesAvailable = false
+				}
+			}
+			if allNodesAvailable {
+				c.log.Info().Msg("All nodes are now available")
+				return
+			}
+
+		case <-c.ctx.Done():
+			// Give up if we're closing the coordinator
+			return
+		}
+	}
 }
 
 // Assign the shards to the available servers

--- a/coordinator/impl/node_controller.go
+++ b/coordinator/impl/node_controller.go
@@ -103,7 +103,7 @@ func (n *nodeController) Status() NodeStatus {
 }
 
 func (n *nodeController) healthCheckWithRetries() {
-	backOff := common.NewBackOffWithInitialInterval(n.ctx, 1*time.Second)
+	backOff := common.NewBackOffWithInitialInterval(n.ctx, 10*time.Second)
 	_ = backoff.RetryNotify(func() error {
 		return n.healthCheck(backOff)
 	}, backOff, func(err error, duration time.Duration) {
@@ -195,7 +195,7 @@ func (n *nodeController) processHealthCheckResponse(res *grpc_health_v1.HealthCh
 }
 
 func (n *nodeController) sendAssignmentsUpdatesWithRetries() {
-	backOff := common.NewBackOffWithInitialInterval(n.ctx, 1*time.Second)
+	backOff := common.NewBackOffWithInitialInterval(n.ctx, 10*time.Second)
 
 	_ = backoff.RetryNotify(func() error {
 		return n.sendAssignmentsUpdates(backOff)


### PR DESCRIPTION
When initializing the cluster for the first time, wait for all the nodes to be available. 

This happens when we bootstrap a new cluster and the coordinator might be the first service to be started.

Also increased the backoff initial time to 10 seconds for health-checks. There's no good reason to have these super-tight as they're not keeping a leader election to happen. 