### PR TITLE
feat(cmd): support wal cmd `truncate` command

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/streamnative/oxia/cmd/wal"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -62,6 +63,7 @@ func init() {
 	rootCmd.AddCommand(server.Cmd)
 	rootCmd.AddCommand(standalone.Cmd)
 	rootCmd.AddCommand(pebble.Cmd)
+	rootCmd.AddCommand(wal.Cmd)
 }
 
 func configureLogLevel(_ *cobra.Command, _ []string) error {

--- a/cmd/wal/cmd.go
+++ b/cmd/wal/cmd.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package wal
 
 import (

--- a/cmd/wal/cmd.go
+++ b/cmd/wal/cmd.go
@@ -1,0 +1,18 @@
+package wal
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/streamnative/oxia/cmd/wal/truncate"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:   "wal",
+		Short: "Wal utils",
+		Long:  `Tools for the oxia WAL`,
+	}
+)
+
+func init() {
+	Cmd.AddCommand(truncate.Cmd)
+}

--- a/cmd/wal/cmd.go
+++ b/cmd/wal/cmd.go
@@ -16,6 +16,7 @@ package wal
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/streamnative/oxia/cmd/wal/common"
 	"github.com/streamnative/oxia/cmd/wal/truncate"
 )
 
@@ -28,5 +29,18 @@ var (
 )
 
 func init() {
+	Cmd.PersistentFlags().Int64Var(&common.WalOption.Shard, "shard", 0, "shard id")
+	Cmd.PersistentFlags().StringVar(&common.WalOption.Namespace, "namespace", "default", "namespace name")
+	Cmd.PersistentFlags().StringVar(&common.WalOption.WalDir, "wal-dir", "", "directory path")
 	Cmd.AddCommand(truncate.Cmd)
+
+	if err := Cmd.MarkPersistentFlagRequired("wal-dir"); err != nil {
+		panic(err)
+	}
+	if err := Cmd.MarkPersistentFlagRequired("shard"); err != nil {
+		panic(err)
+	}
+	if err := Cmd.MarkPersistentFlagRequired("namespace"); err != nil {
+		panic(err)
+	}
 }

--- a/cmd/wal/common/option.go
+++ b/cmd/wal/common/option.go
@@ -1,0 +1,9 @@
+package common
+
+type WalOptions struct {
+	Namespace string
+	Shard     int64
+	WalDir    string
+}
+
+var WalOption WalOptions

--- a/cmd/wal/common/option.go
+++ b/cmd/wal/common/option.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 type WalOptions struct {

--- a/cmd/wal/truncate/cmd.go
+++ b/cmd/wal/truncate/cmd.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package truncate
 
 import (

--- a/cmd/wal/truncate/cmd.go
+++ b/cmd/wal/truncate/cmd.go
@@ -1,0 +1,79 @@
+package truncate
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/streamnative/oxia/server/wal"
+	"log/slog"
+	"math"
+)
+
+type truncateOptions struct {
+	namespace string
+	shard     int64
+	walDir    string
+
+	lastEntry      bool
+	safePointEntry int64
+}
+
+var (
+	options = truncateOptions{}
+	Cmd     = &cobra.Command{
+		Use:   "truncate",
+		Short: "truncate the WAL",
+		Long:  `truncate the WAL by some conditions`,
+		RunE:  exec,
+	}
+)
+
+func init() {
+	Cmd.Flags().Int64Var(&options.shard, "shard", 0, "shard id")
+	Cmd.Flags().StringVar(&options.namespace, "namespace", "default", "namespace name")
+	Cmd.Flags().StringVar(&options.walDir, "wal-dir", "", "directory path")
+	// operations
+	Cmd.Flags().Int64Var(&options.safePointEntry, "safe-point-entry", math.MaxInt64, "the last safe entry offset")
+	Cmd.Flags().BoolVar(&options.lastEntry, "last-entry", false, "if trim the last entry")
+
+	Cmd.MarkFlagsMutuallyExclusive("safe-point-entry", "last-entry")
+	Cmd.MarkFlagsRequiredTogether("wal-dir", "namespace", "shard")
+}
+
+func exec(*cobra.Command, []string) error {
+	factory := wal.NewWalFactory(&wal.FactoryOptions{
+		BaseWalDir:  options.walDir,
+		Retention:   math.MaxInt64,
+		SegmentSize: wal.DefaultFactoryOptions.SegmentSize,
+		SyncData:    true,
+	})
+	writeAheadLog, err := factory.NewWal(options.namespace, options.shard, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer writeAheadLog.Close()
+
+	if options.safePointEntry != math.MaxInt64 {
+		slog.Info("truncate the entries. ", slog.Int64("start", options.safePointEntry),
+			slog.Int64("end", writeAheadLog.LastOffset()))
+		newLastEntry, err := writeAheadLog.TruncateLog(options.safePointEntry)
+		if err != nil {
+			return err
+		}
+		slog.Info("truncate complete", slog.Int64("newLastEntry", newLastEntry))
+		return nil
+	}
+
+	if options.lastEntry {
+		lastOffset := writeAheadLog.LastOffset()
+		safePoint := lastOffset - 1
+		slog.Info("truncate the last entry. ", slog.Int64("start", safePoint), slog.Int64("end", lastOffset))
+		newLastEntry, err := writeAheadLog.TruncateLog(safePoint)
+		if err != nil {
+			return err
+		}
+		slog.Info("truncate complete", slog.Int64("newLastEntry", newLastEntry))
+		return nil
+	}
+
+	slog.Info("no operation applied")
+	return nil
+}

--- a/cmd/wal/truncate/cmd.go
+++ b/cmd/wal/truncate/cmd.go
@@ -16,7 +16,7 @@ package truncate
 
 import (
 	"github.com/spf13/cobra"
-	common "github.com/streamnative/oxia/cmd/wal/common"
+	"github.com/streamnative/oxia/cmd/wal/common"
 	"github.com/streamnative/oxia/server/wal"
 	"log/slog"
 	"math"


### PR DESCRIPTION
### Motivation

Introduce the wal cmd `truncate` command to truncate corrupted unsynced data in the write-ahead log before implementing a CRC-based write-ahead log.
