### PR TITLE
fix(server): fix NPE causes server crash

### DIFF
--- a/server/kv/notifications_tracker.go
+++ b/server/kv/notifications_tracker.go
@@ -212,8 +212,13 @@ func (nt *notificationsTracker) ReadNextNotifications(ctx context.Context, start
 }
 
 func (nt *notificationsTracker) Close() error {
-	nt.cancel()
-	nt.closed.Store(true)
-	nt.cond.Broadcast()
-	return nt.waitClose.Wait(context.Background())
+	select {
+	case <-nt.ctx.Done():
+		return nil
+	default:
+		nt.cancel()
+		nt.closed.Store(true)
+		nt.cond.Broadcast()
+		return nt.waitClose.Wait(context.Background())
+	}
 }

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -1099,16 +1099,19 @@ func (lc *leaderController) DeleteShard(request *proto.DeleteShardRequest) (*pro
 	}
 
 	lc.log.Info("Deleting shard")
+	deleteWal := lc.wal
+	deleteDb := lc.db
 
-	// Wipe out both WAL and DB contents
-	if err := multierr.Combine(
-		lc.wal.Delete(),
-		lc.db.Delete(),
-	); err != nil {
+	// close the leader controller first
+	if err := lc.close(); err != nil {
 		return nil, err
 	}
 
-	if err := lc.close(); err != nil {
+	// Wipe out both WAL and DB contents
+	if err := multierr.Combine(
+		deleteWal.Delete(),
+		deleteDb.Delete(),
+	); err != nil {
 		return nil, err
 	}
 

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -1108,8 +1108,6 @@ func (lc *leaderController) DeleteShard(request *proto.DeleteShardRequest) (*pro
 		return nil, err
 	}
 
-	lc.db = nil
-	lc.wal = nil
 	if err := lc.close(); err != nil {
 		return nil, err
 	}

--- a/server/wal/wal_trimmer.go
+++ b/server/wal/wal_trimmer.go
@@ -86,11 +86,16 @@ type trimmer struct {
 }
 
 func (t *trimmer) Close() error {
-	t.cancel()
-	t.ticker.Stop()
+	select {
+	case <-t.ctx.Done():
+		return nil
+	default:
+		t.cancel()
+		t.ticker.Stop()
 
-	<-t.waitClose
-	return nil
+		<-t.waitClose
+		return nil
+	}
 }
 
 func (t *trimmer) run() {


### PR DESCRIPTION
### Motivation

```
Oct 16 17:43:07.322395 DBG Received list request component=leader-controller namespace=default request={"endExclusive":"__oxia/session/0000000000000000//","shard":"0","startInclusive":"__oxia/session/0000000000000000/"} shard=2 term=2
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1545b3b]

goroutine 1275 [running]:
github.com/streamnative/oxia/server.(*leaderController).list.func1()
	/home/runner/work/oxia/oxia/server/leader_controller.go:654 +0x25b
github.com/streamnative/oxia/common.DoWithLabels.func1({0x1b2cf80?, 0xc000833020?})
	/home/runner/work/oxia/oxia/common/pprof.go:46 +0x2f
runtime/pprof.Do({0x1b2cd50, 0x332be60}, {{0xc001294c00?, 0x1?, 0x1?}}, 0xc000880d10)
	/opt/hostedtoolcache/go/1.22.8/x64/src/runtime/pprof/runtime.go:51 +0x118
github.com/streamnative/oxia/common.DoWithLabels({0x1b2cd50, 0x332be60}, 0xc000880f40, 0xc000880dc8)
	/home/runner/work/oxia/oxia/common/pprof.go:42 +0x585
github.com/streamnative/oxia/server.(*leaderController).list(0xc000ef2120, {0x1b2cd50, 0x332be60}, 0xc001294b40, 0xc00073e540)
	/home/runner/work/oxia/oxia/server/leader_controller.go:639 +0x3b6
created by github.com/streamnative/oxia/server.(*leaderController).ListSliceNoMutex in goroutine 981
	/home/runner/work/oxia/oxia/server/leader_controller.go:686 +0x216
FAIL	github.com/streamnative/oxia/server	8.710s
ok  	github.com/streamnative/oxia/server/kv	8.788s	coverage: 80.2% of statements
ok  	github.com/streamnative/oxia/server/util	1.018s	coverage: 8.5% of statements
ok  	github.com/streamnative/oxia/server/wal	4.214s	coverage: 73.4% of statements
ok  	github.com/streamnative/oxia/server/wal/codec	1.014s	coverage: 83.8% of statements
ok  	github.com/streamnative/oxia/tests/security/auth	5.209s	coverage: 80.5% of statements
ok  	github.com/streamnative/oxia/tests/security/tls	10.355s	coverage: 32.7% of statements
FAIL
make: *** [Makefile:24: test] Error 1
```

https://github.com/streamnative/oxia/actions/runs/11370802586/attempts/2?pr=552
### Modification

- Close resources before deleting.
- Add logic to avoid repeated closures