### PR TITLE
Use `-svc` internal service for readiness

### DIFF
--- a/deploy/charts/oxia-cluster/templates/coordinator-configmap.yaml
+++ b/deploy/charts/oxia-cluster/templates/coordinator-configmap.yaml
@@ -27,6 +27,6 @@ data:
     servers:
       {{- $vars := dict "name" .Release.Name "namespace" .Release.Namespace "public" .Values.server.ports.public "internal" .Values.server.ports.internal }}
       {{- range until (int .Values.server.replicas) }}
-      - public: {{ $vars.name }}-{{ . }}.{{ $vars.name }}.{{ $vars.namespace }}.svc.cluster.local:{{ $vars.public }}
-        internal: {{ $vars.name }}-{{ . }}.{{ $vars.name }}:{{ $vars.internal }}
+      - public: {{ $vars.name }}-{{ . }}.{{ $vars.name }}-svc.{{ $vars.namespace }}.svc.cluster.local:{{ $vars.public }}
+        internal: {{ $vars.name }}-{{ . }}.{{ $vars.name }}-svc:{{ $vars.internal }}
       {{- end }}

--- a/deploy/charts/oxia-cluster/templates/server-service-public.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-service-public.yaml
@@ -18,10 +18,8 @@ metadata:
   labels:
     oxia_cluster: {{ .Release.Name }}
     {{- include "oxia-cluster.server.labels" . | nindent 4 }}
-  name: {{ .Release.Name }}-svc
+  name: {{ .Release.Name }}
 spec:
-  clusterIP: None
-  publishNotReadyAddresses: true
   ports:
     {{- range $key, $value := .Values.server.ports }}
     - name: {{ $key }}

--- a/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
@@ -23,7 +23,7 @@ spec:
   selector:
     matchLabels:
       {{- include "oxia-cluster.server.selectorLabels" . | nindent 6 }}
-  serviceName: {{ .Release.Name }}
+  serviceName: {{ .Release.Name }}-svc
   podManagementPolicy: Parallel
   template:
     metadata:


### PR DESCRIPTION
Oxia servers right now use the K8S Service for 2 different purposes: 

 1. Expose a single URL for an Oxia cluster service discovery
 2. Provide DNS names for individual pods, so that either other oxia pods can contact or clients can connect directly.

for (1) we want that only the pods that are "ready" (meaning they have the current shards mapping) are exposed in the service rotation.

for (2), we need the pods to have a DNS name available immediately when they start, so that the Oxia coordinator can connect to them (through their DNS name), send the shards mapping and make them "ready". For this we can use the K8S `publishNotReadyAddresses: true` property on the service configuration.

The 2 goals are in contrast between each others and there seems to be no way to achieve both of them with a single k8s service.


### Modifications

Use 2 K8S services attached to the same StatefulSet.

 * `oxia` -> Service used to expose the service URL, uses `publishNotReadyAddresses: false`
 * `oxia-svc` -> Headless service, default service for the StatefulSet, uses provides pods names like: `oxia-0.oxia-svc`. Uses `publishNotReadyAddresses: true` to give DNS names immediately to the pods.

### Results 

When doing rolling restarts, the clients will not attempt anymore to connect for service discovery to a pod that does not have the info, causing a retry with exponential backoff.

Instead, the max latency is only dictated by the leader election time -> ~500ms

