### PR TITLE
server: enable pebble bloom filter for better `read` performance

### DIFF
--- a/server/kv/kv_pebble.go
+++ b/server/kv/kv_pebble.go
@@ -16,6 +16,7 @@ package kv
 
 import (
 	"fmt"
+	"github.com/cockroachdb/pebble/bloom"
 	"io"
 	"log/slog"
 	"os"
@@ -199,10 +200,14 @@ func newKVPebble(factory *PebbleFactory, namespace string, shardId int64) (KV, e
 				BlockSize:      64 * 1024,
 				Compression:    pebble.NoCompression,
 				TargetFileSize: 32 * 1024 * 1024,
+				FilterPolicy:   bloom.FilterPolicy(10),
+				FilterType:     pebble.TableFilter,
 			}, {
 				BlockSize:      64 * 1024,
 				Compression:    pebble.ZstdCompression,
 				TargetFileSize: 64 * 1024 * 1024,
+				FilterPolicy:   bloom.FilterPolicy(10),
+				FilterType:     pebble.TableFilter,
 			},
 		},
 		FS:         vfs.Default,


### PR DESCRIPTION
## Motivation

Enable table bloom filter to improve the `read` performance of oxia. The reason is that the bloom filter can reduce the disk IO and quickly judge if the current block has this key. 

## Benchmark Comparing

Env:  
- 2 core 4G, 2G block cache. 100G gp3 SSD
- 64 Bytes 3 Shards
- left: bloom enabled, right: bloom disabled


### Insert only (sequential key distribution)

<img width="1901" alt="image" src="https://github.com/user-attachments/assets/97913ca5-5320-4a15-b0cb-4ffbbcf9244b">

### YCSB A (50% read, 50% write, Zipfian key distribution)

<img width="1841" alt="image" src="https://github.com/user-attachments/assets/9505f484-17eb-4873-85f6-2115c7ae0737">

### YCSB B (%5 write, 95% read, Zipfian key distribution)

<img width="1834" alt="image" src="https://github.com/user-attachments/assets/379a0ed6-f871-4575-ba8a-b9b0dd724149">

### YCSB C (100% read, Zipfian key distribution)

<img width="1825" alt="image" src="https://github.com/user-attachments/assets/a71c6e7f-6aa9-407c-a25a-a6fd41edace2">
