### PR TITLE
Remove all generated go files on `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ lint:
 clean:
 	rm -f bin/oxia
 	rm -f */*.pb.go
+	rm -rf pkg/generated/*
+	find . -type f -name '*.deepcopy.go' | xargs rm
 
 docker:
 	docker build -t oxia:latest .


### PR DESCRIPTION
Currently, these files remain even after `make clean`, so `make clean license-check` fails.