### PR TITLE
Use buffered channel in coordinator NewTerm quorum response tracking

### DIFF
--- a/coordinator/impl/shard_controller.go
+++ b/coordinator/impl/shard_controller.go
@@ -418,7 +418,7 @@ func (s *shardController) newTermQuorum() (map[model.ServerAddress]*proto.EntryI
 		model.ServerAddress
 		*proto.EntryId
 		error
-	})
+	}, fencingQuorumSize)
 
 	for _, sa := range fencingQuorum {
 		// We need to save the address because it gets modified in the loop


### PR DESCRIPTION
When the coordinator sends a `NewTerm` request to the fencing ensemble, it waits for a majority of successful answers. 

After that, we wait for max 100ms and the `NewTerm` is complete. The remaining server will continue to be issued the request in background. 

The problem is that when the answer for original request comes in, after the 100ms threshold, the goroutine is blocked writing on the unbuffered channel, since the original thread already gave up on that request and it's not reading from the channel anymore

```
898 @ 0x4482d6 0x4116ec 0x41129d 0x183197d 0x9daf3b 0x9d43c3 0x9daeb2 0x479ae1
# labels: {"node":"oxia-7.oxia-svc:6649", "oxia":"shard-controller-leader-election", "shard":"7"}
#	0x183197c	oxia/coordinator/impl.(*shardController).newTermQuorum.func1+0x23c	/src/oxia/coordinator/impl/shard_controller.go:443
#	0x9daf3a	oxia/common.DoWithLabels.func1+0x1a					/src/oxia/common/pprof.go:43
#	0x9d43c2	runtime/pprof.Do+0xa2							/usr/local/go/src/runtime/pprof/runtime.go:40
#	0x9daeb1	oxia/common.DoWithLabels+0x331						/src/oxia/common/pprof.go:39
```

### Modification

Use a buffered channel, with enough space for all the servers to reply, so that we don't get any leaked goroutines blocked on the channel.