### PR TITLE
Reduce max segment size in list responses

### DIFF
--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -36,8 +36,8 @@ import (
 
 const (
 	maxTotalScanBatchCount = 1000
-	maxTotalReadValueSize  = 4 << (10 * 2) // 4Mi
-	maxTotalListKeySize    = 4 << (10 * 2) // 4Mi
+	maxTotalReadValueSize  = 2 << (10 * 2) // 2Mi
+	maxTotalListKeySize    = 2 << (10 * 2) // 2Mi
 )
 
 type publicRpcServer struct {


### PR DESCRIPTION
Reduce the max size of one individual segment of a list or get response to 2 MB, to have extra room for gRPC headers not to exceed the default 4MB limit of gRPC.