### PR TITLE
Force configmap ownership when updating

### DIFF
--- a/coordinator/impl/k8s_client.go
+++ b/coordinator/impl/k8s_client.go
@@ -17,6 +17,7 @@ package impl
 import (
 	"context"
 	"encoding/json"
+	pb "google.golang.org/protobuf/proto"
 	"log/slog"
 	"os"
 
@@ -102,6 +103,7 @@ func (c *clientImpl[Resource]) Upsert(namespace, name string, resource *Resource
 
 	result, err := client.Patch(ctx, name, types.ApplyPatchType, desiredBytes, metav1.PatchOptions{
 		FieldManager: fieldManager,
+		Force:        pb.Bool(true),
 	})
 
 	if errors.IsNotFound(err) {


### PR DESCRIPTION
If the status configmap is manually updated with kubectl, the coordinator is not able anymore to update the status.

The error is like: 

```
apply failed with 1 conflict: conflict with "kubectl-edit" using v1: .data.status' 
```

We need to force the coordinator to re-take the ownership of the configmap when trying to make changes.