### PR TITLE
Watch config changes

### DIFF
--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -53,13 +53,7 @@ func init() {
 	Cmd.Flags().StringVarP(&configFile, "conf", "f", "", "Cluster config file")
 	Cmd.Flags().DurationVar(&conf.ClusterConfigRefreshTime, "conf-file-refresh-time", 1*time.Minute, "How frequently to check for updates for cluster configuration file")
 
-	if configFile == "" {
-		viper.AddConfigPath("/oxia/conf")
-		viper.AddConfigPath(".")
-	} else {
-		viper.SetConfigFile(configFile)
-	}
-
+	setConfigPath()
 	viper.OnConfigChange(func(_ fsnotify.Event) {
 		configChangeCh <- struct{}{}
 	})
@@ -81,7 +75,17 @@ func validate(*cobra.Command, []string) error {
 	return nil
 }
 
+func setConfigPath() {
+	if configFile == "" {
+		viper.AddConfigPath("/oxia/conf")
+		viper.AddConfigPath(".")
+	} else {
+		viper.SetConfigFile(configFile)
+	}
+}
+
 func loadClusterConfig() (model.ClusterConfig, chan struct{}, error) {
+	setConfigPath()
 	cc := model.ClusterConfig{}
 
 	if err := viper.ReadInConfig(); err != nil {

--- a/cmd/coordinator/cmd.go
+++ b/cmd/coordinator/cmd.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -29,8 +30,9 @@ import (
 )
 
 var (
-	conf       = coordinator.NewConfig()
-	configFile string
+	conf           = coordinator.NewConfig()
+	configFile     string
+	configChangeCh chan struct{}
 
 	Cmd = &cobra.Command{
 		Use:     "coordinator",
@@ -50,6 +52,18 @@ func init() {
 	Cmd.Flags().StringVar(&conf.FileMetadataPath, "file-clusters-status-path", "data/cluster-status.json", "The path where the cluster status is stored when using 'file' provider")
 	Cmd.Flags().StringVarP(&configFile, "conf", "f", "", "Cluster config file")
 	Cmd.Flags().DurationVar(&conf.ClusterConfigRefreshTime, "conf-file-refresh-time", 1*time.Minute, "How frequently to check for updates for cluster configuration file")
+
+	if configFile == "" {
+		viper.AddConfigPath("/oxia/conf")
+		viper.AddConfigPath(".")
+	} else {
+		viper.SetConfigFile(configFile)
+	}
+
+	viper.OnConfigChange(func(_ fsnotify.Event) {
+		configChangeCh <- struct{}{}
+	})
+	viper.WatchConfig()
 }
 
 func validate(*cobra.Command, []string) error {
@@ -61,31 +75,24 @@ func validate(*cobra.Command, []string) error {
 			return errors.New("k8s-configmap-name must be set with metadata=configmap")
 		}
 	}
-	if _, err := loadClusterConfig(); err != nil {
+	if _, _, err := loadClusterConfig(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func loadClusterConfig() (model.ClusterConfig, error) {
-	if configFile == "" {
-		viper.AddConfigPath("/oxia/conf")
-		viper.AddConfigPath(".")
-	} else {
-		viper.SetConfigFile(configFile)
-	}
-
+func loadClusterConfig() (model.ClusterConfig, chan struct{}, error) {
 	cc := model.ClusterConfig{}
 
 	if err := viper.ReadInConfig(); err != nil {
-		return cc, err
+		return cc, configChangeCh, err
 	}
 
 	if err := viper.Unmarshal(&cc); err != nil {
-		return cc, err
+		return cc, configChangeCh, err
 	}
 
-	return cc, nil
+	return cc, configChangeCh, nil
 }
 
 func exec(*cobra.Command, []string) {

--- a/cmd/coordinator/cmd_test.go
+++ b/cmd/coordinator/cmd_test.go
@@ -156,7 +156,7 @@ func TestCmd(t *testing.T) {
 				assert.Equal(t, test.expectedConf, conf)
 
 				conf.ClusterConfigProvider = loadClusterConfig
-				clusterConf, err := conf.ClusterConfigProvider()
+				clusterConf, _, err := conf.ClusterConfigProvider()
 				assert.NoError(t, err)
 				assert.Equal(t, test.expectedClusterConf, clusterConf)
 			}

--- a/coordinator/coordinator.go
+++ b/coordinator/coordinator.go
@@ -39,7 +39,7 @@ type Config struct {
 	K8SMetadataNamespace      string
 	K8SMetadataConfigMapName  string
 	FileMetadataPath          string
-	ClusterConfigProvider     func() (model.ClusterConfig, error)
+	ClusterConfigProvider     func() (model.ClusterConfig, chan struct{}, error)
 	ClusterConfigRefreshTime  time.Duration
 }
 

--- a/coordinator/impl/coordinator_e2e_test.go
+++ b/coordinator/impl/coordinator_e2e_test.go
@@ -70,7 +70,7 @@ func TestCoordinatorE2E(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, NewRpcProvider(clientPool))
+	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, NewRpcProvider(clientPool))
 
 	assert.NoError(t, err)
 
@@ -108,7 +108,7 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, NewRpcProvider(clientPool))
+	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 
 	cs := coordinator.ClusterStatus()
@@ -161,7 +161,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, NewRpcProvider(clientPool))
+	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 
 	nsStatus := coordinator.ClusterStatus().Namespaces[common.DefaultNamespace]
@@ -264,7 +264,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, NewRpcProvider(clientPool))
+	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 
 	nsDefaultStatus := coordinator.ClusterStatus().Namespaces[common.DefaultNamespace]
@@ -355,7 +355,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, NewRpcProvider(clientPool))
+	coordinator, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 
 	ns1Status := coordinator.ClusterStatus().Namespaces["my-ns-1"]
@@ -400,7 +400,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 		Servers:    []model.ServerAddress{sa1, sa2, sa3},
 	}
 
-	coordinator, err = NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return newClusterConfig, nil }, 0, NewRpcProvider(clientPool))
+	coordinator, err = NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return newClusterConfig, nil, nil }, 0, NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 
 	// Wait for all shards to be deleted
@@ -437,8 +437,8 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	configProvider := func() (model.ClusterConfig, error) {
-		return clusterConfig, nil
+	configProvider := func() (model.ClusterConfig, chan struct{}, error) {
+		return clusterConfig, nil, nil
 	}
 
 	coordinator, err := NewCoordinator(metadataProvider, configProvider, 1*time.Second, NewRpcProvider(clientPool))
@@ -524,10 +524,10 @@ func TestCoordinator_RebalanceCluster(t *testing.T) {
 	clientPool := common.NewClientPool(nil)
 	mutex := &sync.Mutex{}
 
-	configProvider := func() (model.ClusterConfig, error) {
+	configProvider := func() (model.ClusterConfig, chan struct{}, error) {
 		mutex.Lock()
 		defer mutex.Unlock()
-		return clusterConfig, nil
+		return clusterConfig, nil, nil
 	}
 
 	coordinator, err := NewCoordinator(metadataProvider, configProvider, 1*time.Second, NewRpcProvider(clientPool))
@@ -620,8 +620,8 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	configProvider := func() (model.ClusterConfig, error) {
-		return clusterConfig, nil
+	configProvider := func() (model.ClusterConfig, chan struct{}, error) {
+		return clusterConfig, nil, nil
 	}
 
 	c, err := NewCoordinator(metadataProvider, configProvider, 1*time.Second, NewRpcProvider(clientPool))
@@ -679,8 +679,8 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	}
 	clientPool := common.NewClientPool(nil)
 
-	configProvider := func() (model.ClusterConfig, error) {
-		return clusterConfig, nil
+	configProvider := func() (model.ClusterConfig, chan struct{}, error) {
+		return clusterConfig, nil, nil
 	}
 
 	c, err := NewCoordinator(metadataProvider, configProvider, 1*time.Second, NewRpcProvider(clientPool))

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/edsrzf/mmap-go v1.1.0
 	github.com/emirpasic/gods v1.18.1
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
@@ -69,7 +70,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/getsentry/sentry-go v0.21.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/maelstrom/main.go
+++ b/maelstrom/main.go
@@ -173,7 +173,7 @@ func main() {
 
 		_, err := impl.NewCoordinator(
 			impl.NewMetadataProviderFile(filepath.Join(dataDir, "cluster-status.json")),
-			func() (model.ClusterConfig, error) { return clusterConfig, nil },
+			func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil },
 			0, newRpcProvider(dispatcher))
 		if err != nil {
 			slog.Error(

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -122,7 +122,7 @@ func TestClusterHandshakeSuccess(t *testing.T) {
 	clientPool := common.NewClientPool(tlsConf)
 	defer clientPool.Close()
 
-	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, impl.NewRpcProvider(clientPool))
+	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, impl.NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 	defer coordinator.Close()
 }
@@ -152,7 +152,7 @@ func TestClientHandshakeFailByNoTlsConfig(t *testing.T) {
 	clientPool := common.NewClientPool(tlsConf)
 	defer clientPool.Close()
 
-	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, impl.NewRpcProvider(clientPool))
+	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, impl.NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 	defer coordinator.Close()
 
@@ -185,7 +185,7 @@ func TestClientHandshakeByAuthFail(t *testing.T) {
 	clientPool := common.NewClientPool(tlsConf)
 	defer clientPool.Close()
 
-	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, impl.NewRpcProvider(clientPool))
+	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, impl.NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 	defer coordinator.Close()
 
@@ -224,7 +224,7 @@ func TestClientHandshakeWithInsecure(t *testing.T) {
 	clientPool := common.NewClientPool(tlsConf)
 	defer clientPool.Close()
 
-	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, impl.NewRpcProvider(clientPool))
+	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, impl.NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 	defer coordinator.Close()
 
@@ -265,7 +265,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 	clientPool := common.NewClientPool(tlsConf)
 	defer clientPool.Close()
 
-	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, 0, impl.NewRpcProvider(clientPool))
+	coordinator, err := impl.NewCoordinator(metadataProvider, func() (model.ClusterConfig, chan struct{}, error) { return clusterConfig, nil, nil }, 0, impl.NewRpcProvider(clientPool))
 	assert.NoError(t, err)
 	defer coordinator.Close()
 


### PR DESCRIPTION
Fixes https://github.com/streamnative/oxia/issues/461

Not only rely on `clusterConfigRefreshTime`. Support watch conf changes and trigger cluster rebalance.