### PR TITLE
refactor(*): group import by standard/third/current

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,3 +15,14 @@
 run:
   skip-dirs:
     - pkg/generated
+
+linters:
+  enable:
+    - goimports
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/streamnative/oxia
+
+issues:
+  fix: true

--- a/cmd/client/cmd.go
+++ b/cmd/client/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/cmd/client/delete"
 	"github.com/streamnative/oxia/cmd/client/get"

--- a/cmd/client/cmd_test.go
+++ b/cmd/client/cmd_test.go
@@ -17,14 +17,16 @@ package client
 import (
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/streamnative/oxia/cmd/client/delete"
 	"github.com/streamnative/oxia/cmd/client/get"
 	"github.com/streamnative/oxia/cmd/client/list"
 	"github.com/streamnative/oxia/cmd/client/put"
 	"github.com/streamnative/oxia/server"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestClientCmd(t *testing.T) {

--- a/cmd/client/common/client.go
+++ b/cmd/client/common/client.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"github.com/streamnative/oxia/oxia"
 	"time"
+
+	"github.com/streamnative/oxia/oxia"
 )
 
 var (

--- a/cmd/client/common/io_test.go
+++ b/cmd/client/common/io_test.go
@@ -16,9 +16,11 @@ package common
 
 import (
 	"bytes"
-	"github.com/streamnative/oxia/oxia"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/oxia"
 )
 
 func TestWriteOutput(t *testing.T) {

--- a/cmd/client/common/loop.go
+++ b/cmd/client/common/loop.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"github.com/streamnative/oxia/oxia"
 	"io"
+
+	"github.com/streamnative/oxia/oxia"
 )
 
 type CommandLoop struct {

--- a/cmd/client/delete/cmd.go
+++ b/cmd/client/delete/cmd.go
@@ -17,10 +17,12 @@ package delete
 import (
 	"encoding/json"
 	"errors"
+	"io"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/oxia"
-	"io"
 )
 
 var (

--- a/cmd/client/delete/cmd_test.go
+++ b/cmd/client/delete/cmd_test.go
@@ -17,10 +17,12 @@ package delete
 import (
 	"bytes"
 	"errors"
-	"github.com/spf13/cobra"
-	"github.com/streamnative/oxia/cmd/client/common"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/cmd/client/common"
 )
 
 func TestCobra(t *testing.T) {

--- a/cmd/client/get/cmd.go
+++ b/cmd/client/get/cmd.go
@@ -18,10 +18,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/oxia"
-	"io"
 )
 
 var (

--- a/cmd/client/get/cmd_test.go
+++ b/cmd/client/get/cmd_test.go
@@ -18,11 +18,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"testing"
+
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/oxia"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCobra(t *testing.T) {

--- a/cmd/client/list/cmd.go
+++ b/cmd/client/list/cmd.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/oxia"
-	"io"
 )
 
 var (

--- a/cmd/client/list/cmd_test.go
+++ b/cmd/client/list/cmd_test.go
@@ -18,11 +18,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"testing"
+
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/oxia"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCobra(t *testing.T) {

--- a/cmd/client/notifications/cmd.go
+++ b/cmd/client/notifications/cmd.go
@@ -17,6 +17,7 @@ package notifications
 import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 )
 

--- a/cmd/client/put/cmd.go
+++ b/cmd/client/put/cmd.go
@@ -18,10 +18,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"io"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/oxia"
-	"io"
 )
 
 var (

--- a/cmd/client/put/cmd_test.go
+++ b/cmd/client/put/cmd_test.go
@@ -17,12 +17,14 @@ package put
 import (
 	"bytes"
 	"encoding/json"
+	"testing"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/streamnative/oxia/cmd/client/common"
 	"github.com/streamnative/oxia/oxia"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestCobraFlags(t *testing.T) {

--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -16,14 +16,16 @@ package coordinator
 
 import (
 	"errors"
+	"io"
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	"github.com/streamnative/oxia/cmd/flag"
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/coordinator"
 	"github.com/streamnative/oxia/coordinator/model"
-	"io"
-	"time"
 )
 
 var (

--- a/cmd/coordinator/cmd_test.go
+++ b/cmd/coordinator/cmd_test.go
@@ -15,16 +15,18 @@
 package coordinator
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/coordinator"
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/coordinator"
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 func TestCmd(t *testing.T) {

--- a/cmd/flag/flag.go
+++ b/cmd/flag/flag.go
@@ -16,7 +16,9 @@ package flag
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/common"
 )
 

--- a/cmd/health/cmd.go
+++ b/cmd/health/cmd.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/spf13/cobra"
-	"github.com/streamnative/oxia/common"
-	"google.golang.org/grpc/health/grpc_health_v1"
 	"time"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/streamnative/oxia/common"
 )
 
 type Config struct {

--- a/cmd/health/cmd_test.go
+++ b/cmd/health/cmd_test.go
@@ -16,15 +16,17 @@ package health
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/rs/zerolog"
-	"github.com/streamnative/oxia/common/container"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
-	"testing"
+
+	"github.com/streamnative/oxia/common/container"
 )
 
 func TestHealthCmd(t *testing.T) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,8 +16,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
+	"go.uber.org/automaxprocs/maxprocs"
+
 	"github.com/streamnative/oxia/cmd/client"
 	"github.com/streamnative/oxia/cmd/coordinator"
 	"github.com/streamnative/oxia/cmd/health"
@@ -26,8 +30,6 @@ import (
 	"github.com/streamnative/oxia/cmd/server"
 	"github.com/streamnative/oxia/cmd/standalone"
 	"github.com/streamnative/oxia/common"
-	"go.uber.org/automaxprocs/maxprocs"
-	"os"
 )
 
 var (

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -15,11 +15,13 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
-	"github.com/streamnative/oxia/common"
 	"github.com/stretchr/testify/assert"
-	"testing"
+
+	"github.com/streamnative/oxia/common"
 )
 
 func TestCall_LogLevel_Default(t *testing.T) {

--- a/cmd/pebble/cmd.go
+++ b/cmd/pebble/cmd.go
@@ -17,6 +17,7 @@ package pebble
 import (
 	"github.com/cockroachdb/pebble/tool"
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/server/kv"
 )
 

--- a/cmd/perf/cmd.go
+++ b/cmd/perf/cmd.go
@@ -17,11 +17,13 @@ package perf
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/oxia"
 	"github.com/streamnative/oxia/perf"
-	"io"
 )
 
 var (

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -15,13 +15,15 @@
 package server
 
 import (
+	"io"
+	"time"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/flag"
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/server"
 	"github.com/streamnative/oxia/server/kv"
-	"io"
-	"time"
 )
 
 var (

--- a/cmd/standalone/cmd.go
+++ b/cmd/standalone/cmd.go
@@ -15,13 +15,15 @@
 package standalone
 
 import (
+	"io"
+	"time"
+
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/cmd/flag"
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/server"
 	"github.com/streamnative/oxia/server/kv"
-	"io"
-	"time"
 )
 
 var (

--- a/common/backoff.go
+++ b/common/backoff.go
@@ -16,8 +16,9 @@ package common
 
 import (
 	"context"
-	"github.com/cenkalti/backoff/v4"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 func NewBackOff(ctx context.Context) backoff.BackOff {

--- a/common/client_pool.go
+++ b/common/client_pool.go
@@ -16,18 +16,20 @@ package common
 
 import (
 	"context"
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
+	"io"
+	"sync"
+	"time"
+
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/peer"
-	"io"
-	"sync"
-	"time"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 const DefaultRpcTimeout = 30 * time.Second

--- a/common/condition_test.go
+++ b/common/condition_test.go
@@ -16,11 +16,12 @@ package common
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"runtime"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCondCancelContext(t *testing.T) {

--- a/common/container/container.go
+++ b/common/container/container.go
@@ -15,13 +15,15 @@
 package container
 
 import (
-	"github.com/grpc-ecosystem/go-grpc-prometheus"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"google.golang.org/grpc"
 	"io"
 	"net"
+
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc"
+
+	"github.com/streamnative/oxia/common"
 )
 
 const (

--- a/common/hash_test.go
+++ b/common/hash_test.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestXxh332(t *testing.T) {

--- a/common/logger.go
+++ b/common/logger.go
@@ -16,13 +16,14 @@ package common
 
 import (
 	"encoding/json"
+	"os"
+	"time"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/rs/zerolog/pkgerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
-	"os"
-	"time"
 )
 
 const DefaultLogLevel = zerolog.InfoLevel

--- a/common/memoize_test.go
+++ b/common/memoize_test.go
@@ -15,10 +15,11 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMemoize(t *testing.T) {

--- a/common/metrics/counter.go
+++ b/common/metrics/counter.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+
 	"go.opentelemetry.io/otel/metric"
 )
 

--- a/common/metrics/gauge.go
+++ b/common/metrics/gauge.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel/metric"
 )

--- a/common/metrics/histogram.go
+++ b/common/metrics/histogram.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+
 	"go.opentelemetry.io/otel/metric"
 )
 

--- a/common/metrics/latency_histogram.go
+++ b/common/metrics/latency_histogram.go
@@ -16,8 +16,9 @@ package metrics
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/metric"
 	"time"
+
+	"go.opentelemetry.io/otel/metric"
 )
 
 var latencyBucketsMillis = []float64{

--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -15,15 +15,17 @@
 package metrics
 
 import (
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"go.opentelemetry.io/otel/exporters/prometheus"
-	"go.opentelemetry.io/otel/sdk/metric"
 	"io"
 	"net"
 	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/streamnative/oxia/common"
 )
 
 func init() {

--- a/common/metrics/metrics_test.go
+++ b/common/metrics/metrics_test.go
@@ -16,10 +16,11 @@ package metrics
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPrometheusMetrics(t *testing.T) {

--- a/common/pprof.go
+++ b/common/pprof.go
@@ -16,11 +16,12 @@ package common
 
 import (
 	"context"
-	"github.com/rs/zerolog/log"
 	"io"
 	"net/http"
 	_ "net/http/pprof"
 	"runtime/pprof"
+
+	"github.com/rs/zerolog/log"
 )
 
 var (

--- a/common/ref_count_test.go
+++ b/common/ref_count_test.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testRc struct {

--- a/common/run.go
+++ b/common/run.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"github.com/rs/zerolog/log"
 	"io"
+
+	"github.com/rs/zerolog/log"
 )
 
 func RunProcess(startProcess func() (io.Closer, error)) {

--- a/common/set.go
+++ b/common/set.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"golang.org/x/exp/constraints"
 	"sort"
+
+	"golang.org/x/exp/constraints"
 )
 
 type Set[T constraints.Ordered] interface {

--- a/common/set_test.go
+++ b/common/set_test.go
@@ -15,8 +15,9 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSet(t *testing.T) {

--- a/common/shards_test.go
+++ b/common/shards_test.go
@@ -15,9 +15,10 @@
 package common
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateShards(t *testing.T) {

--- a/common/wait_group_test.go
+++ b/common/wait_group_test.go
@@ -16,10 +16,11 @@ package common
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func assertNotReady(t *testing.T, wg WaitGroup) {

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -17,13 +17,15 @@ package coordinator
 import (
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/coordinator/impl"
 	"github.com/streamnative/oxia/coordinator/model"
-	"go.uber.org/multierr"
-	"time"
 )
 
 type Config struct {

--- a/coordinator/coordinator_rpc_server.go
+++ b/coordinator/coordinator_rpc_server.go
@@ -15,10 +15,11 @@
 package coordinator
 
 import (
-	"github.com/streamnative/oxia/common/container"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/streamnative/oxia/common/container"
 )
 
 type rpcServer struct {

--- a/coordinator/impl/cluster_rebalance.go
+++ b/coordinator/impl/cluster_rebalance.go
@@ -15,10 +15,12 @@
 package impl
 
 import (
+	"sort"
+
 	"github.com/rs/zerolog/log"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/coordinator/model"
-	"sort"
 )
 
 type SwapNodeAction struct {

--- a/coordinator/impl/cluster_rebalance_test.go
+++ b/coordinator/impl/cluster_rebalance_test.go
@@ -15,12 +15,14 @@
 package impl
 
 import (
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"testing"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 func TestClusterRebalance_Count(t *testing.T) {

--- a/coordinator/impl/cluster_updates_test.go
+++ b/coordinator/impl/cluster_updates_test.go
@@ -15,11 +15,13 @@
 package impl
 
 import (
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 var (

--- a/coordinator/impl/coordinator.go
+++ b/coordinator/impl/coordinator.go
@@ -16,18 +16,20 @@ package impl
 
 import (
 	"context"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/streamnative/oxia/proto"
-	"go.uber.org/multierr"
-	pb "google.golang.org/protobuf/proto"
 	"io"
 	"reflect"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+	pb "google.golang.org/protobuf/proto"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/coordinator/model"
+	"github.com/streamnative/oxia/proto"
 )
 
 var (

--- a/coordinator/impl/coordinator_e2e_test.go
+++ b/coordinator/impl/coordinator_e2e_test.go
@@ -17,16 +17,18 @@ package impl
 import (
 	"context"
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/streamnative/oxia/oxia"
-	"github.com/streamnative/oxia/server"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/coordinator/model"
+	"github.com/streamnative/oxia/oxia"
+	"github.com/streamnative/oxia/server"
 )
 
 func newServer(t *testing.T) (s *server.Server, addr model.ServerAddress) {

--- a/coordinator/impl/k8s_client.go
+++ b/coordinator/impl/k8s_client.go
@@ -16,6 +16,7 @@ package impl
 
 import (
 	"context"
+
 	"github.com/rs/zerolog/log"
 	coreV1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/coordinator/impl/k8s_client_test.go
+++ b/coordinator/impl/k8s_client_test.go
@@ -16,12 +16,13 @@ package impl
 
 import (
 	"errors"
+	"strconv"
+
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/testing"
-	"strconv"
 )
 
 func K8SResourceVersionSupport(tracker testing.ObjectTracker) testing.ReactionFunc {

--- a/coordinator/impl/metadata.go
+++ b/coordinator/impl/metadata.go
@@ -15,9 +15,11 @@
 package impl
 
 import (
-	"github.com/pkg/errors"
-	"github.com/streamnative/oxia/coordinator/model"
 	"io"
+
+	"github.com/pkg/errors"
+
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 type Version string

--- a/coordinator/impl/metadata_configmap.go
+++ b/coordinator/impl/metadata_configmap.go
@@ -15,16 +15,18 @@
 package impl
 
 import (
+	"sync"
+	"sync/atomic"
+
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common/metrics"
-	"github.com/streamnative/oxia/coordinator/model"
 	"gopkg.in/yaml.v2"
 	coreV1 "k8s.io/api/core/v1"
 	k8sError "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8s "k8s.io/client-go/kubernetes"
-	"sync"
-	"sync/atomic"
+
+	"github.com/streamnative/oxia/common/metrics"
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 type metadataProviderConfigMap struct {

--- a/coordinator/impl/metadata_file.go
+++ b/coordinator/impl/metadata_file.go
@@ -16,12 +16,14 @@ package impl
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+
 	"github.com/juju/fslock"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
+
 	"github.com/streamnative/oxia/coordinator/model"
-	"os"
-	"path/filepath"
 )
 
 // MetadataProviderMemory is a provider that just keeps the cluster status in a local file,

--- a/coordinator/impl/metadata_memory.go
+++ b/coordinator/impl/metadata_memory.go
@@ -15,9 +15,10 @@
 package impl
 
 import (
-	"github.com/streamnative/oxia/coordinator/model"
 	"strconv"
 	"sync"
+
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 // MetadataProviderMemory is a provider that just keeps the cluster status in memory

--- a/coordinator/impl/metadata_test.go
+++ b/coordinator/impl/metadata_test.go
@@ -15,11 +15,13 @@
 package impl
 
 import (
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/kubernetes/fake"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 var (

--- a/coordinator/impl/mock_test.go
+++ b/coordinator/impl/mock_test.go
@@ -17,17 +17,19 @@ package impl
 import (
 	"context"
 	"errors"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/streamnative/oxia/proto"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	pb "google.golang.org/protobuf/proto"
-	"sync"
-	"testing"
-	"time"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/coordinator/model"
+	"github.com/streamnative/oxia/proto"
 )
 
 func init() {

--- a/coordinator/impl/node_controller.go
+++ b/coordinator/impl/node_controller.go
@@ -16,18 +16,20 @@ package impl
 
 import (
 	"context"
+	"io"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/coordinator/model"
 	"github.com/streamnative/oxia/proto"
-	"google.golang.org/grpc/health/grpc_health_v1"
-	"io"
-	"sync"
-	"time"
 )
 
 type NodeStatus uint32

--- a/coordinator/impl/node_controller_test.go
+++ b/coordinator/impl/node_controller_test.go
@@ -16,13 +16,15 @@ package impl
 
 import (
 	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/health/grpc_health_v1"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/coordinator/model"
 	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/health/grpc_health_v1"
-	"testing"
-	"time"
 )
 
 func TestNodeController_HealthCheck(t *testing.T) {

--- a/coordinator/impl/rpc_provider.go
+++ b/coordinator/impl/rpc_provider.go
@@ -16,11 +16,13 @@ package impl
 
 import (
 	"context"
+	"time"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/coordinator/model"
 	"github.com/streamnative/oxia/proto"
-	"google.golang.org/grpc/health/grpc_health_v1"
-	"time"
 )
 
 const rpcTimeout = 30 * time.Second

--- a/coordinator/impl/shard_controller.go
+++ b/coordinator/impl/shard_controller.go
@@ -17,20 +17,22 @@ package impl
 import (
 	"context"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/metrics"
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/streamnative/oxia/proto"
-	"go.uber.org/multierr"
-	"google.golang.org/grpc/status"
 	"io"
 	"math/rand"
 	"sync"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+	"google.golang.org/grpc/status"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/metrics"
+	"github.com/streamnative/oxia/coordinator/model"
+	"github.com/streamnative/oxia/proto"
 )
 
 const (

--- a/coordinator/impl/shard_controller_test.go
+++ b/coordinator/impl/shard_controller_test.go
@@ -16,14 +16,16 @@ package impl
 
 import (
 	"context"
-	"github.com/pkg/errors"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/coordinator/model"
+	"github.com/streamnative/oxia/proto"
 )
 
 func TestShardController(t *testing.T) {

--- a/coordinator/impl/shard_status_test.go
+++ b/coordinator/impl/shard_status_test.go
@@ -15,9 +15,11 @@
 package impl
 
 import (
-	"github.com/streamnative/oxia/coordinator/model"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/coordinator/model"
 )
 
 func TestShardStatus_String(t *testing.T) {

--- a/coordinator/model/cluster_config_test.go
+++ b/coordinator/model/cluster_config_test.go
@@ -15,8 +15,9 @@
 package model
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClusterConfig(t *testing.T) {

--- a/coordinator/model/cluster_status_test.go
+++ b/coordinator/model/cluster_status_test.go
@@ -15,8 +15,9 @@
 package model
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestClusterStatus_Clone(t *testing.T) {

--- a/maelstrom/coordinator_rpc_client.go
+++ b/maelstrom/coordinator_rpc_client.go
@@ -18,15 +18,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"sync"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/coordinator/impl"
 	"github.com/streamnative/oxia/coordinator/model"
 	"github.com/streamnative/oxia/proto"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/metadata"
-	"os"
-	"sync"
 )
 
 type maelstromCoordinatorRpcProvider struct {

--- a/maelstrom/dispatcher.go
+++ b/maelstrom/dispatcher.go
@@ -18,16 +18,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"google.golang.org/protobuf/encoding/protojson"
-	pb "google.golang.org/protobuf/proto"
 	"os"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/encoding/protojson"
+	pb "google.golang.org/protobuf/proto"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
 )
 
 type Dispatcher interface {

--- a/maelstrom/grpc_provider.go
+++ b/maelstrom/grpc_provider.go
@@ -18,15 +18,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"sync"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common/container"
-	"github.com/streamnative/oxia/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	pb "google.golang.org/protobuf/proto"
-	"os"
-	"sync"
+
+	"github.com/streamnative/oxia/common/container"
+	"github.com/streamnative/oxia/proto"
 )
 
 const (

--- a/maelstrom/main.go
+++ b/maelstrom/main.go
@@ -17,17 +17,19 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/coordinator/impl"
 	"github.com/streamnative/oxia/coordinator/model"
 	"github.com/streamnative/oxia/server"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 var (

--- a/maelstrom/messages.go
+++ b/maelstrom/messages.go
@@ -17,11 +17,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/proto"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
-	"os"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 type MsgType string

--- a/maelstrom/replication_rpc_provider.go
+++ b/maelstrom/replication_rpc_provider.go
@@ -18,11 +18,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/proto"
-	"google.golang.org/grpc/metadata"
 	"os"
 	"sync"
+
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 type maelstromReplicationRpcProvider struct {

--- a/oxia/async_client_impl.go
+++ b/oxia/async_client_impl.go
@@ -16,7 +16,13 @@ package oxia
 
 import (
 	"context"
+	"io"
+	"sync"
+
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/streamnative/oxia/common"
 	commonBatch "github.com/streamnative/oxia/common/batch"
 	"github.com/streamnative/oxia/oxia/internal"
@@ -24,10 +30,6 @@ import (
 	"github.com/streamnative/oxia/oxia/internal/metrics"
 	"github.com/streamnative/oxia/oxia/internal/model"
 	"github.com/streamnative/oxia/proto"
-	"go.uber.org/multierr"
-	"golang.org/x/sync/errgroup"
-	"io"
-	"sync"
 )
 
 type clientImpl struct {

--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -17,14 +17,16 @@ package oxia
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/server"
-	"github.com/stretchr/testify/assert"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/server"
 )
 
 func init() {

--- a/oxia/cache.go
+++ b/oxia/cache.go
@@ -16,15 +16,17 @@ package oxia
 
 import (
 	"context"
+	"io"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/dgraph-io/ristretto"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
 	"go.uber.org/multierr"
-	"io"
-	"sync"
-	"time"
+
+	"github.com/streamnative/oxia/common"
 )
 
 // Cache provides a view of the data stored in Oxia that is locally cached.

--- a/oxia/cache_test.go
+++ b/oxia/cache_test.go
@@ -18,13 +18,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/server"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/server"
 )
 
 type testStruct struct {

--- a/oxia/client.go
+++ b/oxia/client.go
@@ -17,8 +17,9 @@ package oxia
 import (
 	"context"
 	"errors"
-	"github.com/streamnative/oxia/oxia/internal/batch"
 	"io"
+
+	"github.com/streamnative/oxia/oxia/internal/batch"
 )
 
 const (

--- a/oxia/internal/batch/batcher_factory.go
+++ b/oxia/internal/batch/batcher_factory.go
@@ -15,10 +15,11 @@
 package batch
 
 import (
+	"time"
+
 	"github.com/streamnative/oxia/common/batch"
 	"github.com/streamnative/oxia/oxia/internal"
 	"github.com/streamnative/oxia/oxia/internal/metrics"
-	"time"
 )
 
 type BatcherFactory struct {

--- a/oxia/internal/batch/manager.go
+++ b/oxia/internal/batch/manager.go
@@ -15,9 +15,11 @@
 package batch
 
 import (
-	"github.com/streamnative/oxia/common/batch"
-	"go.uber.org/multierr"
 	"sync"
+
+	"go.uber.org/multierr"
+
+	"github.com/streamnative/oxia/common/batch"
 )
 
 func NewManager(batcherFactory func(*int64) batch.Batcher) *Manager {

--- a/oxia/internal/batch/manager_test.go
+++ b/oxia/internal/batch/manager_test.go
@@ -16,9 +16,11 @@ package batch
 
 import (
 	"errors"
-	"github.com/streamnative/oxia/common/batch"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common/batch"
 )
 
 var closeErr = errors.New("closed")

--- a/oxia/internal/batch/read_batch.go
+++ b/oxia/internal/batch/read_batch.go
@@ -16,15 +16,17 @@ package batch
 
 import (
 	"context"
+	"io"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog/log"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/batch"
 	"github.com/streamnative/oxia/oxia/internal/metrics"
 	"github.com/streamnative/oxia/oxia/internal/model"
 	"github.com/streamnative/oxia/proto"
-	"io"
-	"time"
 )
 
 type readBatchFactory struct {

--- a/oxia/internal/batch/read_batch_test.go
+++ b/oxia/internal/batch/read_batch_test.go
@@ -16,16 +16,18 @@ package batch
 
 import (
 	"context"
-	"github.com/streamnative/oxia/oxia/internal/metrics"
-	"github.com/streamnative/oxia/oxia/internal/model"
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/otel/metric/noop"
-	"google.golang.org/grpc/metadata"
 	"io"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/metric/noop"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/streamnative/oxia/oxia/internal/metrics"
+	"github.com/streamnative/oxia/oxia/internal/model"
+	"github.com/streamnative/oxia/proto"
 )
 
 func TestReadBatchAdd(t *testing.T) {

--- a/oxia/internal/batch/rpc_errors.go
+++ b/oxia/internal/batch/rpc_errors.go
@@ -15,9 +15,10 @@
 package batch
 
 import (
-	"github.com/streamnative/oxia/common"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/streamnative/oxia/common"
 )
 
 func isRetriable(err error) bool {

--- a/oxia/internal/batch/write_batch.go
+++ b/oxia/internal/batch/write_batch.go
@@ -17,14 +17,16 @@ package batch
 import (
 	"context"
 	"errors"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog/log"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/batch"
 	"github.com/streamnative/oxia/oxia/internal/metrics"
 	"github.com/streamnative/oxia/oxia/internal/model"
 	"github.com/streamnative/oxia/proto"
-	"time"
 )
 
 var ErrorRequestTooLarge = errors.New("put request is too large")

--- a/oxia/internal/batch/write_batch_test.go
+++ b/oxia/internal/batch/write_batch_test.go
@@ -16,15 +16,17 @@ package batch
 
 import (
 	"context"
-	"github.com/streamnative/oxia/oxia/internal/metrics"
-	"github.com/streamnative/oxia/oxia/internal/model"
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/otel/metric/noop"
 	"io"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/streamnative/oxia/oxia/internal/metrics"
+	"github.com/streamnative/oxia/oxia/internal/model"
+	"github.com/streamnative/oxia/proto"
 )
 
 func TestWriteBatchAdd(t *testing.T) {

--- a/oxia/internal/convert_test.go
+++ b/oxia/internal/convert_test.go
@@ -15,9 +15,11 @@
 package internal
 
 import (
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 func TestToShard(t *testing.T) {

--- a/oxia/internal/executor.go
+++ b/oxia/internal/executor.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"context"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/proto"
 )

--- a/oxia/internal/metrics/metrics.go
+++ b/oxia/internal/metrics/metrics.go
@@ -16,11 +16,13 @@ package metrics
 
 import (
 	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/oxia/internal/model"
 	"github.com/streamnative/oxia/proto"
-	"go.opentelemetry.io/otel/metric"
-	"time"
 )
 
 type Metrics struct {

--- a/oxia/internal/metrics/metrics_test.go
+++ b/oxia/internal/metrics/metrics_test.go
@@ -16,16 +16,18 @@ package metrics
 
 import (
 	"context"
+	"io"
+	"testing"
+	"time"
+
 	"github.com/pkg/errors"
-	"github.com/streamnative/oxia/oxia/internal/model"
-	"github.com/streamnative/oxia/proto"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"io"
-	"testing"
-	"time"
+
+	"github.com/streamnative/oxia/oxia/internal/model"
+	"github.com/streamnative/oxia/proto"
 )
 
 func TestMetricsDecorate(t *testing.T) {

--- a/oxia/internal/metrics/timer.go
+++ b/oxia/internal/metrics/timer.go
@@ -16,8 +16,9 @@ package metrics
 
 import (
 	"context"
-	"go.opentelemetry.io/otel/metric"
 	"time"
+
+	"go.opentelemetry.io/otel/metric"
 )
 
 type Timer interface {

--- a/oxia/internal/metrics/utils.go
+++ b/oxia/internal/metrics/utils.go
@@ -16,10 +16,11 @@ package metrics
 
 import (
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common/metrics"
-	"github.com/streamnative/oxia/proto"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+
+	"github.com/streamnative/oxia/common/metrics"
+	"github.com/streamnative/oxia/proto"
 )
 
 func newHistogram(meter metric.Meter, name string, unit metrics.Unit) metric.Int64Histogram {

--- a/oxia/internal/shard_manager.go
+++ b/oxia/internal/shard_manager.go
@@ -16,17 +16,19 @@ package internal
 
 import (
 	"context"
+	"io"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"io"
-	"sync"
-	"time"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
 )
 
 type ShardManager interface {

--- a/oxia/internal/shard_manager_test.go
+++ b/oxia/internal/shard_manager_test.go
@@ -16,11 +16,13 @@ package internal
 
 import (
 	"fmt"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/server"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/server"
 )
 
 type testShardStrategy struct {

--- a/oxia/internal/shard_strategy_impl_test.go
+++ b/oxia/internal/shard_strategy_impl_test.go
@@ -15,8 +15,9 @@
 package internal
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestShardStrategy(t *testing.T) {

--- a/oxia/notifications.go
+++ b/oxia/notifications.go
@@ -17,14 +17,16 @@ package oxia
 import (
 	"context"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/oxia/internal"
 	"github.com/streamnative/oxia/proto"
-	"io"
-	"time"
 )
 
 type notifications struct {

--- a/oxia/optional_test.go
+++ b/oxia/optional_test.go
@@ -15,8 +15,9 @@
 package oxia
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOptionalPresent(t *testing.T) {

--- a/oxia/options.go
+++ b/oxia/options.go
@@ -15,10 +15,12 @@
 package oxia
 
 import (
-	"github.com/streamnative/oxia/common"
+	"time"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric/noop"
-	"time"
+
+	"github.com/streamnative/oxia/common"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"

--- a/oxia/options_test.go
+++ b/oxia/options_test.go
@@ -15,9 +15,10 @@
 package oxia
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewClientConfig(t *testing.T) {

--- a/oxia/sessions.go
+++ b/oxia/sessions.go
@@ -18,15 +18,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/status"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/oxia/internal"
 	"github.com/streamnative/oxia/proto"
-	"google.golang.org/grpc/status"
-	"sync"
-	"time"
 )
 
 func newSessions(ctx context.Context, shardManager internal.ShardManager, pool common.ClientPool, options clientOptions) *sessions {

--- a/oxia/sync_client_impl.go
+++ b/oxia/sync_client_impl.go
@@ -16,8 +16,9 @@ package oxia
 
 import (
 	"context"
-	"go.uber.org/multierr"
 	"sync"
+
+	"go.uber.org/multierr"
 )
 
 type syncClientImpl struct {

--- a/oxia/sync_client_impl_test.go
+++ b/oxia/sync_client_impl_test.go
@@ -16,8 +16,9 @@ package oxia
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type neverCompleteAsyncClient struct {

--- a/perf/perf.go
+++ b/perf/perf.go
@@ -18,13 +18,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/bmizerany/perks/quantile"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/oxia"
-	"golang.org/x/time/rate"
 	"math/rand"
 	"sync/atomic"
 	"time"
+
+	"github.com/bmizerany/perks/quantile"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/time/rate"
+
+	"github.com/streamnative/oxia/oxia"
 )
 
 type Config struct {

--- a/proto/proto_grpc.go
+++ b/proto/proto_grpc.go
@@ -16,6 +16,7 @@ package proto
 
 import (
 	"fmt"
+
 	"github.com/planetscale/vtprotobuf/codec/grpc"
 	"google.golang.org/grpc/encoding"
 

--- a/proto/proto_test.go
+++ b/proto/proto_test.go
@@ -15,10 +15,11 @@
 package proto
 
 import (
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/proto"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 var appendRequest = &Append{

--- a/server/assignment_dispatcher.go
+++ b/server/assignment_dispatcher.go
@@ -16,13 +16,11 @@ package server
 
 import (
 	"context"
+	"io"
+	"sync"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/container"
-	"github.com/streamnative/oxia/common/metrics"
-	"github.com/streamnative/oxia/proto"
-	"github.com/streamnative/oxia/server/util"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -30,8 +28,12 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	pb "google.golang.org/protobuf/proto"
-	"io"
-	"sync"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/container"
+	"github.com/streamnative/oxia/common/metrics"
+	"github.com/streamnative/oxia/proto"
+	"github.com/streamnative/oxia/server/util"
 )
 
 type Client interface {

--- a/server/assignment_dispatcher_test.go
+++ b/server/assignment_dispatcher_test.go
@@ -16,18 +16,20 @@ package server
 
 import (
 	"context"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/container"
-	"github.com/streamnative/oxia/proto"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
-	"math"
-	"sync"
-	"testing"
-	"time"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/container"
+	"github.com/streamnative/oxia/proto"
 )
 
 func TestUninitializedAssignmentDispatcher(t *testing.T) {

--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -17,15 +17,17 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/rs/zerolog"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/oxia"
-	"github.com/streamnative/oxia/perf"
 	"os"
 	"os/exec"
 	"runtime/pprof"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/oxia"
+	"github.com/streamnative/oxia/perf"
 )
 
 func BenchmarkServer(b *testing.B) {

--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -17,20 +17,22 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"go.uber.org/multierr"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"io"
-	"sync"
-	"sync/atomic"
 )
 
 // FollowerController handles all the operations of a given shard's follower

--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -17,17 +17,19 @@ package server
 import (
 	"context"
 	"fmt"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/status"
+	pb "google.golang.org/protobuf/proto"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc/status"
-	pb "google.golang.org/protobuf/proto"
-	"sync"
-	"testing"
-	"time"
 )
 
 var testKVOptions = &kv.KVFactoryOptions{

--- a/server/follower_cursor.go
+++ b/server/follower_cursor.go
@@ -17,21 +17,23 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/dustin/go-humanize"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"io"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 // ReplicateStreamProvider

--- a/server/follower_cursor_test.go
+++ b/server/follower_cursor_test.go
@@ -16,15 +16,17 @@ package server
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	pb "google.golang.org/protobuf/proto"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"github.com/stretchr/testify/assert"
-	pb "google.golang.org/protobuf/proto"
-	"testing"
-	"time"
 )
 
 func TestFollowerCursor(t *testing.T) {

--- a/server/internal_rpc_server.go
+++ b/server/internal_rpc_server.go
@@ -17,19 +17,21 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/container"
-	"github.com/streamnative/oxia/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
-	"io"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/container"
+	"github.com/streamnative/oxia/proto"
 )
 
 type internalRpcServer struct {

--- a/server/internal_rpc_server_test.go
+++ b/server/internal_rpc_server_test.go
@@ -17,13 +17,15 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/streamnative/oxia/common/container"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"testing"
+
+	"github.com/streamnative/oxia/common/container"
 )
 
 func TestInternalHealthCheck(t *testing.T) {

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -17,16 +17,18 @@ package kv
 import (
 	"context"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/wal"
-	"go.uber.org/multierr"
-	"io"
-	"time"
 )
 
 var ErrorBadVersionId = errors.New("oxia: bad version id")

--- a/server/kv/db_notifications_test.go
+++ b/server/kv/db_notifications_test.go
@@ -16,11 +16,13 @@ package kv
 
 import (
 	"context"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
 )
 
 func init() {

--- a/server/kv/db_test.go
+++ b/server/kv/db_test.go
@@ -15,12 +15,14 @@
 package kv
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	pb "google.golang.org/protobuf/proto"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/wal"
-	"github.com/stretchr/testify/assert"
-	pb "google.golang.org/protobuf/proto"
-	"testing"
 )
 
 func TestDBSimple(t *testing.T) {

--- a/server/kv/kv.go
+++ b/server/kv/kv.go
@@ -15,8 +15,9 @@
 package kv
 
 import (
-	"github.com/pkg/errors"
 	"io"
+
+	"github.com/pkg/errors"
 )
 
 var (

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -17,19 +17,21 @@ package kv
 import (
 	"bytes"
 	"fmt"
-	"github.com/cockroachdb/pebble"
-	"github.com/cockroachdb/pebble/vfs"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/metrics"
-	"go.uber.org/multierr"
 	"io"
 	"os"
 	"path/filepath"
 	"sync/atomic"
 	"time"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/vfs"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/metrics"
 )
 
 var (

--- a/server/kv/kv_pebble_test.go
+++ b/server/kv/kv_pebble_test.go
@@ -17,12 +17,14 @@ package kv
 import (
 	"bytes"
 	"fmt"
-	"github.com/streamnative/oxia/common"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
 )
-import "github.com/stretchr/testify/assert"
 
 var testKVOptions = &KVFactoryOptions{
 	InMemory:    true,

--- a/server/kv/notifications_tracker.go
+++ b/server/kv/notifications_tracker.go
@@ -17,16 +17,18 @@ package kv
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/metrics"
-	"github.com/streamnative/oxia/proto"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/metrics"
+	"github.com/streamnative/oxia/proto"
 )
 
 const (

--- a/server/kv/notifications_trimmer.go
+++ b/server/kv/notifications_trimmer.go
@@ -17,13 +17,15 @@ package kv
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	pb "google.golang.org/protobuf/proto"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/proto"
-	pb "google.golang.org/protobuf/proto"
-	"time"
 )
 
 const (

--- a/server/kv/notifications_trimmer_test.go
+++ b/server/kv/notifications_trimmer_test.go
@@ -17,11 +17,13 @@ package kv
 import (
 	"context"
 	"fmt"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
 )
 
 func TestNotificationsTrimmer(t *testing.T) {

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -17,18 +17,20 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
+	"sync"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+	pb "google.golang.org/protobuf/proto"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"go.uber.org/multierr"
-	pb "google.golang.org/protobuf/proto"
-	"io"
-	"sync"
 )
 
 type GetResult struct {

--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -16,16 +16,18 @@ package server
 
 import (
 	"context"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"github.com/streamnative/oxia/server/kv"
-	"github.com/streamnative/oxia/server/wal"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
-	"testing"
-	"time"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
+	"github.com/streamnative/oxia/server/kv"
+	"github.com/streamnative/oxia/server/wal"
 )
 
 func AssertProtoEqual(t *testing.T, expected, actual pb.Message) {

--- a/server/mock_test.go
+++ b/server/mock_test.go
@@ -16,8 +16,10 @@ package server
 
 import (
 	"context"
-	"github.com/streamnative/oxia/proto"
+
 	"google.golang.org/grpc/metadata"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 func newMockServerReplicateStream() *mockServerReplicateStream {

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -16,15 +16,17 @@ package server
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/container"
-	"github.com/streamnative/oxia/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protowire"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/container"
+	"github.com/streamnative/oxia/proto"
 )
 
 const (

--- a/server/quorum_ack_tracker.go
+++ b/server/quorum_ack_tracker.go
@@ -17,12 +17,13 @@ package server
 import (
 	"context"
 	"errors"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"github.com/streamnative/oxia/server/util"
 	"io"
 	"sync"
 	"sync/atomic"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
+	"github.com/streamnative/oxia/server/util"
 )
 
 var (

--- a/server/quorum_ack_tracker_test.go
+++ b/server/quorum_ack_tracker_test.go
@@ -16,11 +16,13 @@ package server
 
 import (
 	"context"
-	"github.com/streamnative/oxia/proto"
-	"github.com/streamnative/oxia/server/wal"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/proto"
+	"github.com/streamnative/oxia/server/wal"
 )
 
 func TestQuorumAckTrackerNoFollower(t *testing.T) {

--- a/server/rpc_provider.go
+++ b/server/rpc_provider.go
@@ -17,11 +17,13 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"google.golang.org/grpc/metadata"
 	"io"
 	"time"
+
+	"google.golang.org/grpc/metadata"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
 )
 
 const rpcTimeout = 30 * time.Second

--- a/server/server.go
+++ b/server/server.go
@@ -15,14 +15,16 @@
 package server
 
 import (
+	"time"
+
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+	"google.golang.org/grpc/health"
+
 	"github.com/streamnative/oxia/common/container"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"go.uber.org/multierr"
-	"google.golang.org/grpc/health"
-	"time"
 )
 
 type Config struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,10 +16,11 @@ package server
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewServer(t *testing.T) {

--- a/server/session.go
+++ b/server/session.go
@@ -16,11 +16,13 @@ package server
 
 import (
 	"context"
-	"github.com/rs/zerolog"
-	"github.com/streamnative/oxia/proto"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 // --- Session

--- a/server/session_manager.go
+++ b/server/session_manager.go
@@ -17,18 +17,20 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/metrics"
-	"github.com/streamnative/oxia/proto"
-	"github.com/streamnative/oxia/server/kv"
 	"io"
 	"net/url"
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/metrics"
+	"github.com/streamnative/oxia/proto"
+	"github.com/streamnative/oxia/server/kv"
 )
 
 const (

--- a/server/session_manager_test.go
+++ b/server/session_manager_test.go
@@ -17,14 +17,16 @@ package server
 import (
 	"context"
 	"errors"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"github.com/streamnative/oxia/server/kv"
-	"github.com/stretchr/testify/assert"
-	pb "google.golang.org/protobuf/proto"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	pb "google.golang.org/protobuf/proto"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
+	"github.com/streamnative/oxia/server/kv"
 )
 
 func TestSessionKey(t *testing.T) {

--- a/server/shards_director.go
+++ b/server/shards_director.go
@@ -15,17 +15,19 @@
 package server
 
 import (
+	"io"
+	"sync"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+	"google.golang.org/grpc/status"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"go.uber.org/multierr"
-	"google.golang.org/grpc/status"
-	"io"
-	"sync"
 )
 
 type ShardsDirector interface {

--- a/server/shards_director_test.go
+++ b/server/shards_director_test.go
@@ -16,11 +16,13 @@ package server
 
 import (
 	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
-	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestShardsDirector_DeleteShardLeader(t *testing.T) {

--- a/server/standalone.go
+++ b/server/standalone.go
@@ -16,17 +16,19 @@ package server
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
 	"github.com/rs/zerolog/log"
+	"go.uber.org/multierr"
+
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/container"
 	"github.com/streamnative/oxia/common/metrics"
 	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/kv"
 	"github.com/streamnative/oxia/server/wal"
-	"go.uber.org/multierr"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 type StandaloneConfig struct {

--- a/server/util/bitset_test.go
+++ b/server/util/bitset_test.go
@@ -15,8 +15,9 @@
 package util
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBitSet(t *testing.T) {

--- a/server/util/stream_reader.go
+++ b/server/util/stream_reader.go
@@ -15,12 +15,14 @@
 package util
 
 import (
+	"io"
+
 	"github.com/rs/zerolog"
-	"github.com/streamnative/oxia/common"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"io"
+
+	"github.com/streamnative/oxia/common"
 )
 
 type Stream[T any] interface {

--- a/server/wal/fsync_test.go
+++ b/server/wal/fsync_test.go
@@ -15,12 +15,13 @@
 package wal
 
 import (
-	"github.com/edsrzf/mmap-go"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/edsrzf/mmap-go"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
 
 const (

--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -16,10 +16,12 @@ package wal
 
 import (
 	"context"
-	"github.com/pkg/errors"
-	"github.com/streamnative/oxia/proto"
 	"io"
 	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 var (

--- a/server/wal/wal_impl.go
+++ b/server/wal/wal_impl.go
@@ -17,18 +17,20 @@ package wal
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/common/metrics"
-	"github.com/streamnative/oxia/proto"
-	"go.uber.org/multierr"
-	"golang.org/x/exp/slices"
-	pb "google.golang.org/protobuf/proto"
 	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+	"golang.org/x/exp/slices"
+	pb "google.golang.org/protobuf/proto"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/common/metrics"
+	"github.com/streamnative/oxia/proto"
 )
 
 type walFactory struct {

--- a/server/wal/wal_reader.go
+++ b/server/wal/wal_reader.go
@@ -15,8 +15,9 @@
 package wal
 
 import (
-	"github.com/streamnative/oxia/proto"
 	"sync"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 func (t *wal) NewReader(after int64) (WalReader, error) {

--- a/server/wal/wal_ro_segment.go
+++ b/server/wal/wal_ro_segment.go
@@ -17,17 +17,19 @@ package wal
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/edsrzf/mmap-go"
-	"github.com/emirpasic/gods/maps/treemap"
-	"github.com/emirpasic/gods/utils"
-	"github.com/pkg/errors"
-	"github.com/streamnative/oxia/common"
-	"go.uber.org/multierr"
 	"io"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/edsrzf/mmap-go"
+	"github.com/emirpasic/gods/maps/treemap"
+	"github.com/emirpasic/gods/utils"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
+	"github.com/streamnative/oxia/common"
 )
 
 const (

--- a/server/wal/wal_ro_segment_test.go
+++ b/server/wal/wal_ro_segment_test.go
@@ -16,8 +16,9 @@ package wal
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReadOnlySegment(t *testing.T) {

--- a/server/wal/wal_rw_segment.go
+++ b/server/wal/wal_rw_segment.go
@@ -16,12 +16,13 @@ package wal
 
 import (
 	"encoding/binary"
-	"github.com/edsrzf/mmap-go"
-	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/edsrzf/mmap-go"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
 )
 
 type ReadWriteSegment interface {

--- a/server/wal/wal_rw_segment_test.go
+++ b/server/wal/wal_rw_segment_test.go
@@ -15,8 +15,9 @@
 package wal
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReadWriteSegment(t *testing.T) {

--- a/server/wal/wal_test.go
+++ b/server/wal/wal_test.go
@@ -17,12 +17,14 @@ package wal
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
 )
 
 const shard = int64(100)

--- a/server/wal/wal_trimmer.go
+++ b/server/wal/wal_trimmer.go
@@ -17,12 +17,14 @@ package wal
 import (
 	"context"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
 	"github.com/streamnative/oxia/common"
-	"io"
-	"time"
 )
 
 const (

--- a/server/wal/wal_trimmer_test.go
+++ b/server/wal/wal_trimmer_test.go
@@ -16,14 +16,16 @@ package wal
 
 import (
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/streamnative/oxia/common"
-	"github.com/streamnative/oxia/proto"
-	"github.com/stretchr/testify/assert"
 	"math"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/common"
+	"github.com/streamnative/oxia/proto"
 )
 
 func init() {


### PR DESCRIPTION
Group import ordering by:

```
std
<blank>
third
<blank>
project
```

There is no convention about the order of `third` and `project`, but separate from stdlib is meaningful.

This is done by blow script:

```
find . -type f -name '*.go' | grep -v '.pb.go' | xargs goimports -local=github.com/streamnative/oxia -w
```