### PR TITLE
Finish streaming gracefully on EOF

### DIFF
--- a/server/follower_cursor.go
+++ b/server/follower_cursor.go
@@ -265,7 +265,7 @@ func (fc *followerCursor) sendSnapshot() error {
 			Msg("Sending snapshot chunk")
 
 		if err := stream.Send(&proto.SnapshotChunk{
-			Term:    fc.term,
+			Term:       fc.term,
 			Name:       chunk.Name(),
 			ChunkIndex: chunk.Index(),
 			ChunkCount: chunk.TotalCount(),
@@ -376,6 +376,10 @@ func (fc *followerCursor) streamEntries() error {
 func (fc *followerCursor) receiveAcks(cancel context.CancelFunc, stream proto.OxiaLogReplication_ReplicateClient) {
 	for {
 		res, err := stream.Recv()
+		if err == io.EOF {
+			fc.log.Info().Msg("Ack stream finished")
+			return
+		}
 		if err != nil {
 			if status.Code(err) != codes.Canceled && status.Code(err) != codes.Unavailable {
 				fc.log.Warn().Err(err).


### PR DESCRIPTION
Follower cursor was not respecting the completion of the ack stream:

```
{"level":"warn","component":"follower-cursor","shard":0,"term":1071,"follower":"oxia-2.oxia.oxia.svc.cluster.local:6649","error":"EOF","time":"2023-02-03T08:54:16.726930279Z","message":"Error while receiving acks"}
```