### PR TITLE
Add K8S startup probe

### DIFF
--- a/deploy/charts/oxia-cluster/templates/_helpers.tpl
+++ b/deploy/charts/oxia-cluster/templates/_helpers.tpl
@@ -69,3 +69,14 @@ exec:
 initialDelaySeconds: 10
 timeoutSeconds: 10
 {{- end }}
+
+{{/*
+Probe
+*/}}
+{{- define "oxia-cluster.startup-probe" -}}
+exec:
+  command: ["oxia", "health", "--port={{ . }}"]
+initialDelaySeconds: 60
+timeoutSeconds: 10
+{{- end }}
+

--- a/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
+++ b/deploy/charts/oxia-cluster/templates/server-statefulset.yaml
@@ -66,6 +66,8 @@ spec:
             {{- include "oxia-cluster.probe" .Values.server.ports.internal | nindent 12 }}
           readinessProbe:
             {{- include "oxia-cluster.readiness-probe" .Values.server.ports.internal | nindent 12 }}
+          startupProbe:
+            {{- include "oxia-cluster.startup-probe" .Values.server.ports.internal | nindent 12 }}
   volumeClaimTemplates:
     - metadata:
         name: data


### PR DESCRIPTION
A fast sequence of rolling restarts can cause some temporary unavailability on some shards. 

The sequence is as this: 

 1. We start where `oxia-4` leader. `oxia-3` and `oxia-5` are followers
 2. `oxia-4` gets restarted
 3. Immediately, `oxia-5` is made leader and `oxia-3` a follower. `oxia-4` is not attached yet to the leader. The coordinator will keep trying until `oxia-4` comes back up
 4. `oxia-3` is restarted, before `oxia-4` was added as a follower 
 5. The shard is unavailable (to writes)
 6. Unailability resolves when the coordinator is getting `oxia-4` back in the followers list and the leader can make progress.

### Modifications

Add a startup probe that delays the rollout to the next pod by at least 1min. This slows down the deployment, but it greatly reduces the chances of deploying to a pod that is currently needed for the leader to make progres..