### PR TITLE
fix(426): discard entry and writingIdx when TruncateLog

### DIFF
--- a/server/wal/wal_rw_segment.go
+++ b/server/wal/wal_rw_segment.go
@@ -218,12 +218,12 @@ func (ms *readWriteSegment) Truncate(lastSafeOffset int64) error {
 	fileLastSafeOffset := fileOffset(ms.writingIdx, ms.baseOffset, lastSafeOffset)
 	entryLen := readInt(ms.txnMappedFile, fileLastSafeOffset)
 	fileEndOffset := fileLastSafeOffset + 4 + entryLen
-	for i := ms.currentFileOffset; i < fileEndOffset; i++ {
+	for i := fileEndOffset; i < ms.currentFileOffset; i++ {
 		ms.txnMappedFile[i] = 0
 	}
 
 	// Truncate the index
-	ms.writingIdx = ms.writingIdx[:4*(lastSafeOffset-ms.baseOffset)]
+	ms.writingIdx = ms.writingIdx[:4*(lastSafeOffset-ms.baseOffset+1)]
 
 	ms.currentFileOffset = fileEndOffset
 	ms.lastOffset = lastSafeOffset

--- a/server/wal/wal_test.go
+++ b/server/wal/wal_test.go
@@ -277,6 +277,13 @@ func TestTruncate(t *testing.T) {
 
 	assert.EqualValues(t, 2, headIndex)
 
+	// Close and Reopen the wal to ensure truncate is persistent
+	err = w.Close()
+	assert.NoError(t, err)
+
+	w, err = f.NewWal(common.DefaultNamespace, shard, nil)
+	assert.NoError(t, err)
+
 	// Read with forward reader from beginning
 	fr, err := w.NewReader(InvalidOffset)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixed: https://github.com/streamnative/oxia/issues/426