### PR TITLE
fix(tool): follow up #524 to add session id to output

### DIFF
--- a/oxia/proto_utils.go
+++ b/oxia/proto_utils.go
@@ -78,6 +78,9 @@ func toVersion(version *proto.Version) Version {
 	if version.ClientIdentity != nil {
 		v.ClientIdentity = *version.ClientIdentity
 	}
+	if version.SessionId != nil {
+		v.SessionId = *version.SessionId
+	}
 
 	return v
 }


### PR DESCRIPTION
### Motivation

#524 didn't add a session ID when deserialising the version. 