### PR TITLE
fix(notification): support notification retention configuration

### DIFF
--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -51,6 +51,8 @@ func init() {
 	Cmd.Flags().StringVar(&conf.DataDir, "data-dir", "./data/db", "Directory where to store data")
 	Cmd.Flags().StringVar(&conf.WalDir, "wal-dir", "./data/wal", "Directory for write-ahead-logs")
 	Cmd.Flags().DurationVar(&conf.WalRetentionTime, "wal-retention-time", 1*time.Hour, "Retention time for the entries in the write-ahead-log")
+	Cmd.Flags().DurationVar(&conf.NotificationsRetentionTime, "notifications-retention-time", 1*time.Hour, "Retention time for the db notifications to clients")
+
 	Cmd.Flags().BoolVar(&conf.WalSyncData, "wal-sync-data", true, "Whether to sync data in write-ahead-log")
 	Cmd.Flags().Int64Var(&conf.DbBlockCacheMB, "db-cache-size-mb", kv.DefaultFactoryOptions.CacheSizeMB,
 		"Max size of the shared DB cache")

--- a/cmd/server/cmd_test.go
+++ b/cmd/server/cmd_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/streamnative/oxia/server"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServerCmd(t *testing.T) {
+	for _, test := range []struct {
+		args         []string
+		expectedConf server.Config
+		isErr        bool
+	}{
+		{[]string{}, server.Config{
+			PublicServiceAddr:          "0.0.0.0:6648",
+			InternalServiceAddr:        "0.0.0.0:6649",
+			MetricsServiceAddr:         "0.0.0.0:8080",
+			DataDir:                    "./data/db",
+			WalDir:                     "./data/wal",
+			WalRetentionTime:           1 * time.Hour,
+			WalSyncData:                true,
+			NotificationsRetentionTime: 1 * time.Hour,
+			DbBlockCacheMB:             100,
+		}, false},
+	} {
+		t.Run(strings.Join(test.args, "_"), func(t *testing.T) {
+			Cmd.SetArgs(test.args)
+			Cmd.RunE = func(cmd *cobra.Command, args []string) error {
+				return nil
+			}
+			err := Cmd.Execute()
+			assert.Equal(t, test.isErr, err != nil)
+			assert.Equal(t, test.expectedConf, conf)
+		})
+	}
+}

--- a/cmd/server/cmd_test.go
+++ b/cmd/server/cmd_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/cmd/server/cmd_test.go
+++ b/cmd/server/cmd_test.go
@@ -15,12 +15,14 @@
 package server
 
 import (
-	"github.com/spf13/cobra"
-	"github.com/streamnative/oxia/server"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/streamnative/oxia/server"
 )
 
 func TestServerCmd(t *testing.T) {

--- a/server/wal/wal_ro_segment.go
+++ b/server/wal/wal_ro_segment.go
@@ -293,7 +293,7 @@ func (r *readOnlySegmentsGroup) PollHighestSegment() (common.RefCount[ReadOnlySe
 	defer r.Unlock()
 
 	if r.allSegments.Empty() {
-		return nil, nil // nolint: nilnil
+		return nil, nil //nolint: nilnil
 	}
 
 	offset, _ := r.allSegments.Max()

--- a/server/wal/wal_ro_segment.go
+++ b/server/wal/wal_ro_segment.go
@@ -293,7 +293,7 @@ func (r *readOnlySegmentsGroup) PollHighestSegment() (common.RefCount[ReadOnlySe
 	defer r.Unlock()
 
 	if r.allSegments.Empty() {
-		return nil, nil //nolint: nilnil
+		return nil, nil // nolint: nilnil
 	}
 
 	offset, _ := r.allSegments.Max()


### PR DESCRIPTION
### Motivation

the PR #353 remove the default configuration of notification retention. which causes unexpected behaviour when user uses oxia as metadata service. 

especially for distributed lock. the revalidate after session expired will be never triggered.

the current value:

```
{"level":"info","time":"2024-09-18T07:11:48.692719842Z","config":{"PublicServiceAddr":"0.0.0.0:6648","InternalServiceAddr":"0.0.0.0:6649","PeerTLS":null,"ServerTLS":null,"InternalServerTLS":null,"MetricsServiceAddr":"0.0.0.0:8080","AuthOptions":{"ProviderName":"","ProviderParams":""},"DataDir":"/data/db","WalDir":"/data/wal","WalRetentionTime":3600000000000,"WalSyncData":true,"NotificationsRetentionTime":0,"DbBlockCacheMB":4096},"time":"2024-09-18T07:11:48.693399934Z","message":"Starting Oxia server"}
```

### Modification

- Add `NotificationsRetentionTime` back and the default time is 1 hour.

### Others


We might need consider filter some notification on the server when user use oxia as some storage index service(high throughput of W/R) to avoid dispatching too much messages that will impact performance. 