### PR TITLE
Fix session cleanup

### DIFF
--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -404,10 +404,12 @@ func (d *db) applyDelete(batch WriteBatch, notifications *notifications, delReq 
 }
 
 func (d *db) applyDeleteRange(batch WriteBatch, notifications *notifications, delReq *proto.DeleteRangeRequest, updateOperationCallback UpdateOperationCallback) (*proto.DeleteRangeResponse, error) {
-	if notifications != nil {
+	if notifications != nil || updateOperationCallback != NoOpCallback {
 		it := batch.KeyRangeScan(delReq.StartInclusive, delReq.EndExclusive)
 		for it.Next() {
-			notifications.Deleted(it.Key())
+			if notifications != nil {
+				notifications.Deleted(it.Key())
+			}
 			err := updateOperationCallback.OnDelete(batch, it.Key())
 			if err != nil {
 				return nil,

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -422,7 +422,7 @@ func (b *PebbleBatch) Get(key string) ([]byte, io.Closer, error) {
 	value, closer, err := b.b.Get([]byte(key))
 	if errors.Is(err, pebble.ErrNotFound) {
 		err = ErrorKeyNotFound
-	} else {
+	} else if err != nil {
 		b.p.readErrors.Inc()
 	}
 	return value, closer, err


### PR DESCRIPTION
* Call `updateOperationCallback` in `applyDeleteRange` even if there is no `notifications` object
* When deleting the shadow node, don't throw an error if the original node is not found anymore
* Don't count successful Get operations as `readError`