### PR TITLE
Coordinator not passing Term in delete shard request

### DIFF
--- a/coordinator/impl/shard_controller.go
+++ b/coordinator/impl/shard_controller.go
@@ -552,6 +552,7 @@ func (s *shardController) deleteShardRpc(ctx context.Context, node model.ServerA
 	_, err := s.rpc.DeleteShard(ctx, node, &proto.DeleteShardRequest{
 		Namespace: s.namespace,
 		ShardId:   s.shard,
+		Term:      s.shardMetadata.Term,
 	})
 
 	return err


### PR DESCRIPTION
Coordinator is not passing the Term field in the delete shard request, so the server will reject it