### PR TITLE
Fixed session expiry with multiple session in a shard

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -17,11 +17,12 @@ package server
 import (
 	"context"
 	"fmt"
-	"github.com/streamnative/oxia/common"
 	"log/slog"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/streamnative/oxia/common"
 
 	"github.com/streamnative/oxia/proto"
 )

--- a/server/session_manager_test.go
+++ b/server/session_manager_test.go
@@ -352,6 +352,7 @@ func TestMultipleSessionsExpiry(t *testing.T) {
 			SessionId: &sessionId1,
 		}},
 	})
+	assert.NoError(t, err)
 
 	_, err = lc.Write(context.Background(), &proto.WriteRequest{
 		ShardId: &shardId,
@@ -361,6 +362,7 @@ func TestMultipleSessionsExpiry(t *testing.T) {
 			SessionId: &sessionId2,
 		}},
 	})
+	assert.NoError(t, err)
 
 	// Let session-2 expire and verify its key was deleted
 	assert.Eventually(t, func() bool {


### PR DESCRIPTION
When multiple session are presents on a shards, depending on the key ordering, it was possible that during expiration the index cleanup was also removing index from other session.

That resulted in the ephemeral keys for other session not getting removed when those session expired too.