### PR TITLE
Restructure CRD, add docs and validations

### DIFF
--- a/deploy/crds/oxiaclusters.yaml
+++ b/deploy/crds/oxiaclusters.yaml
@@ -1,112 +1,209 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
   name: oxiaclusters.oxia.streamnative.io
 spec:
   group: oxia.streamnative.io
   names:
     kind: OxiaCluster
-    singular: cluster
+    listKind: OxiaClusterList
     plural: oxiaclusters
-    shortNames: [ "oc" ]
+    shortNames:
+      - oc
+    singular: oxiacluster
   scope: Namespaced
   versions:
     - name: v1alpha1
-      served: true
-      storage: true
       schema:
         openAPIV3Schema:
-          type: object
-          #TODO field validation, i.e. >0, cpu/memory/volume resources
-          #TODO field defaults
+          description: OxiaCluster is the Schema for the oxiaclusters API
           properties:
-            spec:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
+            spec:
+              description: OxiaClusterSpec defines the desired state of OxiaCluster
               properties:
+                coordinator:
+                  description: Coordinator contains configuration specific to the coordinator
+                    component
+                  properties:
+                    cpu:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Cpu describes the requests and limits of CPU cores
+                        allocated to the pod
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                      x-kubernetes-validations:
+                        - message: Cpu is immutable
+                          rule: self == oldSelf
+                    memory:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Memory describes the requests and limits of Memory
+                        allocated to the pod
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                      x-kubernetes-validations:
+                        - message: Memory is immutable
+                          rule: self == oldSelf
+                  required:
+                    - cpu
+                    - memory
+                  type: object
+                  x-kubernetes-validations:
+                    - message: Coordinator is immutable
+                      rule: self == oldSelf
+                image:
+                  description: Image contains configuration specific to the image being
+                    used
+                  properties:
+                    name:
+                      description: Image is the container image name
+                      type: string
+                      x-kubernetes-validations:
+                        - message: Name is immutable
+                          rule: self == oldSelf
+                    pullPolicy:
+                      description: PullPolicy is one of Always, Never, IfNotPresent
+                      enum:
+                        - Always
+                        - Never
+                        - IfNotPresent
+                      type: string
+                      x-kubernetes-validations:
+                        - message: PullPolicy is immutable
+                          rule: self == oldSelf
+                    pullSecrets:
+                      description: PullSecrets is the optional name of a secret in the
+                        same namespace to use for pulling the image
+                      type: string
+                      x-kubernetes-validations:
+                        - message: PullSecrets is immutable
+                          rule: self == oldSelf
+                  required:
+                    - name
+                  type: object
+                  x-kubernetes-validations:
+                    - message: Image is immutable
+                      rule: self == oldSelf
                 initialShardCount:
+                  description: InitialShardCount is the initial number of shard to bootstrap
+                    a new cluster with
+                  format: int32
+                  minimum: 1
                   type: integer
                   x-kubernetes-validations:
                     - message: InitialShardCount is immutable
                       rule: self == oldSelf
-                replicationFactor:
-                  type: integer
-                  x-kubernetes-validations:
-                    - message: ReplicationFactor is immutable
-                      rule: self == oldSelf
-                serverReplicas:
-                  type: integer
-                  x-kubernetes-validations:
-                    - message: ServerReplicas is immutable
-                      rule: self == oldSelf
-                serverResources:
-                  type: object
-                  properties:
-                    cpu:
-                      type: string
-                      x-kubernetes-validations:
-                        - message: Cpu is immutable
-                          rule: self == oldSelf
-                    memory:
-                      type: string
-                      x-kubernetes-validations:
-                        - message: Memory is immutable
-                          rule: self == oldSelf
-                  required:
-                    - cpu
-                    - memory
-                serverVolume:
-                  type: string
-                  x-kubernetes-validations:
-                    - message: ServerVolume is immutable
-                      rule: self == oldSelf
-                storageClassName:
-                  type: string
-                coordinatorResources:
-                  type: object
-                  properties:
-                    cpu:
-                      type: string
-                      x-kubernetes-validations:
-                        - message: Cpu is immutable
-                          rule: self == oldSelf
-                    memory:
-                      type: string
-                      x-kubernetes-validations:
-                        - message: Memory is immutable
-                          rule: self == oldSelf
-                  required:
-                    - cpu
-                    - memory
-                image:
-                  type: string
-                  x-kubernetes-validations:
-                    - message: Image is immutable
-                      rule: self == oldSelf
-                imagePullSecrets:
-                  type: string
-                  x-kubernetes-validations:
-                    - message: ImagePullSecrets is immutable
-                      rule: self == oldSelf
-                imagePullPolicy:
-                  type: string
-                  x-kubernetes-validations:
-                    - message: ImagePullPolicy is immutable
-                      rule: self == oldSelf
                 monitoringEnabled:
+                  description: MonitoringEnabled determines whether a Prometheus ServiceMonitor
+                    should be created
                   type: boolean
                   x-kubernetes-validations:
                     - message: MonitoringEnabled is immutable
                       rule: self == oldSelf
+                replicationFactor:
+                  description: ReplicationFactor is the number of copies the cluster
+                    will maintain for each shard. leader + followers
+                  format: int32
+                  maximum: 15
+                  minimum: 1
+                  type: integer
+                  x-kubernetes-validations:
+                    - message: ReplicationFactor is immutable
+                      rule: self == oldSelf
+                server:
+                  description: Server contains configuration specific to the server
+                    component
+                  properties:
+                    cpu:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Cpu describes the requests and limits of CPU cores
+                        allocated to each pod
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                      x-kubernetes-validations:
+                        - message: Cpu is immutable
+                          rule: self == oldSelf
+                    memory:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Memory describes the requests and limits of memory
+                        allocated to each pod
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                      x-kubernetes-validations:
+                        - message: Memory is immutable
+                          rule: self == oldSelf
+                    replicas:
+                      description: Replicas is the number of server pods that should
+                        be running
+                      format: int32
+                      minimum: 1
+                      type: integer
+                      x-kubernetes-validations:
+                        - message: Replicas is immutable
+                          rule: self == oldSelf
+                    storage:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Storage describes the size of the persistent volume
+                        allocated to each pod
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                      x-kubernetes-validations:
+                        - message: Volume is immutable
+                          rule: self == oldSelf
+                    storageClassName:
+                      description: StorageClassName is the name of StorageClass to which
+                        the persistent volume belongs
+                      type: string
+                      x-kubernetes-validations:
+                        - message: StorageClassName is immutable
+                          rule: self == oldSelf
+                  required:
+                    - cpu
+                    - memory
+                    - replicas
+                    - storage
+                  type: object
+                  x-kubernetes-validations:
+                    - message: Server is immutable
+                      rule: self == oldSelf
               required:
-                - initialShardCount
-                - replicationFactor
-                - serverReplicas
-                - serverResources
-                - serverVolume
-                - coordinatorResources
+                - coordinator
                 - image
+                - initialShardCount
                 - monitoringEnabled
-            status:
+                - replicationFactor
+                - server
               type: object
+            status:
+              description: OxiaClusterStatus defines the observed state of OxiaCluster
+              type: object
+          type: object
+      served: true
+      storage: true
       subresources:
         status: {}

--- a/examples/resources/oxiacluster.yaml
+++ b/examples/resources/oxiacluster.yaml
@@ -1,19 +1,27 @@
 apiVersion: oxia.streamnative.io/v1alpha1
 kind: OxiaCluster
 metadata:
-  name: oxia
-  namespace: oxia
+  labels:
+    app.kubernetes.io/name: oxiacluster
+    app.kubernetes.io/instance: oxiacluster-sample
+    app.kubernetes.io/part-of: oxia-operator
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/created-by: oxia-operator
+  name: oxiacluster-sample
 spec:
   initialShardCount: 3
   replicationFactor: 3
-  serverReplicas: 3
-  serverResources:
+  coordinator:
     cpu: 100m
     memory: 128Mi
-  serverVolume: 1Gi
-  coordinatorResources:
+  server:
+    replicas: 3
     cpu: 100m
     memory: 128Mi
-  image: streamnative/oxia:main
-  imagePullPolicy: Always
+    storage: 1Gi
+  #    storageClassName: gp2
+  image:
+    name: streamnative/oxia:main
+    pullPolicy: Always
+  #    pullSecrets: my-docker-secret
   monitoringEnabled: true

--- a/kubernetes/cluster_test.go
+++ b/kubernetes/cluster_test.go
@@ -6,6 +6,7 @@ import (
 	fakeMonitoring "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
 	"github.com/stretchr/testify/assert"
 	coreV1 "k8s.io/api/core/v1"
+	k8sResource "k8s.io/apimachinery/pkg/api/resource"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -27,18 +28,20 @@ func TestCluster(t *testing.T) {
 		Spec: v1alpha1.OxiaClusterSpec{
 			InitialShardCount: 1,
 			ReplicationFactor: 2,
-			ServerReplicas:    3,
-			ServerResources: v1alpha1.Resources{
-				Cpu:    "100m",
-				Memory: "128Mi",
+			Coordinator: v1alpha1.Coordinator{
+				Cpu:    k8sResource.MustParse("100m"),
+				Memory: k8sResource.MustParse("128Mi"),
 			},
-			ServerVolume: "1Gi",
-			CoordinatorResources: v1alpha1.Resources{
-				Cpu:    "100m",
-				Memory: "128Mi",
+			Server: v1alpha1.Server{
+				Replicas: 3,
+				Cpu:      k8sResource.MustParse("100m"),
+				Memory:   k8sResource.MustParse("128Mi"),
+				Storage:  k8sResource.MustParse("1Gi"),
 			},
-			Image:             "oxia:latest",
-			ImagePullPolicy:   &pullAlways,
+			Image: v1alpha1.Image{
+				Name:       "streamnative/oxia:latest",
+				PullPolicy: &pullAlways,
+			},
 			MonitoringEnabled: true,
 		},
 	}

--- a/kubernetes/resources_test.go
+++ b/kubernetes/resources_test.go
@@ -16,7 +16,9 @@ func TestConfigMap(t *testing.T) {
 		Spec: v1alpha1.OxiaClusterSpec{
 			InitialShardCount: 1,
 			ReplicationFactor: 2,
-			ServerReplicas:    3,
+			Server: v1alpha1.Server{
+				Replicas: 3,
+			},
 		},
 	}
 	configMap := configMap(cluster)

--- a/pkg/apis/oxia/v1alpha1/types.go
+++ b/pkg/apis/oxia/v1alpha1/types.go
@@ -1,7 +1,8 @@
 package v1alpha1
 
 import (
-	coreV1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -19,26 +20,63 @@ type OxiaCluster struct {
 
 // OxiaClusterSpec is the spec for an OxiaCluster resource
 type OxiaClusterSpec struct {
-	InitialShardCount    uint32             `json:"initialShardCount"`
-	ReplicationFactor    uint32             `json:"replicationFactor"`
-	ServerReplicas       uint32             `json:"serverReplicas"`
-	ServerResources      Resources          `json:"serverResources"`
-	ServerVolume         string             `json:"serverVolume"`
-	StorageClassName     *string            `json:"storageClassName,omitempty"`
-	CoordinatorResources Resources          `json:"coordinatorResources"`
-	Image                string             `json:"image"`
-	ImagePullSecrets     *string            `json:"imagePullSecrets,omitempty"`
-	ImagePullPolicy      *coreV1.PullPolicy `json:"imagePullPolicy,omitempty"`
-	MonitoringEnabled    bool               `json:"monitoringEnabled"`
+	// InitialShardCount is the initial number of shard to bootstrap a new cluster with
+	InitialShardCount uint32 `json:"initialShardCount"`
+
+	// ReplicationFactor is the number of copies the cluster will maintain for each shard. leader + followers
+	ReplicationFactor uint32 `json:"replicationFactor"`
+
+	// Coordinator contains configuration specific to the coordinator component
+	Coordinator Coordinator `json:"coordinator"`
+
+	// Server contains configuration specific to the server component
+	Server Server `json:"server"`
+
+	// Image contains configuration specific to the image being used
+	Image Image `json:"image"`
+
+	// MonitoringEnabled determines whether a Prometheus ServiceMonitor should be created
+	MonitoringEnabled bool `json:"monitoringEnabled"`
+}
+
+type Coordinator struct {
+	// Cpu describes the requests and limits of CPU cores allocated to the pod
+	Cpu resource.Quantity `json:"cpu"`
+
+	// Memory describes the requests and limits of Memory allocated to the pod
+	Memory resource.Quantity `json:"memory"`
+}
+
+type Server struct {
+	// Replicas is the number of server pods that should be running
+	Replicas uint32 `json:"replicas"`
+
+	// Cpu describes the requests and limits of CPU cores allocated to each pod
+	Cpu resource.Quantity `json:"cpu"`
+
+	// Memory describes the requests and limits of memory allocated to each pod
+	Memory resource.Quantity `json:"memory"`
+
+	// Storage describes the size of the persistent volume allocated to each pod
+	Storage resource.Quantity `json:"storage"`
+
+	// StorageClassName is the name of StorageClass to which the persistent volume belongs
+	StorageClassName *string `json:"storageClassName,omitempty"`
+}
+
+type Image struct {
+	// Image is the container image name
+	Name string `json:"name"`
+
+	// PullPolicy is one of Always, Never, IfNotPresent
+	PullPolicy *corev1.PullPolicy `json:"pullPolicy,omitempty"`
+
+	// PullSecrets is the optional name of a secret in the same namespace to use for pulling the image
+	PullSecrets *string `json:"pullSecrets,omitempty"`
 }
 
 // OxiaClusterStatus is the status for an OxiaCluster resource
 type OxiaClusterStatus struct{}
-
-type Resources struct {
-	Cpu    string `json:"cpu"`
-	Memory string `json:"memory"`
-}
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 


### PR DESCRIPTION
- Restructured CRD a bit more logically
- Added validations
- Added field docs

FYI, I've locally created a new `oxia-operator` repo and used kubebuilder to generate an initial project. I then authored the `OxiaCluster` go resource using the [crd](https://book.kubebuilder.io/reference/markers/crd.html) [validation](https://book.kubebuilder.io/reference/markers/crd-validation.html) annotations and generated the CRD yaml from that.