### PR TITLE
*: fix benchmark test issue

### DIFF
--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -53,6 +53,7 @@ func BenchmarkServer(b *testing.B) {
 	}
 
 	perfConf := perf.Config{
+		Namespace:           "default",
 		ServiceAddr:         fmt.Sprintf("localhost:%d", standalone.RpcPort()),
 		RequestRate:         200_000,
 		ReadPercentage:      80,


### PR DESCRIPTION
### Motivation

When I run, `benchmark_test`I found an issue. 

```
 ERR Failed to create Oxia client error={"error":"Namespace cannot be empty","kind":"*errors.fundamental","stack":null}
```