### PR TITLE
Handle client creation error in CLI

### DIFF
--- a/cmd/client/get/cmd.go
+++ b/cmd/client/get/cmd.go
@@ -54,7 +54,10 @@ var Cmd = &cobra.Command{
 }
 
 func exec(cmd *cobra.Command, args []string) error {
-	loop, _ := common.NewCommandLoop(cmd.OutOrStdout())
+	loop, err := common.NewCommandLoop(cmd.OutOrStdout())
+	if err != nil {
+		return err
+	}
 	defer func() {
 		loop.Complete()
 	}()

--- a/cmd/client/put/cmd.go
+++ b/cmd/client/put/cmd.go
@@ -64,7 +64,10 @@ var Cmd = &cobra.Command{
 }
 
 func exec(cmd *cobra.Command, args []string) error {
-	loop, _ := common.NewCommandLoop(cmd.OutOrStdout())
+	loop, err := common.NewCommandLoop(cmd.OutOrStdout())
+	if err != nil {
+		return err
+	}
 	defer func() {
 		loop.Complete()
 	}()

--- a/oxia/internal/shard_manager.go
+++ b/oxia/internal/shard_manager.go
@@ -64,7 +64,7 @@ func NewShardManager(shardStrategy ShardStrategy, clientPool common.ClientPool, 
 	sm.ctx, sm.cancel = context.WithCancel(context.Background())
 
 	if err := sm.start(); err != nil {
-		return nil, errors.Wrap(err, "oxia: failed retrieve the initial list of shard assignments")
+		return nil, errors.Wrap(err, "oxia: failed to retrieve the initial list of shard assignments")
 	}
 
 	return sm, nil


### PR DESCRIPTION
Without this early return, the client panics with the output
```
goroutine 1 [running]:
oxia/cmd/client/common.(*CommandLoop).Complete(...)
	/src/oxia/cmd/client/common/loop.go:78
oxia/cmd/client/put.exec.func1()
	/src/oxia/cmd/client/put/cmd.go:69 +0x24
panic({0x1a093a0, 0x2d31740})
	/usr/local/go/src/runtime/panic.go:884 +0x20c
oxia/cmd/client/common.(*CommandLoop).Add(0x1b7ae60?, {0x1f823c0?, 0x40004430e0?})
	/src/oxia/cmd/client/common/loop.go:74 +0x28
oxia/cmd/client/put._exec({{0x4000404720, 0x1, 0x1}, {0x4000404740, 0x1, 0x1}, {0x2e0a000, 0x0, 0x0}, 0x0}, ...)
	/src/oxia/cmd/client/put/cmd.go:91 +0x28c
oxia/cmd/client/put.exec(0x2d439e0?, {0x40003b15c0?, 0x6?, 0x6?})
	/src/oxia/cmd/client/put/cmd.go:71 +0x148
github.com/spf13/cobra.(*Command).execute(0x2d439e0, {0x40003b1560, 0x6, 0x6})
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x5e0
github.com/spf13/cobra.(*Command).ExecuteC(0x2d428a0)
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x368
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
main.main.func1()
```