### PR TITLE
Add `oxia_cluster` label to all the pods

### DIFF
--- a/deploy/charts/oxia-cluster/templates/coordinator-deployment.yaml
+++ b/deploy/charts/oxia-cluster/templates/coordinator-deployment.yaml
@@ -29,6 +29,7 @@ spec:
         prometheus.io/port: "{{ .Values.coordinator.ports.metrics }}"
         prometheus.io/scrape: "{{ .Values.monitoringEnabled }}"
       labels:
+        oxia_cluster: {{ .Release.Name }}
         {{- include "oxia-cluster.coordinator.labels" . | nindent 8 }}
       name: {{ .Release.Name }}-coordinator
     spec:

--- a/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
@@ -31,6 +31,7 @@ spec:
         prometheus.io/port: "{{ .Values.server.ports.metrics }}"
         prometheus.io/scrape: "{{ .Values.monitoringEnabled }}"
       labels:
+        oxia_cluster: {{ .Release.Name }}
         {{- include "oxia-cluster.server.labels" . | nindent 8 }}
       name: {{ .Release.Name }}
     spec:

--- a/kubernetes/resources.go
+++ b/kubernetes/resources.go
@@ -66,6 +66,7 @@ func selectorLabels(component Component, name string) map[string]string {
 		"app.kubernetes.io/name":      "oxia-cluster",
 		"app.kubernetes.io/Component": string(component),
 		"app.kubernetes.io/instance":  _resourceName,
+		"oxia_cluster":                name,
 	}
 }
 func additionalLabels(version string) map[string]string {


### PR DESCRIPTION
Depending on the Prometheus/VictoriaMetrics scraper, the labels attached to the "service" are attached to the metrics scraped from the pods. It's safer to also have the labels on the pods, so that they will be present on the metrics