### PR TITLE
Update Alpine base image to 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,11 @@ ADD . /src/oxia
 RUN cd /src/oxia \
     && make
 
-FROM alpine:3.18.4
+FROM alpine:3.19
 
 RUN apk add --no-cache bash bash-completion
 
-# Fix CVE-2023-5363 by upgrading to OpenSSL 3.1.4-r1
+# Fix CVE-2023-5363 by upgrading to OpenSSL 3.1.4-r4
 # We can remove once new Alpine image is released
 RUN apk upgrade --no-cache libssl3 libcrypto3
 


### PR DESCRIPTION
Addressing security issues


```
oxia:latest (alpine 3.18.4)

Total: 4 (UNKNOWN: 0, LOW: 0, MEDIUM: 4, HIGH: 0, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-6129 │ MEDIUM   │ fixed  │ 3.1.4-r1          │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector      │
│            │               │          │        │                   │               │ registers on PowerPC                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6237 │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public │
│            │               │          │        │                   │               │ keys                                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                 │
├────────────┼───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-6129 │          │        │                   │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector      │
│            │               │          │        │                   │               │ registers on PowerPC                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6237 │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public │
│            │               │          │        │                   │               │ keys                                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                 │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```