### PR TITLE
ShardManager: Use rlock for get

### DIFF
--- a/oxia/internal/shard_manager.go
+++ b/oxia/internal/shard_manager.go
@@ -90,8 +90,8 @@ func (s *shardManagerImpl) start() error {
 }
 
 func (s *shardManagerImpl) Get(key string) uint32 {
-	s.Lock()
-	defer s.Unlock()
+	s.RLock()
+	defer s.RUnlock()
 
 	predicate := s.shardStrategy.Get(key)
 


### PR DESCRIPTION
I believe get requires a read lock, not a write lock.