### PR TITLE
fix(*): avoid infinite loop when notifications close

### DIFF
--- a/oxia/notifications.go
+++ b/oxia/notifications.go
@@ -100,7 +100,7 @@ func (nm *notifications) Close() error {
 
 	// Ensure the channel is empty, so that the user will not see any notifications
 	// after the close
-	for n := <-nm.multiplexCh; n != nil; {
+	for range nm.multiplexCh {
 	}
 
 	return nil

--- a/oxia/notifications_test.go
+++ b/oxia/notifications_test.go
@@ -1,0 +1,51 @@
+// Copyright 2023 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oxia
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotificationsClose(t *testing.T) {
+	count := 0
+	ctx, cancel := context.WithCancel(context.Background())
+
+	nm := &notifications{
+		cancel: func() {
+			count++
+		},
+		ctxMultiplexChanClosed: ctx,
+		multiplexCh:            make(chan *Notification, 100),
+	}
+	nm.multiplexCh <- &Notification{
+		Key: "key1",
+	}
+	nm.multiplexCh <- &Notification{
+		Key: "key2",
+	}
+	close(nm.multiplexCh)
+
+	cancel()
+	err := nm.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	n, ok := <-nm.multiplexCh
+	assert.Equal(t, ok, false)
+	assert.Nil(t, n)
+}


### PR DESCRIPTION
The original for loop never change the initialize `n`, it will cause infinite loop when channel is not empty when close started.