### PR TITLE
feat(wal): support chained CRC for write ahead log

### DIFF
--- a/server/util/crc/crc.go
+++ b/server/util/crc/crc.go
@@ -18,6 +18,8 @@ import (
 	"hash/crc32"
 )
 
+const MagicNumber uint32 = 0xa282ead8
+
 var table = crc32.MakeTable(crc32.Castagnoli)
 
 type Checksum uint32
@@ -29,5 +31,5 @@ func (c Checksum) Update(b []byte) Checksum {
 	return Checksum(crc32.Update(uint32(c), table, b))
 }
 func (c Checksum) Value() uint32 {
-	return uint32(c>>15|c<<17) + 0xa282ead8
+	return uint32(c>>15|c<<17) + MagicNumber
 }

--- a/server/util/crc/crc.go
+++ b/server/util/crc/crc.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package crc
 
 import (

--- a/server/util/crc/crc.go
+++ b/server/util/crc/crc.go
@@ -24,9 +24,6 @@ var table = crc32.MakeTable(crc32.Castagnoli)
 
 type Checksum uint32
 
-func New(b []byte) Checksum {
-	return Checksum(0).Update(b)
-}
 func (c Checksum) Update(b []byte) Checksum {
 	return Checksum(crc32.Update(uint32(c), table, b))
 }

--- a/server/util/crc/crc.go
+++ b/server/util/crc/crc.go
@@ -1,0 +1,19 @@
+package crc
+
+import (
+	"hash/crc32"
+)
+
+var table = crc32.MakeTable(crc32.Castagnoli)
+
+type Checksum uint32
+
+func New(b []byte) Checksum {
+	return Checksum(0).Update(b)
+}
+func (c Checksum) Update(b []byte) Checksum {
+	return Checksum(crc32.Update(uint32(c), table, b))
+}
+func (c Checksum) Value() uint32 {
+	return uint32(c>>15|c<<17) + 0xa282ead8
+}

--- a/server/wal/crc_test.go
+++ b/server/wal/crc_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package wal
 
 import (

--- a/server/wal/crc_test.go
+++ b/server/wal/crc_test.go
@@ -1,0 +1,358 @@
+package wal
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/streamnative/oxia/proto"
+	"github.com/streamnative/oxia/server/util/crc"
+	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"os"
+	"testing"
+)
+
+func TestSegment(t *testing.T) {
+	entries := 1000
+	path := t.TempDir()
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0)
+	assert.NoError(t, err)
+	for i := 0; i < entries; i++ {
+		err := rw.Append(int64(i), []byte(fmt.Sprintf("%d", i)))
+		assert.NoError(t, err)
+	}
+	rwSegment := rw.(*readWriteSegment)
+	actualRwMmap := rwSegment.txnMappedFile
+
+	var cursor uint32
+	var expectedPreviousCrc uint32
+	for i := 0; i < entries; i++ {
+		payloadSize := readInt(actualRwMmap, cursor)
+		cursor += SizeLen
+		previousCRC := readInt(actualRwMmap, cursor)
+		cursor += CrcLen
+		assert.EqualValues(t, expectedPreviousCrc, previousCRC)
+		payloadCRC := readInt(actualRwMmap, cursor)
+		cursor += CrcLen
+		expectedCrc := crc.Checksum(previousCRC).Update(actualRwMmap[cursor : cursor+payloadSize]).Value()
+		assert.EqualValues(t, expectedCrc, payloadCRC)
+		expectedPreviousCrc = payloadCRC
+		cursor += payloadSize
+	}
+
+	err = rw.Close()
+	assert.NoError(t, err)
+
+	ro, err := newReadOnlySegment(path, 0)
+	assert.NoError(t, err)
+
+	roSegment := ro.(*readonlySegment)
+	actualRoMmap := roSegment.txnMappedFile
+
+	cursor = 0
+	expectedPreviousCrc = 0
+	for i := 0; i < entries; i++ {
+		payloadSize := readInt(actualRoMmap, cursor)
+		cursor += SizeLen
+		previousCRC := readInt(actualRoMmap, cursor)
+		cursor += CrcLen
+		assert.EqualValues(t, expectedPreviousCrc, previousCRC)
+		payloadCRC := readInt(actualRoMmap, cursor)
+		cursor += CrcLen
+		expectedCrc := crc.Checksum(previousCRC).Update(actualRoMmap[cursor : cursor+payloadSize]).Value()
+		assert.EqualValues(t, expectedCrc, payloadCRC)
+		expectedPreviousCrc = payloadCRC
+		cursor += payloadSize
+	}
+	err = ro.Close()
+	assert.NoError(t, err)
+}
+
+func TestModifiedSegment(t *testing.T) {
+	entries := 1000
+	path := t.TempDir()
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0)
+	assert.NoError(t, err)
+	for i := 0; i < entries; i++ {
+		err := rw.Append(int64(i), []byte(fmt.Sprintf("%d", i)))
+		assert.NoError(t, err)
+	}
+
+	segment := rw.(*readWriteSegment)
+	actualMmap := segment.txnMappedFile
+
+	// inject failure
+	randomPosition := rand.Uint64() % uint64(segment.currentFileOffset)
+	binary.BigEndian.PutUint64(actualMmap[randomPosition:], randomPosition)
+
+	detectCorruption := false
+	var corruptionOffset int64
+	for i := 0; i < entries; i++ {
+		_, err := rw.Read(int64(i))
+		if err != nil {
+			if errors.Is(err, ErrWalDataCorrupted) {
+				detectCorruption = true
+				corruptionOffset = int64(i)
+			} else {
+				assert.Fail(t, "expected err", err)
+			}
+		}
+	}
+	assert.True(t, detectCorruption)
+	assert.NotZero(t, corruptionOffset)
+
+	err = rw.Close()
+	assert.NoError(t, err)
+
+	ro, err := newReadOnlySegment(path, 0)
+	assert.NoError(t, err)
+
+	RoDetectCorruption := false
+	var RoCorruptionOffset int64
+	for i := 0; i < entries; i++ {
+		_, err := ro.Read(int64(i))
+		if err != nil {
+			if errors.Is(err, ErrWalDataCorrupted) {
+				RoDetectCorruption = true
+				RoCorruptionOffset = int64(i)
+			} else {
+				assert.Error(t, err, "unexpected err")
+			}
+		}
+	}
+	assert.EqualValues(t, detectCorruption, RoDetectCorruption)
+	assert.NotZero(t, corruptionOffset, RoCorruptionOffset)
+}
+
+func TestWal(t *testing.T) {
+	entries := 10000
+	f, w := createWal(t)
+
+	for i := 0; i < entries; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: int64(i),
+			Value:  []byte(fmt.Sprintf("entry-%d", i)),
+		}))
+	}
+
+	r, err := w.NewReader(0)
+	assert.NoError(t, err)
+	entryIndex := 0
+	for r.HasNext() {
+		entryIndex += 1
+		value, err := r.ReadNext()
+		assert.NoError(t, err)
+		assert.EqualValues(t, value.Value, fmt.Sprintf("entry-%d", entryIndex))
+	}
+	assert.EqualValues(t, entries-1, entryIndex)
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
+func TestModifiedWal(t *testing.T) {
+	entries := 10000
+	f, w := createWal(t)
+
+	for i := 0; i < entries; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: int64(i),
+			Value:  []byte(fmt.Sprintf("entry-%d", i)),
+		}))
+	}
+
+	actualWal := w.(*wal)
+
+	lastOffset := actualWal.lastAppendedOffset.Load()
+
+	// inject failure
+	randomOffset := rand.Uint64() % uint64(lastOffset)
+	currentOffset := actualWal.currentSegment.BaseOffset()
+	if int64(randomOffset) >= currentOffset {
+		segment := actualWal.currentSegment
+		rwSegment := segment.(*readWriteSegment)
+		randomFileOffset := rand.Uint64() % uint64(rwSegment.currentFileOffset)
+		binary.BigEndian.PutUint64(rwSegment.txnMappedFile[randomFileOffset:], randomFileOffset)
+	} else {
+		roSegment, err := actualWal.readOnlySegments.Get(currentOffset)
+		assert.NoError(t, err)
+		actualSegment := roSegment.Get().(*readonlySegment)
+		lastFileOffset := fileOffset(actualSegment.idxMappedFile, actualSegment.baseOffset, actualSegment.lastOffset)
+		txFile, err := os.OpenFile(actualSegment.txnPath, os.O_RDWR, 0644)
+		randomFileOffset := rand.Uint64() % uint64(lastFileOffset)
+		value, err := uuid.New().MarshalBinary()
+		assert.NoError(t, err)
+		_, err = txFile.WriteAt(value, int64(randomFileOffset))
+		assert.NoError(t, err)
+		assert.NoError(t, txFile.Sync())
+		// cleanup
+		assert.NoError(t, roSegment.Close())
+		assert.NoError(t, txFile.Close())
+	}
+
+	r, err := w.NewReader(0)
+	assert.NoError(t, err)
+	entryIndex := 0
+	RoDetectCorruption := false
+	var RoCorruptionOffset int64
+	for r.HasNext() {
+		entryIndex += 1
+		value, err := r.ReadNext()
+		if err != nil {
+			if errors.Is(err, ErrWalDataCorrupted) {
+				RoDetectCorruption = true
+				RoCorruptionOffset = int64(entryIndex)
+			} else {
+				assert.Error(t, err, "unexpected err")
+			}
+			break
+		} else {
+			assert.EqualValues(t, value.Value, fmt.Sprintf("entry-%d", entryIndex))
+		}
+	}
+
+	assert.True(t, RoDetectCorruption)
+	assert.NotZero(t, RoCorruptionOffset)
+
+	assert.NoError(t, r.Close())
+	assert.NoError(t, w.Close())
+	assert.NoError(t, f.Close())
+}
+
+func TestSameWals(t *testing.T) {
+	entries := 10000
+	f, w := createWal(t)
+	defer w.Close()
+	defer f.Close()
+
+	for i := 0; i < entries; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: int64(i),
+			Value:  []byte(fmt.Sprintf("entry-%d", i)),
+		}))
+	}
+
+	w2, err := f.NewWal("other", 0, nil)
+	assert.NoError(t, err)
+	for i := 0; i < entries; i++ {
+		assert.NoError(t, w2.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: int64(i),
+			Value:  []byte(fmt.Sprintf("entry-%d", i)),
+		}))
+	}
+
+	actualWal := w.(*wal)
+	segment := actualWal.currentSegment
+	actualSegment := segment.(*readWriteSegment)
+	previousCrc, currentCrc := getCrc(actualSegment, segment.LastOffset())
+
+	actualWal2 := w2.(*wal)
+	segment2 := actualWal2.currentSegment
+	actualSegment2 := segment2.(*readWriteSegment)
+	previousCrc2, currentCrc2 := getCrc(actualSegment2, segment.LastOffset())
+
+	assert.EqualValues(t, previousCrc2, previousCrc)
+	assert.EqualValues(t, currentCrc2, currentCrc)
+}
+
+func TestDeviatingWals(t *testing.T) {
+	entries := 10000
+	deviatingEntry := 50
+	f, w := createWal(t)
+	defer w.Close()
+	defer f.Close()
+
+	for i := 0; i < entries; i++ {
+		assert.NoError(t, w.Append(&proto.LogEntry{
+			Term:   1,
+			Offset: int64(i),
+			Value:  []byte(fmt.Sprintf("entry-%d", i)),
+		}))
+	}
+
+	w2, err := f.NewWal("other", 0, nil)
+	assert.NoError(t, err)
+	for i := 0; i < entries; i++ {
+		if i == deviatingEntry {
+			assert.NoError(t, w2.Append(&proto.LogEntry{
+				Term:   1,
+				Offset: int64(i),
+				Value:  []byte(fmt.Sprintf("xcxzczxczxczxc-%d", i)),
+			}))
+		} else {
+			assert.NoError(t, w2.Append(&proto.LogEntry{
+				Term:   1,
+				Offset: int64(i),
+				Value:  []byte(fmt.Sprintf("entry-%d", i)),
+			}))
+		}
+	}
+
+	actualWal := w.(*wal)
+	segment := actualWal.currentSegment
+	actualSegment := segment.(*readWriteSegment)
+	previousCrc, currentCrc := getCrc(actualSegment, segment.LastOffset())
+
+	actualWal2 := w2.(*wal)
+	segment2 := actualWal2.currentSegment
+	actualSegment2 := segment2.(*readWriteSegment)
+	previousCrc2, currentCrc2 := getCrc(actualSegment2, segment.LastOffset())
+
+	assert.NotEqualValues(t, previousCrc2, previousCrc)
+	assert.NotEqualValues(t, currentCrc2, currentCrc)
+
+	cursor1 := int64(0)
+	cursor2 := int64(0)
+	roSeg1, err := actualWal.readOnlySegments.Get(cursor1)
+	assert.NoError(t, err)
+	defer roSeg1.Close()
+	roSeg2, err := actualWal2.readOnlySegments.Get(cursor2)
+	assert.NoError(t, err)
+	defer roSeg2.Close()
+
+	errIndex := 0
+	for i := 0; i < 100; i++ {
+		cp1, c1 := getCrc(roSeg1.Get(), cursor1)
+		cp2, c2 := getCrc(roSeg2.Get(), cursor2)
+		if cp1 != cp2 || c1 != c2 {
+			errIndex = i
+			break
+		}
+
+		cursor1++
+		cursor2++
+	}
+	assert.EqualValues(t, errIndex, deviatingEntry)
+
+}
+
+func getCrc(actualSegment interface{}, offset int64) (uint32, uint32) {
+	var position uint32
+	if segment, ok := actualSegment.(*readWriteSegment); ok {
+		position = fileOffset(segment.writingIdx, segment.baseOffset, offset)
+		cursor := position
+		_ = readInt(segment.txnMappedFile, cursor)
+		cursor += SizeLen
+		previousCRC := readInt(segment.txnMappedFile, cursor)
+		cursor += CrcLen
+		payloadCRC := readInt(segment.txnMappedFile, cursor)
+		cursor += CrcLen
+		return previousCRC, payloadCRC
+	} else {
+		ro := actualSegment.(*readonlySegment)
+		position = fileOffset(ro.idxMappedFile, ro.baseOffset, offset)
+		cursor := position
+		_ = readInt(ro.txnMappedFile, cursor)
+		cursor += SizeLen
+		previousCRC := readInt(ro.txnMappedFile, cursor)
+		cursor += CrcLen
+		payloadCRC := readInt(ro.txnMappedFile, cursor)
+		cursor += CrcLen
+		return previousCRC, payloadCRC
+	}
+}

--- a/server/wal/metadata.go
+++ b/server/wal/metadata.go
@@ -14,13 +14,34 @@
 
 package wal
 
+import "github.com/pkg/errors"
+
+// +--------------+-------------------+-------------+--------------+
+// | Size(4Bytes) | PreviousCRC(4Bytes) | CRC(4Bytes) | Payload(...) |
+// +--------------+-------------------+-------------+--------------+
+// Size: 			Length of the payload data
+// PreviousCRC: 	32bit hash computed over the previous payload using CRC.
+// CRC:				32bit hash computed over the previous and the current payload using CRC. CRC(n) = CRC( DATAn, CRCn-1 )
+// Payload: 		Byte stream as long as specified by the payload size.
+
 const (
-	CrcLen         = 4
-	PayloadSizeLen = 4
-	HeaderLen      = 8
+	SizeLen    = 4
+	CrcLen     = 4
+	HeaderSize = SizeLen + CrcLen + CrcLen
 )
 
 type FormatVersion int
 
 const TxnFormatVersion1 FormatVersion = 1
 const TxnFormatVersion2 FormatVersion = 2
+
+const TxnExtension = ".txn"
+const TxnExtensionV2 = ".txnx"
+const TdxExtension = ".idx"
+
+const InitCrc = 0
+const InitOffset = 0
+
+var (
+	ErrWalDataCorrupted = errors.New("WAL data corrupted")
+)

--- a/server/wal/metadata.go
+++ b/server/wal/metadata.go
@@ -1,0 +1,12 @@
+package wal
+
+const (
+	CrcLen         = 4
+	PayloadSizeLen = 4
+	HeaderLen      = 8
+)
+
+type FormatVersion int
+
+const TxnFormatVersion1 FormatVersion = 1
+const TxnFormatVersion2 FormatVersion = 2

--- a/server/wal/metadata.go
+++ b/server/wal/metadata.go
@@ -1,3 +1,17 @@
+// Copyright 2024 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package wal
 
 const (

--- a/server/wal/metadata.go
+++ b/server/wal/metadata.go
@@ -39,9 +39,6 @@ const TxnExtension = ".txn"
 const TxnExtensionV2 = ".txnx"
 const TdxExtension = ".idx"
 
-const InitCrc = 0
-const InitOffset = 0
-
 var (
 	ErrWalDataCorrupted = errors.New("WAL data corrupted")
 )

--- a/server/wal/wal_impl.go
+++ b/server/wal/wal_impl.go
@@ -570,9 +570,17 @@ func listAllSegments(walPath string) (segments []int64, err error) {
 	}
 
 	for _, entry := range dir {
-		if matched, _ := filepath.Match("*"+txnExtension, entry.Name()); matched {
+		if matched, _ := filepath.Match("*"+TxnExtension, entry.Name()); matched {
 			var id int64
-			if _, err := fmt.Sscanf(entry.Name(), "%d"+txnExtension, &id); err != nil {
+			if _, err := fmt.Sscanf(entry.Name(), "%d"+TxnExtension, &id); err != nil {
+				return nil, err
+			}
+
+			segments = append(segments, id)
+		}
+		if matched, _ := filepath.Match("*"+TxnExtensionV2, entry.Name()); matched {
+			var id int64
+			if _, err := fmt.Sscanf(entry.Name(), "%d"+TxnExtensionV2, &id); err != nil {
 				return nil, err
 			}
 

--- a/server/wal/wal_impl.go
+++ b/server/wal/wal_impl.go
@@ -536,8 +536,12 @@ func (t *wal) recoverWal() error {
 	if len(segments) > 0 {
 		firstSegment = segments[0]
 		lastSegment = segments[len(segments)-1]
-		if lastCrc, err = t.readOnlySegments.GetLastCrc(lastSegment); err != nil {
-			return err
+		if firstSegment != lastSegment {
+			if lastCrc, err = t.readOnlySegments.GetLastCrc(lastSegment); err != nil {
+				return err
+			}
+		} else {
+			lastCrc = 0
 		}
 	} else {
 		firstSegment = 0

--- a/server/wal/wal_impl.go
+++ b/server/wal/wal_impl.go
@@ -273,7 +273,7 @@ func (t *wal) AppendAsync(entry *proto.LogEntry) error {
 			return err
 		}
 
-		if t.currentSegment, err = newReadWriteSegment(t.walPath, entry.Offset, t.segmentSize); err != nil {
+		if t.currentSegment, err = newReadWriteSegment(t.walPath, entry.Offset, t.segmentSize, 0); err != nil {
 			t.writeErrors.Inc()
 			return err
 		}
@@ -311,10 +311,10 @@ func (t *wal) rolloverSegment() error {
 	if err = t.currentSegment.Close(); err != nil {
 		return err
 	}
-
+	lastCrc := t.currentSegment.LastCrc()
 	t.readOnlySegments.AddedNewSegment(t.currentSegment.BaseOffset())
 
-	if t.currentSegment, err = newReadWriteSegment(t.walPath, t.lastAppendedOffset.Load()+1, t.segmentSize); err != nil {
+	if t.currentSegment, err = newReadWriteSegment(t.walPath, t.lastAppendedOffset.Load()+1, t.segmentSize, lastCrc); err != nil {
 		return err
 	}
 
@@ -427,7 +427,7 @@ func (t *wal) Clear() error {
 		return errors.Wrap(err, "failed to clear wal")
 	}
 
-	if t.currentSegment, err = newReadWriteSegment(t.walPath, 0, t.segmentSize); err != nil {
+	if t.currentSegment, err = newReadWriteSegment(t.walPath, 0, t.segmentSize, 0); err != nil {
 		return err
 	}
 
@@ -496,8 +496,8 @@ func (t *wal) TruncateLog(lastSafeOffset int64) (int64, error) { //nolint:revive
 				if err = segment.Close(); err != nil {
 					return InvalidOffset, err
 				}
-
-				if t.currentSegment, err = newReadWriteSegment(t.walPath, segment.Get().BaseOffset(), t.segmentSize); err != nil {
+				if t.currentSegment, err = newReadWriteSegment(t.walPath, segment.Get().BaseOffset(),
+					t.segmentSize, segment.Get().LastCrc()); err != nil {
 					err = multierr.Append(err, segment.Close())
 					return InvalidOffset, err
 				}
@@ -532,15 +532,20 @@ func (t *wal) recoverWal() error {
 	}
 
 	var firstSegment, lastSegment int64
+	var lastCrc uint32
 	if len(segments) > 0 {
 		firstSegment = segments[0]
 		lastSegment = segments[len(segments)-1]
+		if lastCrc, err = t.readOnlySegments.GetLastCrc(lastSegment); err != nil {
+			return err
+		}
 	} else {
 		firstSegment = 0
 		lastSegment = 0
+		lastCrc = 0
 	}
 
-	if t.currentSegment, err = newReadWriteSegment(t.walPath, lastSegment, t.segmentSize); err != nil {
+	if t.currentSegment, err = newReadWriteSegment(t.walPath, lastSegment, t.segmentSize, lastCrc); err != nil {
 		return err
 	}
 

--- a/server/wal/wal_ro_segment.go
+++ b/server/wal/wal_ro_segment.go
@@ -132,7 +132,7 @@ func (ms *readonlySegment) Read(offset int64) ([]byte, error) {
 	fileOffset := fileOffset(ms.idxMappedFile, ms.baseOffset, offset)
 
 	var entryCrc *uint32
-	var headerOffset uint32 = 0
+	var headerOffset uint32
 	if ms.formatVersion == TxnFormatVersion2 {
 		v := readInt(ms.txnMappedFile, fileOffset)
 		entryCrc = &v

--- a/server/wal/wal_ro_segment.go
+++ b/server/wal/wal_ro_segment.go
@@ -143,7 +143,7 @@ func (ms *readonlySegment) readWithCrc(offset int64) (uint32, []byte, error) {
 	expectSize := payloadSize + HeaderSize
 	if expectSize > uint32(len(ms.txnMappedFile))-fileReadOffset+headerOffset {
 		return 0, nil, errors.Wrapf(ErrWalDataCorrupted,
-			fmt.Sprintf("entryOffset: %d; overflow size: %d", offset, expectSize))
+			"entryOffset: %d; overflow size: %d", offset, expectSize)
 	}
 
 	var previousCrc uint32
@@ -163,8 +163,7 @@ func (ms *readonlySegment) readWithCrc(offset int64) (uint32, []byte, error) {
 			Update(ms.txnMappedFile[fileReadOffset+headerOffset : fileReadOffset+headerOffset+payloadSize]).Value()
 		if payloadCrc != expectedCrc {
 			return 0, nil, errors.Wrapf(ErrWalDataCorrupted,
-				fmt.Sprintf("entryOffset: %d; expected crc: %d; actual crc: %d",
-					offset, expectedCrc, payloadCrc))
+				"entryOffset: %d; expected crc: %d; actual crc: %d", offset, expectedCrc, payloadCrc)
 		}
 	}
 	return payloadCrc, entry, nil

--- a/server/wal/wal_ro_segment_test.go
+++ b/server/wal/wal_ro_segment_test.go
@@ -24,7 +24,7 @@ import (
 func TestReadOnlySegment(t *testing.T) {
 	path := t.TempDir()
 
-	rw, err := newReadWriteSegment(path, 0, 128*1024)
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0)
 	assert.NoError(t, err)
 	for i := int64(0); i < 10; i++ {
 		assert.NoError(t, rw.Append(i, []byte(fmt.Sprintf("entry-%d", i))))

--- a/server/wal/wal_rw_segment.go
+++ b/server/wal/wal_rw_segment.go
@@ -132,7 +132,7 @@ func (ms *readWriteSegment) Read(offset int64) ([]byte, error) {
 
 	fileOffset := fileOffset(ms.writingIdx, ms.baseOffset, offset)
 	var entryCrc *uint32
-	var headerOffset uint32 = 0
+	var headerOffset uint32
 	if ms.formatVersion == TxnFormatVersion2 {
 		v := readInt(ms.txnMappedFile, fileOffset)
 		entryCrc = &v

--- a/server/wal/wal_rw_segment.go
+++ b/server/wal/wal_rw_segment.go
@@ -16,7 +16,6 @@ package wal
 
 import (
 	"encoding/binary"
-	"fmt"
 	"github.com/streamnative/oxia/server/util/crc"
 	"os"
 	"sync"
@@ -155,7 +154,7 @@ func (ms *readWriteSegment) Read(offset int64) ([]byte, error) {
 	expectEntrySize := payloadSize + HeaderSize
 	if expectEntrySize > ms.segmentSize-fileReadOffset {
 		return nil, errors.Wrapf(ErrWalDataCorrupted,
-			fmt.Sprintf("entryOffset: %d; overflow size: %d", offset, expectEntrySize))
+			"entryOffset: %d; overflow size: %d", offset, expectEntrySize)
 	}
 
 	var previousCrc uint32
@@ -173,9 +172,8 @@ func (ms *readWriteSegment) Read(offset int64) ([]byte, error) {
 		expectedCrc := crc.Checksum(previousCrc).
 			Update(ms.txnMappedFile[fileReadOffset+headerOffset : fileReadOffset+headerOffset+payloadSize]).Value()
 		if payloadCrc != expectedCrc {
-			return nil, errors.Wrapf(ErrWalDataCorrupted,
-				fmt.Sprintf("entryOffset: %d; expected crc: %d; actual crc: %d",
-					offset, expectedCrc, payloadCrc))
+			return nil, errors.Wrapf(ErrWalDataCorrupted, "entryOffset: %d; expected crc: %d; actual crc: %d",
+				offset, expectedCrc, payloadCrc)
 		}
 	}
 	return entry, nil
@@ -244,9 +242,8 @@ func (ms *readWriteSegment) rebuildIdx() error {
 			expectedCrc := crc.Checksum(previousCrc).
 				Update(ms.txnMappedFile[ms.currentFileOffset+headerOffset : ms.currentFileOffset+headerOffset+payloadSize]).Value()
 			if payloadCrc != expectedCrc {
-				return errors.Wrapf(ErrWalDataCorrupted,
-					fmt.Sprintf("entryOffset: %d; expected crc: %d; actual crc: %d",
-						entryOffset, expectedCrc, payloadCrc))
+				return errors.Wrapf(ErrWalDataCorrupted, "entryOffset: %d; expected crc: %d; actual crc: %d",
+					entryOffset, expectedCrc, payloadCrc)
 			}
 			ms.lastCrc = payloadCrc
 		}
@@ -275,7 +272,6 @@ func (ms *readWriteSegment) Close() error {
 		// Write index file
 		ms.writeIndex(),
 	)
-
 	bufferPool.Put(&ms.writingIdx)
 	return err
 }
@@ -289,7 +285,6 @@ func (ms *readWriteSegment) Delete() error {
 }
 
 func (ms *readWriteSegment) writeIndex() error {
-
 	idxFile, err := os.OpenFile(ms.idxPath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open index file %s", ms.idxPath)

--- a/server/wal/wal_rw_segment_test.go
+++ b/server/wal/wal_rw_segment_test.go
@@ -107,5 +107,5 @@ func TestReadWriteSegment_HasSpace(t *testing.T) {
 	assert.True(t, rw.HasSpace(10))
 	assert.False(t, rw.HasSpace(1020))
 	assert.False(t, rw.HasSpace(1020-100))
-	assert.True(t, rw.HasSpace(1020-100-8))
+	assert.True(t, rw.HasSpace(1020-100-HeaderSize))
 }

--- a/server/wal/wal_rw_segment_test.go
+++ b/server/wal/wal_rw_segment_test.go
@@ -100,12 +100,12 @@ func TestReadWriteSegment_HasSpace(t *testing.T) {
 
 	assert.True(t, rw.HasSpace(10))
 	assert.False(t, rw.HasSpace(1024))
-	assert.True(t, rw.HasSpace(1020))
+	assert.True(t, rw.HasSpace(1024-HeaderSize))
 	assert.False(t, rw.HasSpace(1021))
 
 	assert.NoError(t, rw.Append(0, make([]byte, 100)))
 	assert.True(t, rw.HasSpace(10))
 	assert.False(t, rw.HasSpace(1020))
 	assert.False(t, rw.HasSpace(1020-100))
-	assert.True(t, rw.HasSpace(1020-100-HeaderSize))
+	assert.True(t, rw.HasSpace(1024-100-HeaderSize*2))
 }

--- a/server/wal/wal_rw_segment_test.go
+++ b/server/wal/wal_rw_segment_test.go
@@ -23,7 +23,7 @@ import (
 func TestReadWriteSegment(t *testing.T) {
 	path := t.TempDir()
 
-	rw, err := newReadWriteSegment(path, 0, 128*1024)
+	rw, err := newReadWriteSegment(path, 0, 128*1024, 0)
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 0, rw.BaseOffset())
@@ -42,7 +42,7 @@ func TestReadWriteSegment(t *testing.T) {
 	assert.NoError(t, rw.Close())
 
 	// Re-open and recover the segment
-	rw, err = newReadWriteSegment(path, 0, 128*1024)
+	rw, err = newReadWriteSegment(path, 0, 128*1024, 0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 0, rw.BaseOffset())
 	assert.EqualValues(t, 1, rw.LastOffset())
@@ -61,7 +61,7 @@ func TestReadWriteSegment(t *testing.T) {
 func TestReadWriteSegment_NonZero(t *testing.T) {
 	path := t.TempDir()
 
-	rw, err := newReadWriteSegment(path, 5, 128*1024)
+	rw, err := newReadWriteSegment(path, 5, 128*1024, 0)
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 5, rw.BaseOffset())
@@ -88,14 +88,14 @@ func TestReadWriteSegment_NonZero(t *testing.T) {
 	assert.NoError(t, rw.Close())
 
 	// Re-open and recover the segment
-	rw, err = newReadWriteSegment(path, 5, 128*1024)
+	rw, err = newReadWriteSegment(path, 5, 128*1024, 0)
 	assert.NoError(t, err)
 	assert.EqualValues(t, 5, rw.BaseOffset())
 	assert.EqualValues(t, 6, rw.LastOffset())
 }
 
 func TestReadWriteSegment_HasSpace(t *testing.T) {
-	rw, err := newReadWriteSegment(t.TempDir(), 0, 1024)
+	rw, err := newReadWriteSegment(t.TempDir(), 0, 1024, 0)
 	assert.NoError(t, err)
 
 	assert.True(t, rw.HasSpace(10))

--- a/server/wal/wal_rw_segment_test.go
+++ b/server/wal/wal_rw_segment_test.go
@@ -107,5 +107,5 @@ func TestReadWriteSegment_HasSpace(t *testing.T) {
 	assert.True(t, rw.HasSpace(10))
 	assert.False(t, rw.HasSpace(1020))
 	assert.False(t, rw.HasSpace(1020-100))
-	assert.True(t, rw.HasSpace(1020-100-4))
+	assert.True(t, rw.HasSpace(1020-100-8))
 }


### PR DESCRIPTION
### Motivation

To prevent data corruption from affecting the stability or causing unrecoverable exceptions. Introduce CRC to help validate if the data has corrupted.


### Modification

- Support chained CRC `CRC(n) = CRC( DATAn, CRCn-1 )` we can validate that followers have exactly the same identical WAL.
- Support `TxnFormatVersion2` for compatibility with the existing format.
- Adding CRC WAL test

### Others

will add the proposal later.