### PR TITLE
[Go client] Recover from write stream failures

### DIFF
--- a/oxia/internal/executor.go
+++ b/oxia/internal/executor.go
@@ -113,7 +113,7 @@ func (e *executorImpl) writeStream(shardId *int64) (*streamWrapper, error) {
 	e.RLock()
 
 	sw, ok := e.writeStreams[*shardId]
-	if ok {
+	if ok && !sw.failed.Load() {
 		e.RUnlock()
 		return sw, nil
 	}


### PR DESCRIPTION
Get rid of failed write-streams in Go client SDK. 

This is similar change to https://github.com/streamnative/oxia-java/pull/180 in Java SDK.