### PR TITLE
Abort BecomeLeader and Write requests on timeout

### DIFF
--- a/server/follower_cursor.go
+++ b/server/follower_cursor.go
@@ -348,7 +348,9 @@ func (fc *followerCursor) streamEntries() error {
 		if !reader.HasNext() {
 			// We have reached the head of the wal
 			// Wait for more entries to be written
-			fc.ackTracker.WaitForHeadOffset(currentOffset + 1)
+			if err = fc.ackTracker.WaitForHeadOffset(ctx, currentOffset+1); err != nil {
+				return err
+			}
 
 			continue
 		}

--- a/server/internal_rpc_server.go
+++ b/server/internal_rpc_server.go
@@ -142,7 +142,7 @@ func (s *internalRpcServer) BecomeLeader(c context.Context, req *proto.BecomeLea
 		log.Warn().Err(err).Msg("BecomeLeader failed: could not get leader controller")
 		return nil, err
 	} else {
-		res, err2 := leader.BecomeLeader(req)
+		res, err2 := leader.BecomeLeader(c, req)
 		if err2 != nil {
 			log.Warn().Err(err2).Msg("BecomeLeader failed")
 		}

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -40,7 +40,7 @@ type GetResult struct {
 type LeaderController interface {
 	io.Closer
 
-	Write(write *proto.WriteRequest) (*proto.WriteResponse, error)
+	Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error)
 	Read(ctx context.Context, request *proto.ReadRequest) <-chan GetResult
 	List(ctx context.Context, request *proto.ListRequest) (<-chan string, error)
 	ListSliceNoMutex(ctx context.Context, request *proto.ListRequest) ([]string, error)
@@ -49,7 +49,7 @@ type LeaderController interface {
 	NewTerm(req *proto.NewTermRequest) (*proto.NewTermResponse, error)
 
 	// BecomeLeader Handles BecomeLeaderRequest from coordinator and prepares to be leader for the shard
-	BecomeLeader(*proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error)
+	BecomeLeader(ctx context.Context, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error)
 
 	AddFollower(request *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error)
 
@@ -300,7 +300,7 @@ func (lc *leaderController) NewTerm(req *proto.NewTermRequest) (*proto.NewTermRe
 //     the new leader will be informed of these followers, and it is
 //     possible that their head entry id is higher than the leader and
 //     therefore need truncating.
-func (lc *leaderController) BecomeLeader(req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
+func (lc *leaderController) BecomeLeader(ctx context.Context, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
 	lc.Lock()
 	defer lc.Unlock()
 
@@ -345,7 +345,7 @@ func (lc *leaderController) BecomeLeader(req *proto.BecomeLeaderRequest) (*proto
 	// committed in the quorum, to avoid missing any entries in the DB
 	// by the moment we make the leader controller accepting new write/read
 	// requests
-	if _, err = lc.quorumAckTracker.WaitForCommitOffset(lc.leaderElectionHeadEntryId.Offset, nil); err != nil {
+	if _, err = lc.quorumAckTracker.WaitForCommitOffset(ctx, lc.leaderElectionHeadEntryId.Offset, nil); err != nil {
 		return nil, err
 	}
 
@@ -653,14 +653,14 @@ func (lc *leaderController) ListSliceNoMutex(ctx context.Context, request *proto
 // A client writes a value from Values to a leader node
 // if that value has not previously been written. The leader adds
 // the entry to its log, updates its head offset.
-func (lc *leaderController) Write(request *proto.WriteRequest) (*proto.WriteResponse, error) {
-	_, resp, err := lc.write(func(_ int64) *proto.WriteRequest {
+func (lc *leaderController) Write(ctx context.Context, request *proto.WriteRequest) (*proto.WriteResponse, error) {
+	_, resp, err := lc.write(ctx, func(_ int64) *proto.WriteRequest {
 		return request
 	}, false)
 	return resp, err
 }
 
-func (lc *leaderController) write(request func(int64) *proto.WriteRequest, flush bool) (int64, *proto.WriteResponse, error) {
+func (lc *leaderController) write(ctx context.Context, request func(int64) *proto.WriteRequest, flush bool) (int64, *proto.WriteResponse, error) {
 	timer := lc.writeLatencyHisto.Timer()
 	defer timer.Done()
 
@@ -672,7 +672,7 @@ func (lc *leaderController) write(request func(int64) *proto.WriteRequest, flush
 		return wal.InvalidOffset, nil, err
 	}
 
-	resp, err := lc.quorumAckTracker.WaitForCommitOffset(newOffset, func() (*proto.WriteResponse, error) {
+	resp, err := lc.quorumAckTracker.WaitForCommitOffset(ctx, newOffset, func() (*proto.WriteResponse, error) {
 		return lc.db.ProcessWrite(actualRequest, newOffset, timestamp, SessionUpdateOperationCallback)
 	})
 	return newOffset, resp, err

--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -52,7 +52,7 @@ func TestLeaderController_NotInitialized(t *testing.T) {
 	assert.EqualValues(t, wal.InvalidTerm, lc.Term())
 	assert.Equal(t, proto.ServingStatus_NOT_MEMBER, lc.Status())
 
-	res, err := lc.Write(&proto.WriteRequest{
+	res, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "a",
@@ -98,7 +98,7 @@ func TestLeaderController_Closed(t *testing.T) {
 	assert.Nil(t, res)
 	assert.Equal(t, common.CodeAlreadyClosed, status.Code(err))
 
-	res2, err := lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	res2, err := lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:      shard,
 		Term:         2,
 		FollowerMaps: map[string]*proto.EntryId{},
@@ -123,7 +123,7 @@ func TestLeaderController_BecomeLeader_NoFencing(t *testing.T) {
 
 	assert.EqualValues(t, wal.InvalidTerm, lc.Term())
 	assert.Equal(t, proto.ServingStatus_NOT_MEMBER, lc.Status())
-	resp, err := lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	resp, err := lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
@@ -157,7 +157,7 @@ func TestLeaderController_BecomeLeader_RF1(t *testing.T) {
 	assert.NoError(t, err)
 	AssertProtoEqual(t, InvalidEntryId, fr.HeadEntryId)
 
-	_, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
@@ -169,7 +169,7 @@ func TestLeaderController_BecomeLeader_RF1(t *testing.T) {
 	assert.Equal(t, proto.ServingStatus_LEADER, lc.Status())
 
 	/// Write entry
-	res, err := lc.Write(&proto.WriteRequest{
+	res, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "a",
@@ -206,7 +206,7 @@ func TestLeaderController_BecomeLeader_RF1(t *testing.T) {
 
 	// Should not accept anymore writes & reads
 
-	res3, err := lc.Write(&proto.WriteRequest{
+	res3, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "a",
@@ -251,7 +251,7 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, InvalidEntryId, fr.HeadEntryId)
 
-	_, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 2,
@@ -273,7 +273,7 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 	}()
 
 	/// Write entry
-	res, err := lc.Write(&proto.WriteRequest{
+	res, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "a",
@@ -310,7 +310,7 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 
 	// Should not accept anymore writes & reads
 
-	res3, err := lc.Write(&proto.WriteRequest{
+	res3, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "a",
@@ -450,7 +450,7 @@ func TestLeaderController_BecomeLeaderTerm(t *testing.T) {
 	assert.Equal(t, proto.ServingStatus_FENCED, lc.Status())
 
 	// Smaller term will fail
-	resp, err := lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	resp, err := lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              4,
 		ReplicationFactor: 1,
@@ -460,7 +460,7 @@ func TestLeaderController_BecomeLeaderTerm(t *testing.T) {
 	assert.Equal(t, common.CodeInvalidTerm, status.Code(err))
 
 	// Higher term will fail
-	resp, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	resp, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              6,
 		ReplicationFactor: 1,
@@ -470,7 +470,7 @@ func TestLeaderController_BecomeLeaderTerm(t *testing.T) {
 	assert.Equal(t, common.CodeInvalidTerm, status.Code(err))
 
 	// Same term will succeed
-	_, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              5,
 		ReplicationFactor: 1,
@@ -502,7 +502,7 @@ func TestLeaderController_AddFollower(t *testing.T) {
 	assert.EqualValues(t, 5, lc.Term())
 	assert.Equal(t, proto.ServingStatus_FENCED, lc.Status())
 
-	_, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              5,
 		ReplicationFactor: 3,
@@ -597,7 +597,7 @@ func TestLeaderController_AddFollower_Truncate(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              6,
 		ReplicationFactor: 3,
@@ -621,7 +621,7 @@ func TestLeaderController_AddFollower_Truncate(t *testing.T) {
 
 	/// Write entries
 	for i := 10; i < 20; i++ {
-		res, err := lc.Write(&proto.WriteRequest{
+		res, err := lc.Write(context.Background(), &proto.WriteRequest{
 			ShardId: &shard,
 			Puts: []*proto.PutRequest{{
 				Key:   "my-key",
@@ -677,7 +677,7 @@ func TestLeaderController_AddFollowerCheckTerm(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	_, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              5,
 		ReplicationFactor: 3,
@@ -760,7 +760,7 @@ func TestLeaderController_EntryVisibilityAfterBecomingLeader(t *testing.T) {
 		}
 	}()
 
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 2,
@@ -794,7 +794,7 @@ func TestLeaderController_Notifications(t *testing.T) {
 
 	lc, _ := NewLeaderController(Config{}, common.DefaultNamespace, shard, newMockRpcClient(), walFactory, kvFactory)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 1})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
@@ -813,7 +813,7 @@ func TestLeaderController_Notifications(t *testing.T) {
 	}()
 
 	/// Write entry
-	_, _ = lc.Write(&proto.WriteRequest{
+	_, _ = lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "a",
@@ -860,7 +860,7 @@ func TestLeaderController_NotificationsCloseLeader(t *testing.T) {
 
 	lc, _ := NewLeaderController(Config{}, common.DefaultNamespace, shard, newMockRpcClient(), walFactory, kvFactory)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 1})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
@@ -909,14 +909,14 @@ func TestLeaderController_List(t *testing.T) {
 
 	lc, _ := NewLeaderController(Config{}, common.DefaultNamespace, shard, newMockRpcClient(), walFactory, kvFactory)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 1})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
 		FollowerMaps:      nil,
 	})
 
-	_, err := lc.Write(&proto.WriteRequest{
+	_, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{
 			{Key: "/a", Value: []byte{0}},
@@ -952,14 +952,14 @@ func TestLeaderController_DeleteShard(t *testing.T) {
 
 	lc, _ := NewLeaderController(Config{}, common.DefaultNamespace, shard, newMockRpcClient(), walFactory, kvFactory)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 1})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
 		FollowerMaps:      nil,
 	})
 
-	_, err := lc.Write(&proto.WriteRequest{
+	_, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts:    []*proto.PutRequest{{Key: "k1", Value: []byte("hello")}},
 	})
@@ -976,7 +976,7 @@ func TestLeaderController_DeleteShard(t *testing.T) {
 
 	lc, _ = NewLeaderController(Config{}, common.DefaultNamespace, shard, newMockRpcClient(), walFactory, kvFactory)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 2})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              2,
 		ReplicationFactor: 1,
@@ -1005,14 +1005,14 @@ func TestLeaderController_DeleteShard_WrongTerm(t *testing.T) {
 
 	lc, _ := NewLeaderController(Config{}, common.DefaultNamespace, shard, newMockRpcClient(), walFactory, kvFactory)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 1})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
 		FollowerMaps:      nil,
 	})
 
-	_, err := lc.Write(&proto.WriteRequest{
+	_, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts:    []*proto.PutRequest{{Key: "k1", Value: []byte("hello")}},
 	})
@@ -1037,7 +1037,7 @@ func TestLeaderController_GetStatus(t *testing.T) {
 
 	lc, _ := NewLeaderController(Config{}, common.DefaultNamespace, shard, newMockRpcClient(), walFactory, kvFactory)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 2})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              2,
 		ReplicationFactor: 1,
@@ -1045,13 +1045,13 @@ func TestLeaderController_GetStatus(t *testing.T) {
 	})
 
 	/// Write entry
-	_, _ = lc.Write(&proto.WriteRequest{
+	_, _ = lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "a",
 			Value: []byte("value-a")}},
 	})
-	_, _ = lc.Write(&proto.WriteRequest{
+	_, _ = lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts: []*proto.PutRequest{{
 			Key:   "b",

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -86,7 +86,7 @@ func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) 
 		return nil, err
 	}
 
-	wr, err := lc.Write(write)
+	wr, err := lc.Write(ctx, write)
 	if err != nil {
 		s.log.Warn().Err(err).
 			Msg("Failed to perform write operation")

--- a/server/quorum_ack_tracker_test.go
+++ b/server/quorum_ack_tracker_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"github.com/stretchr/testify/assert"
 	"oxia/proto"
 	"oxia/server/wal"
@@ -148,7 +149,7 @@ func TestQuorumAckTracker_WaitForHeadOffset(t *testing.T) {
 	ch := make(chan bool)
 
 	go func() {
-		at.WaitForHeadOffset(4)
+		assert.NoError(t, at.WaitForHeadOffset(context.Background(), 4))
 		ch <- true
 	}()
 
@@ -186,7 +187,7 @@ func TestQuorumAckTracker_WaitForCommitOffset(t *testing.T) {
 	ch := make(chan error)
 
 	go func() {
-		_, err := at.WaitForCommitOffset(2, func() (*proto.WriteResponse, error) {
+		_, err := at.WaitForCommitOffset(context.Background(), 2, func() (*proto.WriteResponse, error) {
 			return nil, nil
 		})
 		ch <- err

--- a/server/session.go
+++ b/server/session.go
@@ -92,7 +92,7 @@ func (s *session) delete() error {
 			})
 		}
 	}
-	_, err = s.sm.leaderController.Write(&proto.WriteRequest{
+	_, err = s.sm.leaderController.Write(s.ctx, &proto.WriteRequest{
 		ShardId: &s.shardId,
 		Puts:    nil,
 		Deletes: deletes,

--- a/server/session_manager_test.go
+++ b/server/session_manager_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"github.com/stretchr/testify/assert"
 	pb "google.golang.org/protobuf/proto"
@@ -298,7 +299,7 @@ func TestSessionManager(t *testing.T) {
 	assert.NotNil(t, meta)
 	keepAlive(t, sManager, sessionId, err, 30*time.Millisecond, 6)
 
-	_, err = lc.Write(&proto.WriteRequest{
+	_, err = lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shardId,
 		Puts: []*proto.PutRequest{{
 			Key:       "a/b",
@@ -367,7 +368,7 @@ func createSessionManager(t *testing.T) (*sessionManager, *leaderController) {
 	assert.NoError(t, err)
 	_, err = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 1})
 	assert.NoError(t, err)
-	_, err = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, err = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,

--- a/server/shards_director_test.go
+++ b/server/shards_director_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"github.com/stretchr/testify/assert"
 	"oxia/common"
 	"oxia/proto"
@@ -32,14 +33,14 @@ func TestShardsDirector_DeleteShardLeader(t *testing.T) {
 
 	lc, _ := sd.GetOrCreateLeader(common.DefaultNamespace, shard)
 	_, _ = lc.NewTerm(&proto.NewTermRequest{ShardId: shard, Term: 1})
-	_, _ = lc.BecomeLeader(&proto.BecomeLeaderRequest{
+	_, _ = lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 		ShardId:           shard,
 		Term:              1,
 		ReplicationFactor: 1,
 		FollowerMaps:      nil,
 	})
 
-	_, err := lc.Write(&proto.WriteRequest{
+	_, err := lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shard,
 		Puts:    []*proto.PutRequest{{Key: "k1", Value: []byte("hello")}},
 	})

--- a/server/standalone.go
+++ b/server/standalone.go
@@ -124,7 +124,7 @@ func (s *Standalone) initializeShards(numShards uint32) error {
 			return err
 		}
 
-		if _, err := lc.BecomeLeader(&proto.BecomeLeaderRequest{
+		if _, err := lc.BecomeLeader(context.Background(), &proto.BecomeLeaderRequest{
 			ShardId:           i,
 			Term:              newTerm,
 			ReplicationFactor: 1,


### PR DESCRIPTION
During the `BecomeLeader` we need to wait until all the entries in the leader wal are fully replicated. Right now there is no timeout for that operation and the call is stuck waiting even if the gRPC client (oxia coordinator) has given up. 

When the coordinator tries to restart a new term, the process might get deadlock because this node become unresponsive.

```



1 @ 0x4482d6 0x4595de 0x4595b5 0x475a45 0x490785 0x491d76 0x491d55 0x1a722fb 0x1a7b0aa 0x1a6c4b2 0x99841f 0x985a49 0x972163 0x973a2a 0x96c298 0x479ae1
# labels: {"bind":"[::]:6649", "oxia":"internal"}
#	0x475a44	sync.runtime_SemacquireMutex+0x24									/usr/local/go/src/runtime/sema.go:77
#	0x490784	sync.(*Mutex).lockSlow+0x164										/usr/local/go/src/sync/mutex.go:171
#	0x491d75	sync.(*Mutex).Lock+0x35											/usr/local/go/src/sync/mutex.go:90
#	0x491d54	sync.(*RWMutex).Lock+0x14										/usr/local/go/src/sync/rwmutex.go:147
#	0x1a722fa	oxia/server.(*leaderController).Close+0x3a								/src/oxia/server/leader_controller.go:782
#	0x1a7b0a9	oxia/server.(*shardsDirector).GetOrCreateFollower+0x129							/src/oxia/server/shards_director.go:169
#	0x1a6c4b1	oxia/server.(*internalRpcServer).Replicate+0x431							/src/oxia/server/internal_rpc_server.go:218
#	0x99841e	oxia/proto._OxiaLogReplication_Replicate_Handler+0x9e							/src/oxia/proto/replication_grpc.pb.go:468
#	0x985a48	github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).StreamServerInterceptor.func1+0x108	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:121
#	0x972162	google.golang.org/grpc.(*Server).processStreamingRPC+0x1302						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1646
#	0x973a29	google.golang.org/grpc.(*Server).handleStream+0x9e9							/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1726
#	0x96c297	google.golang.org/grpc.(*Server).serveStreams.func1.2+0x97						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:966


10 @ 0x4482d6 0x4595de 0x4595b5 0x475a45 0x490785 0x491d76 0x491d55 0x1a71836 0x1a715ad 0x1a71445 0x1a737db 0x991778 0x985807 0x991638 0x96e9b0 0x973a6f 0x96c298 0x479ae1
# labels: {"bind":"[::]:6648", "oxia":"public"}
#	0x475a44	sync.runtime_SemacquireMutex+0x24								/usr/local/go/src/runtime/sema.go:77
#	0x490784	sync.(*Mutex).lockSlow+0x164									/usr/local/go/src/sync/mutex.go:171
#	0x491d75	sync.(*Mutex).Lock+0x35										/usr/local/go/src/sync/mutex.go:90
#	0x491d54	sync.(*RWMutex).Lock+0x14									/usr/local/go/src/sync/rwmutex.go:147
#	0x1a71835	oxia/server.(*leaderController).appendToWal+0x35						/src/oxia/server/leader_controller.go:680
#	0x1a715ac	oxia/server.(*leaderController).write+0x10c							/src/oxia/server/leader_controller.go:668
#	0x1a71444	oxia/server.(*leaderController).Write+0x64							/src/oxia/server/leader_controller.go:655
#	0x1a737da	oxia/server.(*publicRpcServer).Write+0xda							/src/oxia/server/public_rpc_server.go:89
#	0x991777	oxia/proto._OxiaClient_Write_Handler.func1+0x77							/src/oxia/proto/client_grpc.pb.go:351
#	0x985806	github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1+0x86	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107
#	0x991637	oxia/proto._OxiaClient_Write_Handler+0x137							/src/oxia/proto/client_grpc.pb.go:353
#	0x96e9af	google.golang.org/grpc.(*Server).processUnaryRPC+0xdef						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1345
#	0x973a6e	google.golang.org/grpc.(*Server).handleStream+0xa2e						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1722
#	0x96c297	google.golang.org/grpc.(*Server).serveStreams.func1.2+0x97					/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:966

1 @ 0x4482d6 0x475c2c 0x475c0c 0x48ea8c 0x1a75006 0x1a6e9ae 0x1a6b678 0x997078 0x985807 0x996f38 0x96e9b0 0x973a6f 0x96c298 0x479ae1
#	0x475c0b	sync.runtime_notifyListWait+0x12b								/usr/local/go/src/runtime/sema.go:517
#	0x48ea8b	sync.(*Cond).Wait+0x8b										/usr/local/go/src/sync/cond.go:70
#	0x1a75005	oxia/server.(*quorumAckTracker).WaitForCommitOffset+0xa5					/src/oxia/server/quorum_ack_tracker.go:162
#	0x1a6e9ad	oxia/server.(*leaderController).BecomeLeader+0x4cd						/src/oxia/server/leader_controller.go:346
#	0x1a6b677	oxia/server.(*internalRpcServer).BecomeLeader+0x3d7						/src/oxia/server/internal_rpc_server.go:145
#	0x997077	oxia/proto._OxiaCoordination_BecomeLeader_Handler.func1+0x77					/src/oxia/proto/replication_grpc.pb.go:225
#	0x985806	github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1+0x86	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107
#	0x996f37	oxia/proto._OxiaCoordination_BecomeLeader_Handler+0x137						/src/oxia/proto/replication_grpc.pb.go:227
#	0x96e9af	google.golang.org/grpc.(*Server).processUnaryRPC+0xdef						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1345
#	0x973a6e	google.golang.org/grpc.(*Server).handleStream+0xa2e						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1722
#	0x96c297	google.golang.org/grpc.(*Server).serveStreams.func1.2+0x97					/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:966

1 @ 0x4482d6 0x475c2c 0x475c0c 0x48ea8c 0x1a75006 0x1a6e9ae 0x1a6b678 0x997078 0x985807 0x996f38 0x96e9b0 0x973a6f 0x96c298 0x479ae1
# labels: {"bind":"[::]:6649", "oxia":"internal"}
#	0x475c0b	sync.runtime_notifyListWait+0x12b								/usr/local/go/src/runtime/sema.go:517
#	0x48ea8b	sync.(*Cond).Wait+0x8b										/usr/local/go/src/sync/cond.go:70
#	0x1a75005	oxia/server.(*quorumAckTracker).WaitForCommitOffset+0xa5					/src/oxia/server/quorum_ack_tracker.go:162
#	0x1a6e9ad	oxia/server.(*leaderController).BecomeLeader+0x4cd						/src/oxia/server/leader_controller.go:346
#	0x1a6b677	oxia/server.(*internalRpcServer).BecomeLeader+0x3d7						/src/oxia/server/internal_rpc_server.go:145
#	0x997077	oxia/proto._OxiaCoordination_BecomeLeader_Handler.func1+0x77					/src/oxia/proto/replication_grpc.pb.go:225
#	0x985806	github.com/grpc-ecosystem/go-grpc-prometheus.(*ServerMetrics).UnaryServerInterceptor.func1+0x86	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107
#	0x996f37	oxia/proto._OxiaCoordination_BecomeLeader_Handler+0x137						/src/oxia/proto/replication_grpc.pb.go:227
#	0x96e9af	google.golang.org/grpc.(*Server).processUnaryRPC+0xdef						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1345
#	0x973a6e	google.golang.org/grpc.(*Server).handleStream+0xa2e						/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:1722
#	0x96c297	google.golang.org/grpc.(*Server).serveStreams.func1.2+0x97					/go/pkg/mod/google.golang.org/grpc@v1.54.0/server.go:966
```

### Modifications

We need to abort the `BecomeLeader` request when it gets timed-out or cancelled by the client.