### PR TITLE
Use unique version ids within the same batch

### DIFF
--- a/oxia/example_test.go
+++ b/oxia/example_test.go
@@ -117,8 +117,8 @@ func ExampleAsyncClient() {
 
 	// Output:
 	// First operation complete: version: 0 - error: <nil>
-	// First operation complete: version: 0 - error: <nil>
-	// First operation complete: version: 0 - error: <nil>
+	// First operation complete: version: 1 - error: <nil>
+	// First operation complete: version: 2 - error: <nil>
 }
 
 func ExampleNotifications() {

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -418,7 +418,7 @@ func (d *db) ReadTerm() (term int64, err error) {
 	return term, nil
 }
 
-func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *proto.PutRequest, timestamp uint64, updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) {
+func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *proto.PutRequest, timestamp uint64, updateOperationCallback UpdateOperationCallback, internal bool) (*proto.PutResponse, error) { //nolint:revive
 	var se *proto.StorageEntry
 	var err error
 	var newKey string

--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -638,7 +638,6 @@ func TestLeaderController_AddFollower_Truncate(t *testing.T) {
 		assert.NoError(t, err)
 		assert.EqualValues(t, 1, len(res.Puts))
 		assert.Equal(t, proto.Status_OK, res.Puts[0].Status)
-		assert.EqualValues(t, i, res.Puts[0].Version.VersionId)
 	}
 
 	rpcClient.truncateResps <- struct {


### PR DESCRIPTION
Put requests grouped on a single batch will have a unique version-id.

Semantic of version-id is not changed otherwise, different versions of same record will have unique and increasing ids.