### PR TITLE
Fix NPE in coordinator when closing a half-initialized node controller

### DIFF
--- a/coordinator/impl/node_controller.go
+++ b/coordinator/impl/node_controller.go
@@ -176,7 +176,9 @@ func (n *nodeController) healthCheckWithRetries() {
 
 		// To avoid the send assignments stream to miss the notification about the current
 		// node went down, we interrupt the current stream when the ping on the node fails
-		n.sendAssignmentsCancel()
+		if n.sendAssignmentsCancel != nil {
+			n.sendAssignmentsCancel()
+		}
 	})
 }
 


### PR DESCRIPTION


```
Sep 13 22:30:01.883157 WRN Storage node health check failed error={"error":"node is not actively serving","kind":"*errors.fundamental","stack":null} addr={"internal":"my-server:8190","public":"my-server:9190"} component=node-controller retry-after=1290.424087
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2b4f6fa]

goroutine 2364 [running]:
github.com/streamnative/oxia/coordinator/impl.(*nodeController).healthCheckWithRetries.func2({0x35cb5a0, 0xc00020b338}, 0x4cea4f17)
	/home/runner/work/oxia/oxia/coordinator/impl/node_controller.go:179 +0x43a
github.com/cenkalti/backoff/v4.doRetryNotify[...](0xc001369ca0, {0x7f82e826bb38, 0xc001100fa0}, 0xc001369d20, {0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.3.0/retry.go:107 +0x2d1
github.com/cenkalti/backoff/v4.RetryNotifyWithTimer(0xc000476d30, {0x7f82e826bb38, 0xc001100fa0}, 0xc000476d20, {0x0, 0x0})
	/home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.3.0/retry.go:61 +0xa8
github.com/cenkalti/backoff/v4.RetryNotify(...)
	/home/runner/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.3.0/retry.go:49
github.com/streamnative/oxia/coordinator/impl.(*nodeController).healthCheckWithRetries(0xc000900300)
	/home/runner/work/oxia/oxia/coordinator/impl/node_controller.go:153 +0x3c5
github.com/streamnative/oxia/common.DoWithLabels.func1({0x35e9d40?, 0xc0013af710?})
	/home/runner/work/oxia/oxia/common/pprof.go:46 +0x2f
runtime/pprof.Do({0x35e9d78, 0xc0007c2ff0}, {{0xc00002c100?, 0xc000140cb0?, 0x480acc?}}, 0xc000476f10)
	/opt/hostedtoolcache/go/1.22.7/x64/src/runtime/pprof/runtime.go:51 +0x118
github.com/streamnative/oxia/common.DoWithLabels({0x35e9d78, 0xc0007c2ff0}, 0xc0013af530, 0xc00027e0b0)
	/home/runner/work/oxia/oxia/common/pprof.go:42 +0x585
created by github.com/streamnative/oxia/coordinator/impl.newNodeController in goroutine 2363
	/home/runner/work/oxia/oxia/coordinator/impl/node_controller.go:116 +0xb6b
```