### PR TITLE
feat(cli): support list ephemeral keys and pass multi keys to delete

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,7 +92,7 @@ linters-settings:
         severity: warning
         disabled: false
         arguments:
-          - 15
+          - 17
       - name: cyclomatic
         severity: warning
         disabled: false

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o bin/oxia ./cmd
+	go build -v -o bin/oxia ./cmd
 
 .PHONY: maelstrom
 maelstrom:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY: build
 build:
-	go build -v -o bin/oxia ./cmd
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o bin/oxia ./cmd
 
 .PHONY: maelstrom
 maelstrom:

--- a/cmd/client/del/cmd.go
+++ b/cmd/client/del/cmd.go
@@ -68,6 +68,9 @@ func exec(_ *cobra.Command, args []string) error {
 
 	for _, key := range keys {
 		if err := client.Delete(context.Background(), key, options...); err != nil {
+			if len(keys) == 1 {
+				return err
+			}
 			slog.Warn("delete key got an error", slog.String("key", key), slog.Any("error", err))
 			continue
 		}

--- a/cmd/client/get/cmd.go
+++ b/cmd/client/get/cmd.go
@@ -107,7 +107,7 @@ func exec(cmd *cobra.Command, args []string) error {
 			shadowKey := server.ShadowKey(server.SessionId(version.SessionId), originKey)
 			key, value, version, err := client.Get(context.Background(), shadowKey, options...)
 			if err != nil {
-				slog.Warn("Failed to get shadow key", slog.String("originKey", key),
+				slog.Warn("Failed to get shadow key", slog.String("originKey", originKey),
 					slog.String("shadowKey", shadowKey))
 			}
 			output(cmd, key, value, version)

--- a/cmd/client/list/cmd.go
+++ b/cmd/client/list/cmd.go
@@ -45,7 +45,6 @@ func init() {
 	Cmd.Flags().StringVarP(&Config.keyMax, "key-max", "e", "", "Key range maximum (exclusive)")
 	Cmd.Flags().StringVarP(&Config.partitionKey, "partition-key", "p", "", "Partition Key to be used in override the shard routing")
 	Cmd.Flags().BoolVar(&Config.ephemeral, "ephemeral", false, "Whether only list ephemeral keys")
-
 }
 
 var Cmd = &cobra.Command{

--- a/cmd/client/list/cmd.go
+++ b/cmd/client/list/cmd.go
@@ -70,7 +70,11 @@ func exec(cmd *cobra.Command, _ []string) error {
 
 	var keys []string
 	if Config.ephemeral {
-		ch := client.RangeScan(context.Background(), Config.keyMin, Config.keyMax)
+		var options []oxia.RangeScanOption
+		if Config.partitionKey != "" {
+			options = append(options, oxia.PartitionKey(Config.partitionKey))
+		}
+		ch := client.RangeScan(context.Background(), Config.keyMin, Config.keyMax, options...)
 		for result := range ch {
 			if result.Err != nil {
 				return result.Err


### PR DESCRIPTION
### Motivation

Support list ephemeral keys and pass multi keys to delete operation. Which can be used for uncleaned ephemeral keys by bugs.

example of deletion:
```
./oxia  client list --ephemeral -n xxxx | xargs ./oxia client delete -n xxxx
```

example of get shadow keys

```
oxia client list --ephemeral -n xxxx | xargs ./oxia client get --ephemeral-shadow-key -n xxxx
```
