### PR TITLE
Unify bind addr and port into service address arguments

### DIFF
--- a/cmd/controller/cmd.go
+++ b/cmd/controller/cmd.go
@@ -34,8 +34,8 @@ var (
 )
 
 func init() {
-	flag.InternalPort(Cmd, &conf.InternalServicePort)
-	flag.MetricsPort(Cmd, &conf.MetricsPort)
+	flag.InternalAddr(Cmd, &conf.InternalServiceAddr)
+	flag.MetricsAddr(Cmd, &conf.MetricsServiceAddr)
 }
 
 func exec(*cobra.Command, []string) {

--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -38,8 +38,8 @@ var (
 )
 
 func init() {
-	flag.InternalPort(Cmd, &conf.InternalServicePort)
-	flag.MetricsPort(Cmd, &conf.MetricsPort)
+	flag.InternalAddr(Cmd, &conf.InternalServiceAddr)
+	flag.MetricsAddr(Cmd, &conf.MetricsServiceAddr)
 	Cmd.Flags().Var(&conf.MetadataProviderImpl, "metadata", "Metadata provider implementation: file, configmap or memory")
 	Cmd.Flags().StringVar(&conf.K8SMetadataNamespace, "k8s-namespace", conf.K8SMetadataNamespace, "Kubernetes namespace for metadata configmap")
 	Cmd.Flags().StringVar(&conf.K8SMetadataConfigMapName, "k8s-configmap-name", conf.K8SMetadataConfigMapName, "ConfigMap name for metadata configmap")

--- a/cmd/coordinator/cmd_test.go
+++ b/cmd/coordinator/cmd_test.go
@@ -55,8 +55,8 @@ func TestCmd(t *testing.T) {
 		isErr        bool
 	}{
 		{[]string{}, coordinator.Config{
-			InternalServicePort:  6649,
-			MetricsPort:          8080,
+			InternalServiceAddr:  "localhost:6649",
+			MetricsServiceAddr:   "localhost:8080",
 			MetadataProviderImpl: coordinator.File,
 			ClusterConfig: model.ClusterConfig{
 				ReplicationFactor: 1,
@@ -65,9 +65,9 @@ func TestCmd(t *testing.T) {
 					Public:   "public:1234",
 					Internal: "internal:5678",
 				}}}}, false},
-		{[]string{"-i=1234"}, coordinator.Config{
-			InternalServicePort:  1234,
-			MetricsPort:          8080,
+		{[]string{"-i=localhost:1234"}, coordinator.Config{
+			InternalServiceAddr:  "localhost:1234",
+			MetricsServiceAddr:   "localhost:8080",
 			MetadataProviderImpl: coordinator.File,
 			ClusterConfig: model.ClusterConfig{
 				ReplicationFactor: 1,
@@ -76,9 +76,20 @@ func TestCmd(t *testing.T) {
 					Public:   "public:1234",
 					Internal: "internal:5678",
 				}}}}, false},
-		{[]string{"-m=1234"}, coordinator.Config{
-			InternalServicePort:  6649,
-			MetricsPort:          1234,
+		{[]string{"-i=0.0.0.0:1234"}, coordinator.Config{
+			InternalServiceAddr:  "0.0.0.0:1234",
+			MetricsServiceAddr:   "localhost:8080",
+			MetadataProviderImpl: coordinator.File,
+			ClusterConfig: model.ClusterConfig{
+				ReplicationFactor: 1,
+				InitialShardCount: 2,
+				Servers: []model.ServerAddress{{
+					Public:   "public:1234",
+					Internal: "internal:5678",
+				}}}}, false},
+		{[]string{"-m=localhost:1234"}, coordinator.Config{
+			InternalServiceAddr:  "localhost:6649",
+			MetricsServiceAddr:   "localhost:1234",
 			MetadataProviderImpl: coordinator.File,
 			ClusterConfig: model.ClusterConfig{
 				ReplicationFactor: 1,
@@ -88,8 +99,8 @@ func TestCmd(t *testing.T) {
 					Internal: "internal:5678",
 				}}}}, false},
 		{[]string{"-f=" + name}, coordinator.Config{
-			InternalServicePort:  6649,
-			MetricsPort:          8080,
+			InternalServiceAddr:  "localhost:6649",
+			MetricsServiceAddr:   "localhost:8080",
 			MetadataProviderImpl: coordinator.File,
 			ClusterConfig: model.ClusterConfig{
 				ReplicationFactor: 1,
@@ -99,8 +110,8 @@ func TestCmd(t *testing.T) {
 					Internal: "internal:5678",
 				}}}}, false},
 		{[]string{"-f=invalid.yaml"}, coordinator.Config{
-			InternalServicePort: 6649,
-			MetricsPort:         8080,
+			InternalServiceAddr: "localhost:6649",
+			MetricsServiceAddr:  "localhost:8080",
 			ClusterConfig:       model.ClusterConfig{}}, true},
 	} {
 		t.Run(strings.Join(test.args, "_"), func(t *testing.T) {

--- a/cmd/flag/flag.go
+++ b/cmd/flag/flag.go
@@ -15,18 +15,19 @@
 package flag
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"oxia/kubernetes"
 )
 
-func PublicPort(cmd *cobra.Command, conf *int) {
-	cmd.Flags().IntVarP(conf, "public-port", "p", kubernetes.PublicPort.Port, "Public service port")
+func PublicAddr(cmd *cobra.Command, conf *string) {
+	cmd.Flags().StringVarP(conf, "public-addr", "p", fmt.Sprintf("0.0.0.0:%d", kubernetes.PublicPort.Port), "Public service bind address")
 }
 
-func InternalPort(cmd *cobra.Command, conf *int) {
-	cmd.Flags().IntVarP(conf, "internal-port", "i", kubernetes.InternalPort.Port, "Internal service port")
+func InternalAddr(cmd *cobra.Command, conf *string) {
+	cmd.Flags().StringVarP(conf, "internal-addr", "i", fmt.Sprintf("0.0.0.0:%d", kubernetes.InternalPort.Port), "Internal service bind address")
 }
 
-func MetricsPort(cmd *cobra.Command, conf *int) {
-	cmd.Flags().IntVarP(conf, "metrics-port", "m", kubernetes.MetricsPort.Port, "Metrics port")
+func MetricsAddr(cmd *cobra.Command, conf *string) {
+	cmd.Flags().StringVarP(conf, "metrics-addr", "m", fmt.Sprintf("0.0.0.0:%d", kubernetes.MetricsPort.Port), "Metrics service bind address")
 }

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -35,9 +35,9 @@ var (
 )
 
 func init() {
-	flag.PublicPort(Cmd, &conf.PublicServicePort)
-	flag.InternalPort(Cmd, &conf.InternalServicePort)
-	flag.MetricsPort(Cmd, &conf.MetricsPort)
+	flag.PublicAddr(Cmd, &conf.PublicServiceAddr)
+	flag.InternalAddr(Cmd, &conf.InternalServiceAddr)
+	flag.MetricsAddr(Cmd, &conf.MetricsServiceAddr)
 	Cmd.Flags().StringVar(&conf.DataDir, "data-dir", "./data/db", "Directory where to store data")
 	Cmd.Flags().StringVar(&conf.WalDir, "wal-dir", "./data/wal", "Directory for write-ahead-logs")
 	Cmd.Flags().DurationVar(&conf.WalRetentionTime, "wal-retention-time", 1*time.Hour, "Retention time for the entries in the write-ahead-log")

--- a/cmd/standalone/cmd.go
+++ b/cmd/standalone/cmd.go
@@ -35,8 +35,8 @@ var (
 )
 
 func init() {
-	flag.PublicPort(Cmd, &conf.PublicServicePort)
-	flag.MetricsPort(Cmd, &conf.MetricsPort)
+	flag.PublicAddr(Cmd, &conf.PublicServiceAddr)
+	flag.MetricsAddr(Cmd, &conf.MetricsServiceAddr)
 	Cmd.Flags().StringVarP(&conf.AdvertisedPublicAddress, "advertised-address", "a", "", "Advertised address")
 	Cmd.Flags().Uint32VarP(&conf.NumShards, "shards", "s", 1, "Number of shards")
 	Cmd.Flags().StringVar(&conf.DataDir, "data-dir", "./data/db", "Directory where to store data")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -15,7 +15,6 @@
 package controller
 
 import (
-	"fmt"
 	"github.com/rs/zerolog/log"
 	"go.uber.org/multierr"
 	"oxia/common/metrics"
@@ -23,9 +22,8 @@ import (
 )
 
 type Config struct {
-	BindHost            string
-	InternalServicePort int
-	MetricsPort         int
+	InternalServiceAddr string
+	MetricsServiceAddr  string
 }
 
 type Controller struct {
@@ -57,12 +55,12 @@ func New(config Config) (*Controller, error) {
 		return nil, err
 	}
 
-	s.rpc, err = NewControllerRpcServer(fmt.Sprintf("%s:%d", config.BindHost, config.InternalServicePort))
+	s.rpc, err = NewControllerRpcServer(config.InternalServiceAddr)
 	if err != nil {
 		return nil, err
 	}
 
-	s.metrics, err = metrics.Start(fmt.Sprintf("%s:%d", config.BindHost, config.MetricsPort))
+	s.metrics, err = metrics.Start(config.MetricsServiceAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -27,9 +27,8 @@ import (
 )
 
 type Config struct {
-	BindHost                 string
-	InternalServicePort      int
-	MetricsPort              int
+	InternalServiceAddr      string
+	MetricsServiceAddr       string
 	MetadataProviderImpl     MetadataProviderImpl
 	K8SMetadataNamespace     string
 	K8SMetadataConfigMapName string
@@ -65,8 +64,8 @@ var (
 
 func NewConfig() Config {
 	return Config{
-		InternalServicePort:  kubernetes.InternalPort.Port,
-		MetricsPort:          kubernetes.MetricsPort.Port,
+		InternalServiceAddr:  fmt.Sprintf("localhost:%d", kubernetes.InternalPort.Port),
+		MetricsServiceAddr:   fmt.Sprintf("localhost:%d", kubernetes.MetricsPort.Port),
 		MetadataProviderImpl: File,
 	}
 }
@@ -106,11 +105,11 @@ func New(config Config) (*Coordinator, error) {
 		return nil, err
 	}
 
-	if s.rpcServer, err = newRpcServer(fmt.Sprintf("%s:%d", config.BindHost, config.InternalServicePort)); err != nil {
+	if s.rpcServer, err = newRpcServer(config.InternalServiceAddr); err != nil {
 		return nil, err
 	}
 
-	if s.metrics, err = metrics.Start(fmt.Sprintf("%s:%d", config.BindHost, config.MetricsPort)); err != nil {
+	if s.metrics, err = metrics.Start(config.MetricsServiceAddr); err != nil {
 		return nil, err
 	}
 

--- a/coordinator/impl/coordinator_e2e_test.go
+++ b/coordinator/impl/coordinator_e2e_test.go
@@ -31,10 +31,9 @@ import (
 func newServer(t *testing.T) (s *server.Server, addr model.ServerAddress) {
 	var err error
 	s, err = server.New(server.Config{
-		BindHost:            "localhost",
-		PublicServicePort:   0,
-		InternalServicePort: 0,
-		MetricsPort:         -1, // Disable metrics to avoid conflict
+		PublicServiceAddr:   "localhost:0",
+		InternalServiceAddr: "localhost:0",
+		MetricsServiceAddr:  "", // Disable metrics to avoid conflict
 		DataDir:             t.TempDir(),
 		WalDir:              t.TempDir(),
 	})

--- a/maelstrom/main.go
+++ b/maelstrom/main.go
@@ -146,9 +146,9 @@ func main() {
 	} else {
 		// Any other node will be a storage node
 		_, err := server.NewWithGrpcProvider(server.Config{
-			MetricsPort: -1,
-			DataDir:     filepath.Join(dataDir, thisNode, "db"),
-			WalDir:      filepath.Join(dataDir, thisNode, "wal"),
+			MetricsServiceAddr: "",
+			DataDir:            filepath.Join(dataDir, thisNode, "db"),
+			WalDir:             filepath.Join(dataDir, thisNode, "wal"),
 		}, grpcProvider, replicationGrpcProvider)
 		if err != nil {
 			return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -24,10 +24,9 @@ import (
 
 func TestNewServer(t *testing.T) {
 	config := Config{
-		BindHost:            "localhost",
-		InternalServicePort: 0,
-		PublicServicePort:   0,
-		MetricsPort:         0,
+		InternalServiceAddr: "localhost:0",
+		PublicServiceAddr:   "localhost:0",
+		MetricsServiceAddr:  "localhost:0",
 	}
 
 	server, err := New(config)


### PR DESCRIPTION
Unify the way we pass bind and port args for different ports, to always take an address string, comprised of `bind-address:port`. 

