### PR TITLE
Perform client retry on InvalidStatus error

### DIFF
--- a/oxia/internal/batch/rpc_errors.go
+++ b/oxia/internal/batch/rpc_errors.go
@@ -27,6 +27,9 @@ func isRetriable(err error) bool {
 	case codes.Unavailable:
 		// Failure to connect is ok to re-attempt
 		return true
+	case common.CodeInvalidStatus:
+		// Leader has fenced the shard, though we expect a new leader to be elected
+		return true
 	case common.CodeAlreadyClosed:
 		// Leader is closing, though we expect a new leader to be elected
 		return true

--- a/perf/perf.go
+++ b/perf/perf.go
@@ -161,14 +161,14 @@ func (p *perf) generateWriteTraffic(ctx context.Context, client oxia.AsyncClient
 			r := <-ch
 			if r.Err != nil {
 				slog.Warn(
-					"Operation has failed",
+					"Write operation has failed",
 					slog.Any("error", r.Err),
 					slog.String("key", key),
 				)
 				p.failedOps.Add(1)
 			} else {
 				slog.Debug(
-					"Operation has succeeded",
+					"Write operation has succeeded",
 					slog.String("key", key),
 					slog.Any("version", r.Version),
 				)
@@ -196,14 +196,14 @@ func (p *perf) generateReadTraffic(ctx context.Context, client oxia.AsyncClient,
 			r := <-ch
 			if r.Err != nil && !errors.Is(r.Err, oxia.ErrKeyNotFound) {
 				slog.Warn(
-					"Operation has failed",
+					"Read operation has failed",
 					slog.Any("error", r.Err),
 					slog.String("key", key),
 				)
 				p.failedOps.Add(1)
 			} else {
 				slog.Debug(
-					"Operation has succeeded",
+					"Read operation has succeeded",
 					slog.String("key", key),
 					slog.Any("version", r.Version),
 				)


### PR DESCRIPTION
The invalid status is going to be transient, so it needs to be retried (within the timeout)