### PR TITLE
[build] do apt-get update to avoid missing package versions

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - name: Install Gnuplot
         run: |
-          sudo apt-get install -y gnuplot
+          sudo apt-get update && sudo apt-get install -y gnuplot
 
       - run: make
       - run: make maelstrom


### PR DESCRIPTION
CI is failing for a missing package on Ubuntu mirrors.

We should do an `update` before installing.