### PR TITLE
Close controller when delete shard fails

### DIFF
--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -750,6 +750,10 @@ func (fc *followerController) DeleteShard(request *proto.DeleteShardRequest) (*p
 	defer fc.Unlock()
 
 	if request.Term != fc.term {
+		fc.log.Warn("Invalid term when deleting shard",
+			slog.Int64("follower-term", fc.term),
+			slog.Int64("new-term", request.Term))
+		_ = fc.Close()
 		return nil, common.ErrorInvalidTerm
 	}
 

--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -753,7 +753,7 @@ func (fc *followerController) DeleteShard(request *proto.DeleteShardRequest) (*p
 		fc.log.Warn("Invalid term when deleting shard",
 			slog.Int64("follower-term", fc.term),
 			slog.Int64("new-term", request.Term))
-		_ = fc.Close()
+		_ = fc.close()
 		return nil, common.ErrorInvalidTerm
 	}
 

--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -833,10 +833,6 @@ func TestFollowerController_DeleteShard_WrongTerm(t *testing.T) {
 	})
 
 	assert.ErrorIs(t, err, common.ErrorInvalidTerm)
-
-	assert.NoError(t, fc.Close())
-	assert.NoError(t, kvFactory.Close())
-	assert.NoError(t, walFactory.Close())
 }
 
 func TestFollowerController_Closed(t *testing.T) {

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -969,6 +969,10 @@ func (lc *leaderController) DeleteShard(request *proto.DeleteShardRequest) (*pro
 	defer lc.Unlock()
 
 	if request.Term != lc.term {
+		lc.log.Warn("Invalid term when deleting shard",
+			slog.Int64("follower-term", lc.term),
+			slog.Int64("new-term", request.Term))
+		_ = lc.close()
 		return nil, common.ErrorInvalidTerm
 	}
 


### PR DESCRIPTION
If a `DeleteShard` operation fails for invalid term, we must close the controllers, otherwise it will go into a slowly growing resource leak and it will prevent the eventual deletion of the shard, since the DB will always be locked.