### PR TITLE
Enable publishNotReadyAddresses on server service

### DIFF
--- a/deploy/charts/oxia-cluster/templates/server-service.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-service.yaml
@@ -21,6 +21,7 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     {{- range $key, $value := .Values.server.ports }}
     - name: {{ $key }}

--- a/kubernetes/resources.go
+++ b/kubernetes/resources.go
@@ -121,17 +121,18 @@ func roleBinding(cluster v1alpha1.OxiaCluster) *rbacV1.RoleBinding {
 
 func service(component Component, cluster v1alpha1.OxiaCluster, ports []NamedPort) *coreV1.Service {
 	var clusterIp string
+	var publishNotReadyAddresses bool
 	if component == Server {
 		clusterIp = coreV1.ClusterIPNone
-	} else {
-		clusterIp = ""
+		publishNotReadyAddresses = true
 	}
 	service := &coreV1.Service{
 		ObjectMeta: objectMeta(component, cluster.Name),
 		Spec: coreV1.ServiceSpec{
-			Selector:  selectorLabels(component, cluster.Name),
-			Ports:     transform(ports, servicePort),
-			ClusterIP: clusterIp,
+			Selector:                 selectorLabels(component, cluster.Name),
+			Ports:                    transform(ports, servicePort),
+			ClusterIP:                clusterIp,
+			PublishNotReadyAddresses: publishNotReadyAddresses,
 		},
 	}
 	service.Labels["oxia_cluster"] = cluster.Name


### PR DESCRIPTION
This means server addresses will be propagated to DNS and be discoverable before they have passed their readiness probe. This will allow the coordinator to connect and determine health before they are 'ready'.