### PR TITLE
Use Seek() to create new wal segment

### DIFF
--- a/server/wal/fsync_test.go
+++ b/server/wal/fsync_test.go
@@ -68,10 +68,12 @@ func BenchmarkMSync(b *testing.B) {
 
 	data := make([]byte, writeSize)
 
-	for i := 0; i < b.N; i++ {
-		_, err = f.Write(data)
-		assert.NoError(b, err)
-	}
+	_, err = f.Seek(int64(writeSize*b.N), 0)
+	assert.NoError(b, err)
+	_, err = f.Write([]byte{0x00})
+	assert.NoError(b, err)
+	err = f.Sync()
+	assert.NoError(b, err)
 
 	assert.NoError(b, f.Sync())
 

--- a/server/wal/wal_rw_segment.go
+++ b/server/wal/wal_rw_segment.go
@@ -230,26 +230,13 @@ func (ms *readWriteSegment) Truncate(lastSafeOffset int64) error {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-var (
-	zeroedBuf    = make([]byte, 4096)
-	zeroedBufLen = uint32(len(zeroedBuf))
-)
-
 func initFileWithZeroes(f *os.File, size uint32) error {
-	toWrite := size
-	for toWrite > 0 {
-		if toWrite > zeroedBufLen {
-			if _, err := f.Write(zeroedBuf); err != nil {
-				return errors.Wrap(err, "error creating transaction file")
-			}
-			toWrite -= zeroedBufLen
-		} else {
-			if _, err := f.Write(zeroedBuf[:toWrite]); err != nil {
-				return errors.Wrap(err, "error creating transaction file")
-			}
+	if _, err := f.Seek(int64(size), 0); err != nil {
+		return err
+	}
 
-			toWrite = 0
-		}
+	if _, err := f.Write([]byte{0x00}); err != nil {
+		return err
 	}
 
 	return f.Sync()


### PR DESCRIPTION
When doing a wal segment rollover, if we allocate and write & sync the entire segment, we are imposing a latency bump while the whole segments is synced to disk. 

Instead we can just seek to the size write 1 byte and we're ready to mmap the whole segment.

Before: 

```
Jul 10 09:02:25.350762 INF Stats - Total ops: 100455.4 ops/s - Failed ops:    0.0 ops/s
			Write ops 100455.4 w/s  Latency ms: 50%   6.5 - 95%   8.1 - 99%  93.3 - 99.9%  93.3 - max   93.3
			Read  ops    0.0 r/s  Latency ms: 50%   0.0 - 95%   0.0 - 99%   0.0 - 99.9%   0.0 - max    0.0
```

After:

```
Jul 10 09:01:07.853821 INF Stats - Total ops: 109892.6 ops/s - Failed ops:    0.0 ops/s
			Write ops 109892.6 w/s  Latency ms: 50%   6.6 - 95%  13.6 - 99%  40.2 - 99.9%  40.2 - max   40.2
			Read  ops    0.0 r/s  Latency ms: 50%   0.0 - 95%   0.0 - 99%   0.0 - 99.9%   0.0 - max    0.0
```

Note: forcing to write the entire segment could make sense because all the block are pre-allocated, though we should be doing it in more complex way: eg: pre-allocating segments in background and renaming the files when doing the rollover.
