### PR TITLE
Added readiness support in server health-check

### DIFF
--- a/common/container/container.go
+++ b/common/container/container.go
@@ -26,6 +26,8 @@ import (
 
 const (
 	maxGrpcFrameSize = 256 * 1024 * 1024
+
+	ReadinessProbeService = "oxia-readiness"
 )
 
 type GrpcServer interface {

--- a/deploy/charts/oxia-cluster/templates/_helpers.tpl
+++ b/deploy/charts/oxia-cluster/templates/_helpers.tpl
@@ -58,3 +58,14 @@ exec:
 initialDelaySeconds: 10
 timeoutSeconds: 10
 {{- end }}
+
+
+{{/*
+Probe
+*/}}
+{{- define "oxia-cluster.readiness-probe" -}}
+exec:
+  command: ["oxia", "health", "--port={{ . }}", "--service=oxia-readiness"]
+initialDelaySeconds: 10
+timeoutSeconds: 10
+{{- end }}

--- a/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
@@ -64,7 +64,7 @@ spec:
           livenessProbe:
             {{- include "oxia-cluster.probe" .Values.server.ports.internal | nindent 12 }}
           readinessProbe:
-            {{- include "oxia-cluster.probe" .Values.server.ports.internal | nindent 12 }}
+            {{- include "oxia-cluster.readiness-probe" .Values.server.ports.internal | nindent 12 }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/server/internal_rpc_server.go
+++ b/server/internal_rpc_server.go
@@ -43,11 +43,12 @@ type internalRpcServer struct {
 	log                  zerolog.Logger
 }
 
-func newInternalRpcServer(grpcProvider container.GrpcProvider, bindAddress string, shardsDirector ShardsDirector, assignmentDispatcher ShardAssignmentsDispatcher) (*internalRpcServer, error) {
+func newInternalRpcServer(grpcProvider container.GrpcProvider, bindAddress string, shardsDirector ShardsDirector,
+	assignmentDispatcher ShardAssignmentsDispatcher, healthServer *health.Server) (*internalRpcServer, error) {
 	server := &internalRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,
-		healthServer:         health.NewServer(),
+		healthServer:         healthServer,
 		log: log.With().
 			Str("component", "internal-rpc-server").
 			Logger(),
@@ -67,7 +68,6 @@ func newInternalRpcServer(grpcProvider container.GrpcProvider, bindAddress strin
 }
 
 func (s *internalRpcServer) Close() error {
-	s.healthServer.Shutdown()
 	return s.grpcServer.Close()
 }
 
@@ -82,6 +82,7 @@ func (s *internalRpcServer) PushShardAssignments(srv proto.OxiaCoordination_Push
 			Str("peer", common.GetPeer(srv.Context())).
 			Msg("Failed to provide shards assignments updates")
 	}
+
 	return err
 }
 

--- a/server/internal_rpc_server_test.go
+++ b/server/internal_rpc_server_test.go
@@ -20,13 +20,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"oxia/common/container"
 	"testing"
 )
 
 func TestInternalHealthCheck(t *testing.T) {
-	server, err := newInternalRpcServer(container.Default, "localhost:0", nil, NewShardAssignmentDispatcher())
+	healthServer := health.NewServer()
+	server, err := newInternalRpcServer(container.Default, "localhost:0", nil,
+		NewShardAssignmentDispatcher(healthServer), healthServer)
 	assert.NoError(t, err)
 
 	target := fmt.Sprintf("localhost:%d", server.grpcServer.Port())


### PR DESCRIPTION
The oxia server should not considered to be "ready" to be put in the load-balancer rotation for service discovery until it has received the shards mapping from the coordinator. This can happen 10s of seconds after restarting a storage pod.

Added gRPC service `oxia-readiness` that can be probed from K8S readiness probe, so that we don't get a client to ask for service discovery to a pod that does not have that information yet.