### PR TITLE
Improve fsync invocation in wal

### DIFF
--- a/server/wal/fsync_generic.go
+++ b/server/wal/fsync_generic.go
@@ -1,0 +1,11 @@
+//go:build !unix
+
+package wal
+
+import (
+	"github.com/spf13/afero"
+)
+
+func doFSync(file afero.File) error {
+	return l.sfile.Sync()
+}

--- a/server/wal/fsync_test.go
+++ b/server/wal/fsync_test.go
@@ -1,0 +1,51 @@
+package wal
+
+import (
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+	"os"
+	"testing"
+)
+
+const (
+	testFile  = "test-file.bin"
+	writeSize = 4096
+)
+
+func BenchmarkFSync_stdlib(b *testing.B) {
+	_ = os.Remove(testFile)
+	f, err := os.Create(testFile)
+	assert.NoError(b, err)
+	data := make([]byte, writeSize)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := f.Write(data)
+		assert.NoError(b, err)
+
+		err = f.Sync()
+		assert.NoError(b, err)
+	}
+
+	b.StopTimer()
+	_ = os.Remove(testFile)
+}
+
+func BenchmarkFSync_x_sys(b *testing.B) {
+	_ = os.Remove(testFile)
+	f, err := os.Create(testFile)
+	assert.NoError(b, err)
+	data := make([]byte, writeSize)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := f.Write(data)
+		assert.NoError(b, err)
+
+		err = unix.Fsync(int(f.Fd()))
+		assert.NoError(b, err)
+	}
+
+	b.StopTimer()
+	_ = os.Remove(testFile)
+}

--- a/server/wal/fsync_unix.go
+++ b/server/wal/fsync_unix.go
@@ -1,0 +1,17 @@
+//go:build unix
+
+package wal
+
+import (
+	"github.com/spf13/afero"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+func doFSync(file afero.File) error {
+	if f, ok := file.(*os.File); ok {
+		return unix.Fsync(int(f.Fd()))
+	} else {
+		return file.Sync()
+	}
+}

--- a/server/wal/log.go
+++ b/server/wal/log.go
@@ -992,7 +992,7 @@ func (l *Log) syncNoMutex() error {
 	timer := l.syncLatency.Timer()
 	defer timer.Done()
 
-	return l.sfile.Sync()
+	return doFSync(l.sfile)
 }
 
 func (l *Log) newFile(name string) (afero.File, error) {


### PR DESCRIPTION
The `os.File.Sync()` is not super efficient. In MacOS it takes ~5ms to do fsyncs and that severely limits the throughput on the wal. 

Using unix facilities from standard extension package (https://pkg.go.dev/golang.org/x/sys/unix) we can get much better performance: 

```
BenchmarkFSync_stdlib
BenchmarkFSync_stdlib-10    	     289	   4460224 ns/op
BenchmarkFSync_x_sys
BenchmarkFSync_x_sys-10     	   24694	    126559 ns/op
```

This is 5ms vs 100micros (which is the expected avg time for fsyncs on SSDs)

The overall difference on the write performance in Oxia is very visible when writing to multiple shards on the same node. because it looks like the fsync on 1 file is clogging everything else.

eg: 

 * 1 shard --    56K --> 80K writes/s
 * 16 shards --  2.2K --> 120K write/s


Ideally we should also be using `fdatasync()`, though to take advantage we should also pre-allocate the file.