### PR TITLE
Fixed wrong error returned after NewTerm failure

### DIFF
--- a/common/logging_client_rpc.go
+++ b/common/logging_client_rpc.go
@@ -16,9 +16,11 @@ package common
 
 import (
 	"context"
-	"github.com/streamnative/oxia/proto"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
+
+	"github.com/streamnative/oxia/proto"
 )
 
 type loggingClientRpc struct {

--- a/server/internal_rpc_server.go
+++ b/server/internal_rpc_server.go
@@ -123,10 +123,10 @@ func (s *internalRpcServer) NewTerm(c context.Context, req *proto.NewTermRequest
 		if err2 != nil {
 			log.Warn(
 				"NewTerm of follower failed",
-				slog.Any("error", err),
+				slog.Any("error", err2),
 			)
 		}
-		return res, err
+		return res, err2
 	}
 
 	leader, err := s.shardsDirector.GetOrCreateLeader(req.Namespace, req.ShardId)
@@ -143,11 +143,12 @@ func (s *internalRpcServer) NewTerm(c context.Context, req *proto.NewTermRequest
 			"New term processing of leader failed",
 			slog.Any("error", err),
 		)
+	} else {
+		log.Info(
+			"New term processing completed",
+			slog.Any("response", res),
+		)
 	}
-	log.Info(
-		"New term processing completed",
-		slog.Any("response", res),
-	)
 	return res, err2
 }
 


### PR DESCRIPTION
After a `NewTerm` operation fails on on a follower, the rpc server is actually returning the wrong error object `err` instead of `err2`. 

This leads to a situation where the coordinator receives a successful response, though the reply is `nil`.

Also, the actual error was not getting printed on the storage node log