### PR TITLE
chore(*): enable revive.typeassert rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -87,7 +87,7 @@ linters-settings:
             allowStrs: '""'
             allowInts: '0,1,2,3,4,5,6,7,8,9,10,11,16,17,20,22,32,64,100,128,1000,1024,0644,0755,0600'
             allowFloats: "0.0,0.,0.5,0.50,0.95,0.99,0.999,1.0,1.,2.0,2.,80.0,100.0"
-            ignoreFuncs: 'slog\.*,metrics\.*'
+            ignoreFuncs: 'slog\.*,metrics\.*,fmt\.*'
       - name: cognitive-complexity
         severity: warning
         disabled: true
@@ -174,4 +174,4 @@ issues:
     - path: server/wal/
       linters:
         - revive
-      text: "exported|unchecked-type-assertion"
+      text: "exported"

--- a/server/wal/treemap.go
+++ b/server/wal/treemap.go
@@ -1,0 +1,126 @@
+// Copyright 2023 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wal
+
+import (
+	"fmt"
+
+	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	"github.com/emirpasic/gods/utils"
+)
+
+type treeMap[K comparable, V any] struct {
+	tree *rbt.Tree
+}
+
+func newInt64TreeMap[V any]() *treeMap[int64, V] {
+	return &treeMap[int64, V]{
+		tree: rbt.NewWith(utils.Int64Comparator),
+	}
+}
+
+func (m *treeMap[K, V]) Put(key K, value V) {
+	m.tree.Put(key, value)
+}
+
+func (m *treeMap[K, V]) Get(key K) (value V, found bool) {
+	v, ok := m.tree.Get(key)
+	if !ok {
+		return *new(V), false
+	}
+
+	return m.toValue(v), true
+}
+
+func (m *treeMap[K, V]) Remove(key K) {
+	m.tree.Remove(key)
+}
+
+func (m *treeMap[K, V]) Empty() bool {
+	return m.tree.Empty()
+}
+
+func (m *treeMap[K, V]) Size() int {
+	return m.tree.Size()
+}
+
+func (m *treeMap[K, V]) Keys() []K {
+	keys := make([]K, 0, m.tree.Size())
+	m.Each(func(k K, v V) bool {
+		keys = append(keys, k)
+		return true
+	})
+	return keys
+}
+
+func (m *treeMap[K, V]) Clear() {
+	m.tree.Clear()
+}
+
+func (m *treeMap[K, V]) Min() (K, V) {
+	if node := m.tree.Left(); node != nil {
+		return m.toKey(node.Key), m.toValue(node.Value)
+	}
+
+	return *new(K), *new(V)
+}
+
+func (m *treeMap[K, V]) Max() (K, V) {
+	if node := m.tree.Right(); node != nil {
+		return m.toKey(node.Key), m.toValue(node.Value)
+	}
+
+	return *new(K), *new(V)
+}
+
+func (m *treeMap[K, V]) Floor(key K) (K, V) {
+	node, found := m.tree.Floor(key)
+	if !found {
+		return *new(K), *new(V)
+	}
+
+	return m.toKey(node.Key), m.toValue(node.Value)
+}
+
+func (m *treeMap[K, V]) String() string {
+	return m.tree.String()
+}
+
+func (m *treeMap[K, V]) Each(f func(K, V) bool) {
+	iterator := m.tree.Iterator()
+	for iterator.Next() {
+		if !f(m.toKey(iterator.Key()), m.toValue(iterator.Value())) {
+			return
+		}
+	}
+}
+
+func (*treeMap[K, V]) toKey(key any) K {
+	kk, ok := key.(K)
+	if !ok {
+		panic(fmt.Errorf("expect key %T, got %T from treemap", *new(K), key))
+	}
+
+	return kk
+}
+
+func (*treeMap[K, V]) toValue(value any) V {
+	vv, ok := value.(V)
+	if !ok {
+		panic(fmt.Errorf("expect value %T, got %T from treemap", *new(V), value))
+	}
+
+	return vv
+}

--- a/server/wal/treemap_test.go
+++ b/server/wal/treemap_test.go
@@ -1,0 +1,205 @@
+// Copyright 2023 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTreeMapPut(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	tm.Put(1, 2)
+
+	v, ok := tm.tree.Get(int64(1))
+	assert.True(t, ok)
+	assert.Equal(t, int(2), v)
+}
+
+func TestTreeMapGet(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	tm.Put(1, 2)
+
+	v, ok := tm.Get(int64(1))
+	assert.True(t, ok)
+	assert.Equal(t, int(2), v)
+
+	v, ok = tm.Get(3)
+	assert.False(t, ok)
+	assert.Equal(t, int(0), v)
+}
+
+func TestTreeMapRemove(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	tm.Put(1, 2)
+
+	v, ok := tm.Get(int64(1))
+	assert.True(t, ok)
+	assert.Equal(t, int(2), v)
+
+	tm.Remove(3)
+
+	v, ok = tm.Get(int64(1))
+	assert.True(t, ok)
+	assert.Equal(t, int(2), v)
+
+	tm.Remove(1)
+
+	v, ok = tm.Get(int64(1))
+	assert.False(t, ok)
+	assert.Equal(t, int(0), v)
+}
+
+func TestTreeMapEmpty(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	assert.True(t, tm.Empty())
+
+	tm.Put(1, 2)
+	assert.False(t, tm.Empty())
+}
+
+func TestTreeMapSize(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	assert.Equal(t, 0, tm.Size())
+
+	tm.Put(1, 2)
+	assert.Equal(t, 1, tm.Size())
+}
+
+func TestTreeMapKeys(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	assert.Equal(t, []int64{}, tm.Keys())
+
+	tm.Put(1, 2)
+	tm.Put(3, 4)
+	assert.Equal(t, []int64{1, 3}, tm.Keys())
+}
+
+func TestTreeMapClear(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+
+	tm.Put(1, 2)
+	tm.Put(3, 4)
+	assert.Equal(t, 2, tm.Size())
+
+	tm.Clear()
+	assert.Equal(t, 0, tm.Size())
+}
+
+func TestTreeMapMin(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+
+	k, v := tm.Min()
+	assert.Equal(t, int64(0), k)
+	assert.Equal(t, int(0), v)
+
+	tm.Put(1, 2)
+	tm.Put(3, 4)
+
+	k, v = tm.Min()
+	assert.Equal(t, int64(1), k)
+	assert.Equal(t, int(2), v)
+}
+
+func TestTreeMapMax(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+
+	k, v := tm.Max()
+	assert.Equal(t, int64(0), k)
+	assert.Equal(t, int(0), v)
+
+	tm.Put(1, 2)
+	tm.Put(3, 4)
+
+	k, v = tm.Max()
+	assert.Equal(t, int64(3), k)
+	assert.Equal(t, int(4), v)
+}
+
+func TestTreeMapFloor(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+
+	tm.Put(1, 2)
+	tm.Put(5, 6)
+
+	k, v := tm.Floor(3)
+	assert.Equal(t, int64(1), k)
+	assert.Equal(t, int(2), v)
+
+	k, v = tm.Floor(5)
+	assert.Equal(t, int64(5), k)
+	assert.Equal(t, int(6), v)
+
+	k, v = tm.Floor(0)
+	assert.Equal(t, int64(0), k)
+	assert.Equal(t, int(0), v)
+}
+
+func TestTreeMapString(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+
+	tm.Put(1, 2)
+	tm.Put(5, 6)
+
+	assert.Regexp(t, "RedBlackTree", tm.String())
+}
+
+func TestTreeMapEach(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+
+	tm.Put(1, 2)
+	tm.Put(5, 6)
+	tm.Put(7, 8)
+
+	var keys []int64
+	tm.Each(func(k int64, v int) bool {
+		keys = append(keys, k)
+		return true
+	})
+	assert.Equal(t, []int64{1, 5, 7}, keys)
+
+	keys = []int64{}
+	count := 0
+	tm.Each(func(k int64, v int) bool {
+		count++
+		if k > 1 {
+			return false
+		}
+
+		keys = append(keys, k)
+		return true
+	})
+	assert.Equal(t, []int64{1}, keys)
+	assert.Equal(t, 2, count)
+}
+
+func TestTreeMapToKey(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	assert.Equal(t, int64(1), tm.toKey(int64(1)))
+
+	assert.PanicsWithError(t, "expect key int64, got string from treemap", func() {
+		tm.toKey("1")
+	})
+}
+
+func TestTreeMapToValue(t *testing.T) {
+	tm := newInt64TreeMap[int]()
+	assert.Equal(t, int(1), tm.toValue(int(1)))
+
+	assert.PanicsWithError(t, "expect value int, got string from treemap", func() {
+		tm.toValue("1")
+	})
+}


### PR DESCRIPTION
Add an generic `treeMap` wrapper for `redblacktree` to simplify the wal's code to avoid use of type assert. Currently `gods` didn't have an release of generic support, after the official support of generic is released we should migrate to it.