### PR TITLE
doc: add file type to avoid confusing

### DIFF
--- a/docs/bare-metal-deploy.md
+++ b/docs/bare-metal-deploy.md
@@ -70,7 +70,7 @@ Global Flags:
 
 Since the coordinator is brain-like in the oxia cluster, it should have some configurations to help it to make decisions.
 
-We can create it in the specific path you need. the configuration template is as follows. 
+We can create it in the specific path you need. the configuration template `oxia_conf.yaml` is as follows. 
 
 ```yaml
 namespaces:


### PR DESCRIPTION
In the demo of bare mental deploy. we didn't specify the config file type. it might confuse some users and block them adopt oxia.