### PR TITLE
Use `Recreate` rollout strategy for coordinator deployment

### DIFF
--- a/deploy/charts/oxia-cluster/templates/coordinator-deployment.yaml
+++ b/deploy/charts/oxia-cluster/templates/coordinator-deployment.yaml
@@ -23,6 +23,8 @@ spec:
   selector:
     matchLabels:
       {{- include "oxia-cluster.coordinator.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
For coordinator deployment, it's better to first stop the pod with the old coordinator and then spin up the new pod, avoiding having 2 coordinators running at the same time. 

While there's no correctness issue, we would avoid a brief period or error/retries.