### PR TITLE
Immediately trigger error for non-recoverable error in client creation

### DIFF
--- a/common/wait_group.go
+++ b/common/wait_group.go
@@ -62,7 +62,10 @@ func (g *waitGroup) Wait(ctx context.Context) error {
 }
 
 func (g *waitGroup) Done() {
-	g.responses <- nil
+	select {
+	case g.responses <- nil:
+	default:
+	}
 }
 
 func (g *waitGroup) Fail(err error) {

--- a/coordinator/impl/coordinator_e2e_test.go
+++ b/coordinator/impl/coordinator_e2e_test.go
@@ -293,6 +293,10 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	assert.NoError(t, err)
 	defer clientNs1.Close()
 
+	clientNs3, err := oxia.NewSyncClient(sa1.Public, oxia.WithNamespace("my-ns-does-not-exist"))
+	assert.ErrorIs(t, err, common.ErrorNamespaceNotFound)
+	assert.Nil(t, clientNs3)
+
 	ctx := context.Background()
 
 	// Write in default ns

--- a/server/assignment_dispatcher.go
+++ b/server/assignment_dispatcher.go
@@ -73,6 +73,7 @@ func (s *shardAssignmentDispatcher) RegisterForUpdates(req *proto.ShardAssignmen
 	}
 
 	if _, ok := s.assignments.Namespaces[namespace]; !ok {
+		s.Unlock()
 		return common.ErrorNamespaceNotFound
 	}
 


### PR DESCRIPTION
A non-recoverable error, such as trying to use a namespace that does not exist, should trigger an immediate error in the client creation, instead of having the client do multiple retries.