### PR TITLE
Revert "Set metadata.ownerReferences on cluster resources (#309)"

### DIFF
--- a/kubernetes/cluster_test.go
+++ b/kubernetes/cluster_test.go
@@ -68,15 +68,15 @@ func TestCluster(t *testing.T) {
 	err := client.Apply(cluster)
 	assert.NoError(t, err)
 
-	assertClusterResources(t, &cluster, _kubernetes, _monitoring, cluster.Namespace, 1)
+	assertClusterResources(t, _kubernetes, _monitoring, cluster.Namespace, 1)
 
 	err = client.Delete(cluster.Namespace, cluster.Name, true)
 	assert.NoError(t, err)
 
-	assertClusterResources(t, &cluster, _kubernetes, _monitoring, cluster.Namespace, 0)
+	assertClusterResources(t, _kubernetes, _monitoring, cluster.Namespace, 0)
 }
 
-func assertClusterResources(t *testing.T, cluster *v1alpha1.OxiaCluster, _kubernetes kubernetes.Interface, _monitoring monitoring.Interface, namespace string, length int) {
+func assertClusterResources(t *testing.T, _kubernetes kubernetes.Interface, _monitoring monitoring.Interface, namespace string, length int) {
 	serviceAccounts, err := _kubernetes.CoreV1().ServiceAccounts(namespace).
 		List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
@@ -96,35 +96,19 @@ func assertClusterResources(t *testing.T, cluster *v1alpha1.OxiaCluster, _kubern
 		List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Len(t, deployments.Items, length)
-	for _, deployment := range deployments.Items {
-		assert.Equal(t, cluster.Name, deployment.OwnerReferences[0].Name)
-		assert.Equal(t, true, *deployment.OwnerReferences[0].Controller)
-	}
 
 	statefulsets, err := _kubernetes.AppsV1().StatefulSets(namespace).
 		List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Len(t, statefulsets.Items, length)
-	for _, statefulset := range statefulsets.Items {
-		assert.Equal(t, cluster.Name, statefulset.OwnerReferences[0].Name)
-		assert.Equal(t, true, *statefulset.OwnerReferences[0].Controller)
-	}
 
 	services, err := _kubernetes.CoreV1().Services(namespace).
 		List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Len(t, services.Items, length*2)
-	for _, service := range services.Items {
-		assert.Equal(t, cluster.Name, service.OwnerReferences[0].Name)
-		assert.Equal(t, true, *service.OwnerReferences[0].Controller)
-	}
 
 	serviceMonitors, err := _monitoring.MonitoringV1().ServiceMonitors(namespace).
 		List(context.Background(), v1.ListOptions{})
 	assert.NoError(t, err)
 	assert.Len(t, serviceMonitors.Items, length*2)
-	for _, serviceMonitor := range serviceMonitors.Items {
-		assert.Equal(t, cluster.Name, serviceMonitor.OwnerReferences[0].Name)
-		assert.Equal(t, true, *serviceMonitor.OwnerReferences[0].Controller)
-	}
 }


### PR DESCRIPTION
This reverts commit 54184a4f0bcc862933307586adbf4e2e825ddd03.

Update event has different data structure.

```
{"level":"info","cluster-spec":{"metadata":{"name":"my-oxia-cluster","namespace":"chaos-platform","uid":"b486fa87-c9a4-48fa-9ba5-3f184d7bdad5","resourceVersion":"213117586","generation":1,"creationTimestamp":"2023-04-21T15:26:34Z","labels":{"app.kubernetes.io/created-by":"oxia-operator","app.kubernetes.io/instance":"oxiacluster-sample","app.kubernetes.io/managed-by":"kustomize","app.kubernetes.io/name":"oxiacluster","app.kubernetes.io/part-of":"oxia-operator"},"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"oxia.streamnative.io/v1alpha1\",\"kind\":\"OxiaCluster\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/created-by\":\"oxia-operator\",\"app.kubernetes.io/instance\":\"oxiacluster-sample\",\"app.kubernetes.io/managed-by\":\"kustomize\",\"app.kubernetes.io/name\":\"oxiacluster\",\"app.kubernetes.io/part-of\":\"oxia-operator\"},\"name\":\"my-oxia-cluster\",\"namespace\":\"chaos-platform\"},\"spec\":{\"coordinator\":{\"cpu\":\"100m\",\"memory\":\"128Mi\"},\"image\":{\"pullPolicy\":\"Always\",\"repository\":\"streamnative/oxia\",\"tag\":\"main\"},\"monitoringEnabled\":true,\"namespaces\":[{\"initialShardCount\":3,\"name\":\"default\",\"replicationFactor\":3}],\"pprofEnabled\":false,\"server\":{\"cpu\":1,\"memory\":\"1Gi\",\"replicas\":3,\"storage\":\"8Gi\"}}}\n"},"managedFields":[{"manager":"kubectl-client-side-apply","operation":"Update","apiVersion":"oxia.streamnative.io/v1alpha1","time":"2023-04-21T15:26:34Z","fieldsType":"FieldsV1","fieldsV1":{"f:metadata":{"f:annotations":{".":{},"f:kubectl.kubernetes.io/last-applied-configuration":{}},"f:labels":{".":{},"f:app.kubernetes.io/created-by":{},"f:app.kubernetes.io/instance":{},"f:app.kubernetes.io/managed-by":{},"f:app.kubernetes.io/name":{},"f:app.kubernetes.io/part-of":{}}},"f:spec":{".":{},"f:coordinator":{".":{},"f:cpu":{},"f:memory":{}},"f:image":{".":{},"f:pullPolicy":{},"f:repository":{},"f:tag":{}},"f:monitoringEnabled":{},"f:namespaces":{},"f:pprofEnabled":{},"f:server":{".":{},"f:cpu":{},"f:memory":{},"f:replicas":{},"f:storage":{}}}}}]},"spec":{"namespaces":[{"name":"default","initialShardCount":3,"replicationFactor":3}],"coordinator":{"cpu":"100m","memory":"128Mi"},"server":{"replicas":3,"cpu":"1","memory":"1Gi","storage":"8Gi"},"image":{"repository":"streamnative/oxia","tag":"main","pullPolicy":"Always"},"pprofEnabled":false,"monitoringEnabled":true},"status":{}},"time":"2023-04-21T15:26:34.933426007Z","message":"Applying cluster spec"}
```