### PR TITLE
Close all closers when shutting down

### DIFF
--- a/common/signal.go
+++ b/common/signal.go
@@ -39,7 +39,7 @@ func WaitUntilSignal(closers ...io.Closer) {
 				"Failed when shutting down server",
 				slog.Any("error", err),
 			)
-			os.Exit(1)
+			code = 1
 		}
 	}
 


### PR DESCRIPTION
When a closer fails during the process of shutting down closers, the others won't be closed. We should make sure to close all closers to free all resources.

