### PR TITLE
Upgrade OpenSSL in Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ FROM alpine:3.18.4
 
 RUN apk add --no-cache bash bash-completion
 
+# Fix CVE-2023-5363 by upgrading to OpenSSL 3.1.4-r1
+# We can remove once new Alpine image is released
+RUN apk upgrade --no-cache libssl3 libcrypto3
+
 RUN mkdir /oxia
 WORKDIR /oxia
 


### PR DESCRIPTION
Fixed security issue in base image

```
┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ fixed  │ 3.1.3-r0          │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
│            ├───────────────┼──────────┤        │                   ├───────────────┼────────────────────────────────────────────────────────┤
│            │ CVE-2023-5678 │ MEDIUM   │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or  │
│            │               │          │        │                   │               │ checking excessively long X9.42...                     │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678              │
├────────────┼───────────────┼──────────┤        │                   ├───────────────┼────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-5363 │ HIGH     │        │                   │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
│            ├───────────────┼──────────┤        │                   ├───────────────┼────────────────────────────────────────────────────────┤
│            │ CVE-2023-5678 │ MEDIUM   │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or  │
│            │               │          │        │                   │               │ checking excessively long X9.42...                     │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678              │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘
```