### PR TITLE
Re-Create session manager on BecomeLeader

### DIFF
--- a/server/session_manager.go
+++ b/server/session_manager.go
@@ -87,7 +87,7 @@ type sessionManager struct {
 	activeSessions  metrics.Gauge
 }
 
-func NewSessionManager(namespace string, shardId int64, controller *leaderController) SessionManager {
+func NewSessionManager(ctx context.Context, namespace string, shardId int64, controller *leaderController) SessionManager {
 	labels := metrics.LabelsForShard(namespace, shardId)
 	sm := &sessionManager{
 		sessions:         make(map[SessionId]*session),
@@ -108,7 +108,7 @@ func NewSessionManager(namespace string, shardId int64, controller *leaderContro
 			"The total number of sessions expired", "count", labels),
 	}
 
-	sm.ctx, sm.cancel = context.WithCancel(context.Background())
+	sm.ctx, sm.cancel = context.WithCancel(ctx)
 
 	sm.activeSessions = metrics.NewGauge("oxia_server_session_active",
 		"The number of sessions currently active", "count", labels, func() int64 {

--- a/server/session_manager_test.go
+++ b/server/session_manager_test.go
@@ -375,5 +375,8 @@ func createSessionManager(t *testing.T) (*sessionManager, *leaderController) {
 		FollowerMaps:      nil,
 	})
 	assert.NoError(t, err)
-	return lc.(*leaderController).sessionManager.(*sessionManager), lc.(*leaderController)
+
+	sessionManager := lc.(*leaderController).sessionManager.(*sessionManager)
+	assert.NoError(t, sessionManager.ctx.Err())
+	return sessionManager, lc.(*leaderController)
 }


### PR DESCRIPTION
The session manager in leader controller gets closed on `NewTerm` request, though it's not being recreated when the leader is elected again as leader, leaving the sessions as they are.