### PR TITLE
Added async flushing of WAL

### DIFF
--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -877,42 +877,44 @@ func (lc *leaderController) handleWriteStream(stream proto.OxiaClient_WriteStrea
 		slog.Debug("Got request in stream",
 			slog.Any("req", req))
 
-		offset, timestamp, err1 := lc.appendToWalStreamRequest(stream.Context(), req)
-		if err1 != nil {
-			timer.Done()
-			closeCh <- err1
-			return
-		}
+		lc.appendToWalStreamRequest(stream.Context(), req, func(offset int64, timestamp uint64, err error) {
+			if err != nil {
+				timer.Done()
+				closeCh <- err
+				return
+			}
 
-		resp, err2 := lc.quorumAckTracker.WaitForCommitOffset(stream.Context(), offset, func() (*proto.WriteResponse, error) {
-			return lc.db.ProcessWrite(req, offset, timestamp, SessionUpdateOperationCallback)
+			resp, err2 := lc.quorumAckTracker.WaitForCommitOffset(stream.Context(), offset, func() (*proto.WriteResponse, error) {
+				return lc.db.ProcessWrite(req, offset, timestamp, SessionUpdateOperationCallback)
+			})
+			if err2 != nil {
+				timer.Done()
+				closeCh <- err2
+				return
+			}
+
+			if err3 := stream.Send(resp); err3 != nil {
+				timer.Done()
+				closeCh <- err3
+				return
+			}
+			timer.Done()
 		})
-		if err2 != nil {
-			timer.Done()
-			closeCh <- err2
-			return
-		}
-
-		if err3 := stream.Send(resp); err3 != nil {
-			timer.Done()
-			closeCh <- err3
-			return
-		}
-		timer.Done()
 	}
 }
 
-func (lc *leaderController) appendToWalStreamRequest(ctx context.Context, request *proto.WriteRequest) (
-	offset int64, timestamp uint64, err error) {
+func (lc *leaderController) appendToWalStreamRequest(ctx context.Context, request *proto.WriteRequest,
+	callback func(offset int64, timestamp uint64, err error)) {
 	lc.Lock()
 
 	if err := checkStatusIsLeader(lc.status); err != nil {
 		lc.Unlock()
-		return wal.InvalidOffset, 0, err
+		callback(wal.InvalidOffset, 0, err)
+		return
 	}
 
 	newOffset := lc.quorumAckTracker.NextOffset()
-	timestamp = uint64(time.Now().UnixMilli())
+	timestamp := uint64(time.Now().UnixMilli())
 
 	lc.log.Debug(
 		"Append operation",
@@ -930,7 +932,8 @@ func (lc *leaderController) appendToWalStreamRequest(ctx context.Context, reques
 	value, err := logEntryValue.MarshalVT()
 	if err != nil {
 		lc.Unlock()
-		return wal.InvalidOffset, timestamp, err
+		callback(wal.InvalidOffset, timestamp, err)
+		return
 	}
 	logEntry := &proto.LogEntry{
 		Term:      lc.term,
@@ -939,20 +942,15 @@ func (lc *leaderController) appendToWalStreamRequest(ctx context.Context, reques
 		Timestamp: timestamp,
 	}
 
-	if err = lc.wal.AppendAsync(logEntry); err != nil {
-		lc.Unlock()
-		return wal.InvalidOffset, timestamp, errors.Wrap(err, "oxia: failed to append to wal")
-	}
-
+	lc.wal.AppendAndSync(logEntry, func(err error) {
+		if err != nil {
+			callback(wal.InvalidOffset, timestamp, errors.Wrap(err, "oxia: failed to append to wal"))
+		} else {
+			lc.quorumAckTracker.AdvanceHeadOffset(newOffset)
+			callback(newOffset, timestamp, nil)
+		}
+	})
 	lc.Unlock()
-
-	// Sync the WAL outside the mutex, so that we can have multiple waiting
-	// sync requests
-	if err = lc.wal.Sync(ctx); err != nil {
-		return wal.InvalidOffset, timestamp, errors.Wrap(err, "oxia: failed to sync the wal")
-	}
-	lc.quorumAckTracker.AdvanceHeadOffset(newOffset)
-	return newOffset, timestamp, nil
 }
 
 // ////

--- a/server/wal/wal.go
+++ b/server/wal/wal.go
@@ -74,6 +74,11 @@ type Wal interface {
 	// Caller should use Sync to make the entry visible
 	AppendAsync(entry *proto.LogEntry) error
 
+	// AppendAndSync an entry and forces the sync on the WAL
+	// The operation is perfomed in background and the callback is
+	// triggered when it's completed
+	AppendAndSync(entry *proto.LogEntry, callback func(err error))
+
 	// Sync flushes all the entries in the wal to disk
 	Sync(ctx context.Context) error
 

--- a/server/wal/wal_test.go
+++ b/server/wal/wal_test.go
@@ -37,6 +37,7 @@ func NewTestWalFactory(t *testing.T) Factory {
 		BaseWalDir:  dir,
 		Retention:   1 * time.Hour,
 		SegmentSize: 128 * 1024,
+		SyncData:    true,
 	})
 }
 


### PR DESCRIPTION
When using write stream, we have 1 single goroutine handling the stream. We shouldn't block the goroutine while flushing the wal, instead it should proceed to process the next write request.