### PR TITLE
server: introduce filter component to filter internal key

### DIFF
--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -637,9 +637,7 @@ func TestSyncClientImpl_PartitionRouting(t *testing.T) {
 	assert.Equal(t, "1", string(value))
 
 	key, value, _, err = client.Get(ctx, "a", ComparisonHigher(), PartitionKey("wrong-partition-key"))
-	assert.NoError(t, err)
-	assert.NotEqual(t, "b", key)
-	assert.NotEqual(t, "1", string(value))
+	assert.ErrorIs(t, err, ErrKeyNotFound)
 
 	// Delete with wrong partition key would fail to delete all keys
 	err = client.DeleteRange(ctx, "c", "e", PartitionKey("wrong-partition-key"))

--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -636,7 +636,7 @@ func TestSyncClientImpl_PartitionRouting(t *testing.T) {
 	assert.Equal(t, "b", key)
 	assert.Equal(t, "1", string(value))
 
-	key, value, _, err = client.Get(ctx, "a", ComparisonHigher(), PartitionKey("wrong-partition-key"))
+	_, _, _, err = client.Get(ctx, "a", ComparisonHigher(), PartitionKey("wrong-partition-key"))
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 
 	// Delete with wrong partition key would fail to delete all keys

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -77,6 +77,7 @@ type DB interface {
 	// Delete and close the database and all its files
 	Delete() error
 
+	// GetWithFilter Get with the specific key Filter
 	GetWithFilter(request *proto.GetRequest, filter Filter) (*proto.GetResponse, error)
 }
 

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -64,7 +64,6 @@ type DB interface {
 	Get(request *proto.GetRequest) (*proto.GetResponse, error)
 	List(request *proto.ListRequest) (KeyIterator, error)
 	RangeScan(request *proto.RangeScanRequest) (RangeScanIterator, error)
-
 	ReadCommitOffset() (int64, error)
 
 	ReadNextNotifications(ctx context.Context, startOffset int64) ([]*proto.NotificationBatch, error)

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -270,7 +270,7 @@ func (it *listIterator) Close() error {
 func (d *db) List(request *proto.ListRequest) (KeyIterator, error) {
 	d.listCounter.Add(1)
 
-	it, err := d.kv.KeyRangeScan(request.StartInclusive, request.EndExclusive, InternalKeyFilter)
+	it, err := d.kv.KeyRangeScan(request.StartInclusive, request.EndExclusive)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (it *rangeScanIterator) Close() error {
 func (d *db) RangeScan(request *proto.RangeScanRequest) (RangeScanIterator, error) {
 	d.rangeScanCounter.Add(1)
 
-	it, err := d.kv.RangeScan(request.StartInclusive, request.EndExclusive, InternalKeyFilter)
+	it, err := d.kv.RangeScan(request.StartInclusive, request.EndExclusive)
 	if err != nil {
 		return nil, err
 	}

--- a/server/kv/filter.go
+++ b/server/kv/filter.go
@@ -15,13 +15,14 @@
 package kv
 
 import (
-	"github.com/streamnative/oxia/common"
 	"strings"
+
+	"github.com/streamnative/oxia/common"
 )
 
 type Filter func(key string) bool
 
-func DisableFilter(key string) bool {
+func DisableFilter(_ string) bool {
 	return false
 }
 

--- a/server/kv/filter.go
+++ b/server/kv/filter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/streamnative/oxia/common"
 )
 
+// Filter used for key filtering
 type Filter func(key string) bool
 
 func DisableFilter(_ string) bool {

--- a/server/kv/filter.go
+++ b/server/kv/filter.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package kv
 
 import (

--- a/server/kv/filter.go
+++ b/server/kv/filter.go
@@ -20,7 +20,7 @@ import (
 	"github.com/streamnative/oxia/common"
 )
 
-// Filter used for key filtering
+// Filter used for key filtering.
 type Filter func(key string) bool
 
 func DisableFilter(_ string) bool {

--- a/server/kv/filter.go
+++ b/server/kv/filter.go
@@ -1,0 +1,16 @@
+package kv
+
+import (
+	"github.com/streamnative/oxia/common"
+	"strings"
+)
+
+type Filter func(key string) bool
+
+func DisableFilter(key string) bool {
+	return false
+}
+
+func InternalKeyFilter(key string) bool {
+	return strings.HasPrefix(key, common.InternalKeyPrefix)
+}

--- a/server/kv/kv.go
+++ b/server/kv/kv.go
@@ -114,7 +114,6 @@ type KV interface {
 	Get(key string, comparisonType ComparisonType, filter Filter) (storedKey string, value []byte, closer io.Closer, err error)
 
 	KeyRangeScan(lowerBound, upperBound string) (KeyIterator, error)
-
 	KeyRangeScanReverse(lowerBound, upperBound string) (ReverseKeyIterator, error)
 
 	RangeScan(lowerBound, upperBound string) (KeyValueIterator, error)

--- a/server/kv/kv.go
+++ b/server/kv/kv.go
@@ -15,8 +15,9 @@
 package kv
 
 import (
-	"github.com/streamnative/oxia/proto"
 	"io"
+
+	"github.com/streamnative/oxia/proto"
 
 	"github.com/pkg/errors"
 )
@@ -112,11 +113,11 @@ type KV interface {
 
 	Get(key string, comparisonType ComparisonType, filter Filter) (storedKey string, value []byte, closer io.Closer, err error)
 
-	KeyRangeScan(lowerBound, upperBound string, filter Filter) (KeyIterator, error)
+	KeyRangeScan(lowerBound, upperBound string) (KeyIterator, error)
 
-	KeyRangeScanReverse(lowerBound, upperBound string, filter Filter) (ReverseKeyIterator, error)
+	KeyRangeScanReverse(lowerBound, upperBound string) (ReverseKeyIterator, error)
 
-	RangeScan(lowerBound, upperBound string, filter Filter) (KeyValueIterator, error)
+	RangeScan(lowerBound, upperBound string) (KeyValueIterator, error)
 
 	Snapshot() (Snapshot, error)
 

--- a/server/kv/kv.go
+++ b/server/kv/kv.go
@@ -15,9 +15,8 @@
 package kv
 
 import (
-	"io"
-
 	"github.com/streamnative/oxia/proto"
+	"io"
 
 	"github.com/pkg/errors"
 )
@@ -111,12 +110,13 @@ type KV interface {
 
 	NewWriteBatch() WriteBatch
 
-	Get(key string, comparisonType ComparisonType) (storedKey string, value []byte, closer io.Closer, err error)
+	Get(key string, comparisonType ComparisonType, filter Filter) (storedKey string, value []byte, closer io.Closer, err error)
 
-	KeyRangeScan(lowerBound, upperBound string) (KeyIterator, error)
-	KeyRangeScanReverse(lowerBound, upperBound string) (ReverseKeyIterator, error)
+	KeyRangeScan(lowerBound, upperBound string, filter Filter) (KeyIterator, error)
 
-	RangeScan(lowerBound, upperBound string) (KeyValueIterator, error)
+	KeyRangeScanReverse(lowerBound, upperBound string, filter Filter) (ReverseKeyIterator, error)
+
+	RangeScan(lowerBound, upperBound string, filter Filter) (KeyValueIterator, error)
 
 	Snapshot() (Snapshot, error)
 

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -391,6 +391,7 @@ func (p *Pebble) getCeiling(key string, filter Filter) (returnedKey string, valu
 	}
 
 	for {
+		returnedKey = string(it.Key())
 		if !filter(key) {
 			break
 		} else if !it.Next() {
@@ -415,6 +416,7 @@ func (p *Pebble) getLower(key string, filter Filter) (returnedKey string, value 
 	}
 
 	for {
+		returnedKey = string(it.Key())
 		if !filter(key) {
 			break
 		} else if !it.Prev() {
@@ -448,12 +450,11 @@ func (p *Pebble) getHigher(key string, filter Filter) (returnedKey string, value
 		if !it.Next() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 		}
-		returnedKey = string(it.Key())
 	}
 
 	for {
+		returnedKey = string(it.Key())
 		if !filter(returnedKey) {
-			returnedKey = string(it.Key())
 			break
 		} else if !it.Next() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -448,7 +448,6 @@ func (p *Pebble) getHigher(key string, filter Filter) (returnedKey string, value
 		if !it.Next() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 		}
-		returnedKey = string(it.Key())
 	}
 
 	for {
@@ -493,11 +492,11 @@ func (p *Pebble) Get(key string, comparisonType ComparisonType, filter Filter) (
 	return returnedKey, value, closer, err
 }
 
-func (p *Pebble) KeyRangeScan(lowerBound, upperBound string, filter Filter) (KeyIterator, error) {
-	return p.RangeScan(lowerBound, upperBound, filter)
+func (p *Pebble) KeyRangeScan(lowerBound, upperBound string) (KeyIterator, error) {
+	return p.RangeScan(lowerBound, upperBound)
 }
 
-func (p *Pebble) KeyRangeScanReverse(lowerBound, upperBound string, filter Filter) (ReverseKeyIterator, error) {
+func (p *Pebble) KeyRangeScanReverse(lowerBound, upperBound string) (ReverseKeyIterator, error) {
 	opts := &pebble.IterOptions{}
 	if lowerBound != "" {
 		opts.LowerBound = []byte(lowerBound)
@@ -513,7 +512,7 @@ func (p *Pebble) KeyRangeScanReverse(lowerBound, upperBound string, filter Filte
 	return &PebbleReverseIterator{p, pbit}, nil
 }
 
-func (p *Pebble) RangeScan(lowerBound, upperBound string, filter Filter) (KeyValueIterator, error) {
+func (p *Pebble) RangeScan(lowerBound, upperBound string) (KeyValueIterator, error) {
 	opts := &pebble.IterOptions{}
 	if lowerBound != "" {
 		opts.LowerBound = []byte(lowerBound)

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -448,10 +448,11 @@ func (p *Pebble) getHigher(key string, filter Filter) (returnedKey string, value
 		if !it.Next() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
 		}
+		returnedKey = string(it.Key())
 	}
 
 	for {
-		if !filter(key) {
+		if !filter(returnedKey) {
 			returnedKey = string(it.Key())
 			break
 		} else if !it.Next() {

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -392,7 +392,7 @@ func (p *Pebble) getCeiling(key string, filter Filter) (returnedKey string, valu
 
 	for {
 		returnedKey = string(it.Key())
-		if !filter(key) {
+		if !filter(returnedKey) {
 			break
 		} else if !it.Next() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)
@@ -416,7 +416,7 @@ func (p *Pebble) getLower(key string, filter Filter) (returnedKey string, value 
 
 	for {
 		returnedKey = string(it.Key())
-		if !filter(key) {
+		if !filter(returnedKey) {
 			break
 		} else if !it.Prev() {
 			return "", nil, nil, multierr.Combine(it.Close(), pebble.ErrNotFound)

--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -399,7 +399,6 @@ func (p *Pebble) getCeiling(key string, filter Filter) (returnedKey string, valu
 		}
 	}
 
-	returnedKey = string(it.Key())
 	value, err = it.ValueAndErr()
 	return returnedKey, value, it, err
 }
@@ -424,7 +423,6 @@ func (p *Pebble) getLower(key string, filter Filter) (returnedKey string, value 
 		}
 	}
 
-	returnedKey = string(it.Key())
 	value, err = it.ValueAndErr()
 	return returnedKey, value, it, err
 }

--- a/server/kv/kv_pebble_test.go
+++ b/server/kv/kv_pebble_test.go
@@ -118,7 +118,7 @@ func TestPebbbleKeyRangeScan(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.KeyRangeScan("/root/a", "/root/c", DisableFilter)
+	it, err := kv.KeyRangeScan("/root/a", "/root/c")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -134,7 +134,7 @@ func TestPebbbleKeyRangeScan(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// Scan with empty result
-	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c", DisableFilter)
+	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c")
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -157,7 +157,7 @@ func TestPebbbleKeyRangeScanReverse(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.KeyRangeScanReverse("/root/a", "/root/c", DisableFilter)
+	it, err := kv.KeyRangeScanReverse("/root/a", "/root/c")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -173,7 +173,7 @@ func TestPebbbleKeyRangeScanReverse(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// Scan with empty result
-	it, err = kv.KeyRangeScanReverse("/xyz/a", "/xyz/c", DisableFilter)
+	it, err = kv.KeyRangeScanReverse("/xyz/a", "/xyz/c")
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -196,7 +196,7 @@ func TestPebbleRangeScan(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.RangeScan("/root/a", "/root/c", DisableFilter)
+	it, err := kv.RangeScan("/root/a", "/root/c")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -218,7 +218,7 @@ func TestPebbleRangeScan(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// Scan with empty result
-	it, err = kv.RangeScan("/xyz/a", "/xyz/c", DisableFilter)
+	it, err = kv.RangeScan("/xyz/a", "/xyz/c")
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -251,7 +251,7 @@ func TestPebbleRangeScanWithSlashOrder(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.KeyRangeScan("/a/b/a/", "/a/b/a//", DisableFilter)
+	it, err := kv.KeyRangeScan("/a/b/a/", "/a/b/a//")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -409,7 +409,7 @@ func TestPebbbleRangeScanInBatch(t *testing.T) {
 	assert.NoError(t, wb.Close())
 
 	// Scan with empty result
-	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c", DisableFilter)
+	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c")
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -661,7 +661,7 @@ func TestPebbleRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, wb.Close())
 
 	// No max
-	it, err := kv.RangeScan("/root/b", "", DisableFilter)
+	it, err := kv.RangeScan("/root/b", "")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -690,7 +690,7 @@ func TestPebbleRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min
-	it, err = kv.RangeScan("", "/root/c", DisableFilter)
+	it, err = kv.RangeScan("", "/root/c")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -712,7 +712,7 @@ func TestPebbleRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min and max
-	it, err = kv.RangeScan("", "", DisableFilter)
+	it, err = kv.RangeScan("", "")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -766,7 +766,7 @@ func TestPebbleReverseRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, wb.Close())
 
 	// No max
-	it, err := kv.KeyRangeScanReverse("/root/b", "", DisableFilter)
+	it, err := kv.KeyRangeScanReverse("/root/b", "")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -786,7 +786,7 @@ func TestPebbleReverseRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min
-	it, err = kv.KeyRangeScanReverse("", "/root/c", DisableFilter)
+	it, err = kv.KeyRangeScanReverse("", "/root/c")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -802,7 +802,7 @@ func TestPebbleReverseRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min and max
-	it, err = kv.KeyRangeScanReverse("", "", DisableFilter)
+	it, err = kv.KeyRangeScanReverse("", "")
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())

--- a/server/kv/kv_pebble_test.go
+++ b/server/kv/kv_pebble_test.go
@@ -43,25 +43,25 @@ func TestPebbbleSimple(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	key, res, closer, err := kv.Get("a", ComparisonEqual)
+	key, res, closer, err := kv.Get("a", ComparisonEqual, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "0", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("b", ComparisonEqual)
+	key, res, closer, err = kv.Get("b", ComparisonEqual, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "b", key)
 	assert.Equal(t, "1", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("c", ComparisonEqual)
+	key, res, closer, err = kv.Get("c", ComparisonEqual, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", key)
 	assert.Equal(t, "2", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("non-existing", ComparisonEqual)
+	key, res, closer, err = kv.Get("non-existing", ComparisonEqual, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
@@ -76,25 +76,25 @@ func TestPebbbleSimple(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	key, res, closer, err = kv.Get("a", ComparisonEqual)
+	key, res, closer, err = kv.Get("a", ComparisonEqual, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "00", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("b", ComparisonEqual)
+	key, res, closer, err = kv.Get("b", ComparisonEqual, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "b", key)
 	assert.Equal(t, "11", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("c", ComparisonEqual)
+	key, res, closer, err = kv.Get("c", ComparisonEqual, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
 	assert.Nil(t, closer)
 
-	key, res, closer, err = kv.Get("d", ComparisonEqual)
+	key, res, closer, err = kv.Get("d", ComparisonEqual, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "d", key)
 	assert.Equal(t, "22", string(res))
@@ -118,7 +118,7 @@ func TestPebbbleKeyRangeScan(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.KeyRangeScan("/root/a", "/root/c")
+	it, err := kv.KeyRangeScan("/root/a", "/root/c", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -134,7 +134,7 @@ func TestPebbbleKeyRangeScan(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// Scan with empty result
-	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c")
+	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c", DisableFilter)
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -157,7 +157,7 @@ func TestPebbbleKeyRangeScanReverse(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.KeyRangeScanReverse("/root/a", "/root/c")
+	it, err := kv.KeyRangeScanReverse("/root/a", "/root/c", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -173,7 +173,7 @@ func TestPebbbleKeyRangeScanReverse(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// Scan with empty result
-	it, err = kv.KeyRangeScanReverse("/xyz/a", "/xyz/c")
+	it, err = kv.KeyRangeScanReverse("/xyz/a", "/xyz/c", DisableFilter)
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -196,7 +196,7 @@ func TestPebbleRangeScan(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.RangeScan("/root/a", "/root/c")
+	it, err := kv.RangeScan("/root/a", "/root/c", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -218,7 +218,7 @@ func TestPebbleRangeScan(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// Scan with empty result
-	it, err = kv.RangeScan("/xyz/a", "/xyz/c")
+	it, err = kv.RangeScan("/xyz/a", "/xyz/c", DisableFilter)
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -251,7 +251,7 @@ func TestPebbleRangeScanWithSlashOrder(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	it, err := kv.KeyRangeScan("/a/b/a/", "/a/b/a//")
+	it, err := kv.KeyRangeScan("/a/b/a/", "/a/b/a//", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -351,7 +351,7 @@ func TestPebbbleDurability(t *testing.T) {
 		kv, err := factory.NewKV(common.DefaultNamespace, 1)
 		assert.NoError(t, err)
 
-		key, res, closer, err := kv.Get("a", ComparisonEqual)
+		key, res, closer, err := kv.Get("a", ComparisonEqual, DisableFilter)
 		assert.NoError(t, err)
 		assert.Equal(t, "a", key)
 		assert.Equal(t, "0", string(res))
@@ -409,7 +409,7 @@ func TestPebbbleRangeScanInBatch(t *testing.T) {
 	assert.NoError(t, wb.Close())
 
 	// Scan with empty result
-	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c")
+	it, err = kv.KeyRangeScan("/xyz/a", "/xyz/c", DisableFilter)
 	assert.NoError(t, err)
 	assert.False(t, it.Valid())
 	assert.NoError(t, it.Close())
@@ -445,13 +445,13 @@ func TestPebbbleDeleteRangeInBatch(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	key, res, closer, err := kv.Get("/a/b/a/a", ComparisonEqual)
+	key, res, closer, err := kv.Get("/a/b/a/a", ComparisonEqual, DisableFilter)
 	assert.Nil(t, res)
 	assert.Nil(t, closer)
 	assert.Equal(t, "", key)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 
-	key, res, closer, err = kv.Get("/a/a/a/zzzzzz", ComparisonEqual)
+	key, res, closer, err = kv.Get("/a/a/a/zzzzzz", ComparisonEqual, DisableFilter)
 	assert.Nil(t, err)
 	assert.Equal(t, "/a/a/a/zzzzzz", key)
 	assert.Equal(t, "/a/a/a/zzzzzz", string(res))
@@ -551,7 +551,7 @@ func TestPebbleSnapshot(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			for j := 0; j < 100; j++ {
 				k := fmt.Sprintf("key-%d-%d", i, j)
-				key, r, closer, err := kv2.Get(k, ComparisonEqual)
+				key, r, closer, err := kv2.Get(k, ComparisonEqual, DisableFilter)
 				assert.NoError(t, err)
 				assert.Equal(t, k, key)
 				assert.Equal(t, fmt.Sprintf("value-%d-%d", i, j), string(r))
@@ -628,7 +628,7 @@ func TestPebbleSnapshot_Loader(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		for j := 0; j < 100; j++ {
 			k := fmt.Sprintf("key-%d-%d", i, j)
-			key, r, closer, err := kv2.Get(k, ComparisonEqual)
+			key, r, closer, err := kv2.Get(k, ComparisonEqual, DisableFilter)
 			assert.NoError(t, err)
 			assert.Equal(t, k, key)
 			assert.Equal(t, fmt.Sprintf("value-%d-%d", i, j), string(r))
@@ -636,7 +636,7 @@ func TestPebbleSnapshot_Loader(t *testing.T) {
 		}
 	}
 
-	key, r, closer, err := kv2.Get("my-key", ComparisonEqual)
+	key, r, closer, err := kv2.Get("my-key", ComparisonEqual, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, r)
@@ -661,7 +661,7 @@ func TestPebbleRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, wb.Close())
 
 	// No max
-	it, err := kv.RangeScan("/root/b", "")
+	it, err := kv.RangeScan("/root/b", "", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -690,7 +690,7 @@ func TestPebbleRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min
-	it, err = kv.RangeScan("", "/root/c")
+	it, err = kv.RangeScan("", "/root/c", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -712,7 +712,7 @@ func TestPebbleRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min and max
-	it, err = kv.RangeScan("", "")
+	it, err = kv.RangeScan("", "", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -766,7 +766,7 @@ func TestPebbleReverseRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, wb.Close())
 
 	// No max
-	it, err := kv.KeyRangeScanReverse("/root/b", "")
+	it, err := kv.KeyRangeScanReverse("/root/b", "", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -786,7 +786,7 @@ func TestPebbleReverseRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min
-	it, err = kv.KeyRangeScanReverse("", "/root/c")
+	it, err = kv.KeyRangeScanReverse("", "/root/c", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -802,7 +802,7 @@ func TestPebbleReverseRangeScanNoLimits(t *testing.T) {
 	assert.NoError(t, it.Close())
 
 	// No min and max
-	it, err = kv.KeyRangeScanReverse("", "")
+	it, err = kv.KeyRangeScanReverse("", "", DisableFilter)
 	assert.NoError(t, err)
 
 	assert.True(t, it.Valid())
@@ -835,25 +835,25 @@ func TestPebbbleFloorCeiling(t *testing.T) {
 	kv, err := factory.NewKV(common.DefaultNamespace, 1)
 	assert.NoError(t, err)
 
-	key, res, closer, err := kv.Get("e", ComparisonFloor)
+	key, res, closer, err := kv.Get("e", ComparisonFloor, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
 	assert.Nil(t, closer)
 
-	key, res, closer, err = kv.Get("e", ComparisonCeiling)
+	key, res, closer, err = kv.Get("e", ComparisonCeiling, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
 	assert.Nil(t, closer)
 
-	key, res, closer, err = kv.Get("e", ComparisonLower)
+	key, res, closer, err = kv.Get("e", ComparisonLower, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
 	assert.Nil(t, closer)
 
-	key, res, closer, err = kv.Get("e", ComparisonHigher)
+	key, res, closer, err = kv.Get("e", ComparisonHigher, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
@@ -870,62 +870,62 @@ func TestPebbbleFloorCeiling(t *testing.T) {
 	assert.NoError(t, wb.Commit())
 	assert.NoError(t, wb.Close())
 
-	key, res, closer, err = kv.Get("a", ComparisonEqual)
+	key, res, closer, err = kv.Get("a", ComparisonEqual, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "0", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("a", ComparisonFloor)
+	key, res, closer, err = kv.Get("a", ComparisonFloor, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "0", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("a", ComparisonCeiling)
+	key, res, closer, err = kv.Get("a", ComparisonCeiling, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "0", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("a", ComparisonLower)
+	key, res, closer, err = kv.Get("a", ComparisonLower, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
 	assert.Nil(t, closer)
 
-	key, res, closer, err = kv.Get("a", ComparisonHigher)
+	key, res, closer, err = kv.Get("a", ComparisonHigher, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", key)
 	assert.Equal(t, "2", string(res))
 	assert.NoError(t, closer.Close())
 
 	// ---------------------------------------------------------------
-	key, res, closer, err = kv.Get("b", ComparisonEqual)
+	key, res, closer, err = kv.Get("b", ComparisonEqual, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)
 	assert.Nil(t, closer)
 
-	key, res, closer, err = kv.Get("b", ComparisonFloor)
+	key, res, closer, err = kv.Get("b", ComparisonFloor, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "0", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("b", ComparisonCeiling)
+	key, res, closer, err = kv.Get("b", ComparisonCeiling, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", key)
 	assert.Equal(t, "2", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("b", ComparisonLower)
+	key, res, closer, err = kv.Get("b", ComparisonLower, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "0", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("b", ComparisonHigher)
+	key, res, closer, err = kv.Get("b", ComparisonHigher, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", key)
 	assert.Equal(t, "2", string(res))
@@ -933,25 +933,25 @@ func TestPebbbleFloorCeiling(t *testing.T) {
 
 	// ---------------------------------------------------------------
 
-	key, res, closer, err = kv.Get("c", ComparisonFloor)
+	key, res, closer, err = kv.Get("c", ComparisonFloor, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", key)
 	assert.Equal(t, "2", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("c", ComparisonCeiling)
+	key, res, closer, err = kv.Get("c", ComparisonCeiling, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", key)
 	assert.Equal(t, "2", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("c", ComparisonLower)
+	key, res, closer, err = kv.Get("c", ComparisonLower, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "a", key)
 	assert.Equal(t, "0", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("c", ComparisonHigher)
+	key, res, closer, err = kv.Get("c", ComparisonHigher, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "d", key)
 	assert.Equal(t, "3", string(res))
@@ -959,25 +959,25 @@ func TestPebbbleFloorCeiling(t *testing.T) {
 
 	// ---------------------------------------------------------------
 
-	key, res, closer, err = kv.Get("d", ComparisonFloor)
+	key, res, closer, err = kv.Get("d", ComparisonFloor, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "d", key)
 	assert.Equal(t, "3", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("d", ComparisonCeiling)
+	key, res, closer, err = kv.Get("d", ComparisonCeiling, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "d", key)
 	assert.Equal(t, "3", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("d", ComparisonLower)
+	key, res, closer, err = kv.Get("d", ComparisonLower, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "c", key)
 	assert.Equal(t, "2", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("d", ComparisonHigher)
+	key, res, closer, err = kv.Get("d", ComparisonHigher, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "e", key)
 	assert.Equal(t, "4", string(res))
@@ -985,25 +985,25 @@ func TestPebbbleFloorCeiling(t *testing.T) {
 
 	// ---------------------------------------------------------------
 
-	key, res, closer, err = kv.Get("e", ComparisonFloor)
+	key, res, closer, err = kv.Get("e", ComparisonFloor, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "e", key)
 	assert.Equal(t, "4", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("e", ComparisonCeiling)
+	key, res, closer, err = kv.Get("e", ComparisonCeiling, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "e", key)
 	assert.Equal(t, "4", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("e", ComparisonLower)
+	key, res, closer, err = kv.Get("e", ComparisonLower, DisableFilter)
 	assert.NoError(t, err)
 	assert.Equal(t, "d", key)
 	assert.Equal(t, "3", string(res))
 	assert.NoError(t, closer.Close())
 
-	key, res, closer, err = kv.Get("e", ComparisonHigher)
+	key, res, closer, err = kv.Get("e", ComparisonHigher, DisableFilter)
 	assert.ErrorIs(t, err, ErrKeyNotFound)
 	assert.Equal(t, "", key)
 	assert.Nil(t, res)

--- a/server/kv/notifications_tracker.go
+++ b/server/kv/notifications_tracker.go
@@ -168,7 +168,7 @@ func (nt *notificationsTracker) ReadNextNotifications(ctx context.Context, start
 		return nil, err
 	}
 
-	it, err := nt.kv.RangeScan(notificationKey(startOffset), lastNotificationKey, DisableFilter)
+	it, err := nt.kv.RangeScan(notificationKey(startOffset), lastNotificationKey)
 	if err != nil {
 		return nil, err
 	}

--- a/server/kv/notifications_tracker.go
+++ b/server/kv/notifications_tracker.go
@@ -168,7 +168,7 @@ func (nt *notificationsTracker) ReadNextNotifications(ctx context.Context, start
 		return nil, err
 	}
 
-	it, err := nt.kv.RangeScan(notificationKey(startOffset), lastNotificationKey)
+	it, err := nt.kv.RangeScan(notificationKey(startOffset), lastNotificationKey, DisableFilter)
 	if err != nil {
 		return nil, err
 	}

--- a/server/kv/notifications_trimmer.go
+++ b/server/kv/notifications_trimmer.go
@@ -161,7 +161,7 @@ func (t *notificationsTrimmer) trimNotifications() error {
 }
 
 func (t *notificationsTrimmer) getFirstLast() (first, last int64, err error) {
-	it1, err := t.kv.KeyRangeScan(firstNotificationKey, lastNotificationKey, DisableFilter)
+	it1, err := t.kv.KeyRangeScan(firstNotificationKey, lastNotificationKey)
 	if err != nil {
 		return -1, -1, err
 	}
@@ -175,7 +175,7 @@ func (t *notificationsTrimmer) getFirstLast() (first, last int64, err error) {
 		return first, last, err
 	}
 
-	it2, err := t.kv.KeyRangeScanReverse(firstNotificationKey, lastNotificationKey, DisableFilter)
+	it2, err := t.kv.KeyRangeScanReverse(firstNotificationKey, lastNotificationKey)
 	if err != nil {
 		return -1, -1, err
 	}

--- a/server/kv/notifications_trimmer.go
+++ b/server/kv/notifications_trimmer.go
@@ -161,7 +161,7 @@ func (t *notificationsTrimmer) trimNotifications() error {
 }
 
 func (t *notificationsTrimmer) getFirstLast() (first, last int64, err error) {
-	it1, err := t.kv.KeyRangeScan(firstNotificationKey, lastNotificationKey)
+	it1, err := t.kv.KeyRangeScan(firstNotificationKey, lastNotificationKey, DisableFilter)
 	if err != nil {
 		return -1, -1, err
 	}
@@ -175,7 +175,7 @@ func (t *notificationsTrimmer) getFirstLast() (first, last int64, err error) {
 		return first, last, err
 	}
 
-	it2, err := t.kv.KeyRangeScanReverse(firstNotificationKey, lastNotificationKey)
+	it2, err := t.kv.KeyRangeScanReverse(firstNotificationKey, lastNotificationKey, DisableFilter)
 	if err != nil {
 		return -1, -1, err
 	}
@@ -218,7 +218,7 @@ func (t *notificationsTrimmer) binarySearch(firstOffset, lastOffset int64, cutof
 }
 
 func (t *notificationsTrimmer) readAt(offset int64) (time.Time, error) {
-	_, res, closer, err := t.kv.Get(notificationKey(offset), ComparisonEqual)
+	_, res, closer, err := t.kv.Get(notificationKey(offset), ComparisonEqual, DisableFilter)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -597,7 +597,7 @@ func (lc *leaderController) read(ctx context.Context, request *proto.ReadRequest
 			lc.log.Debug("Received read request")
 
 			for _, get := range request.Gets {
-				response, err := lc.db.Get(get)
+				response, err := lc.db.GetWithFilter(get, kv.InternalKeyFilter)
 				if err != nil {
 					return
 				}


### PR DESCRIPTION
### Motivation


Introduce the filter component to filter some specific keys by rule for DB. This PR only support the `Get` method. we might need to support the `scan`, and `List` methods later. 

### Modification

- Support `DisableFilter` for internal key getting logic.
- Support `InternalKeyFilter` for user getting logic.

### Tests

- Add test `TestGetWithFilter` for it.