### PR TITLE
feat(coordinator): using the pointer bool for NotificationsEnabled flag

### DIFF
--- a/coordinator/impl/shard_controller.go
+++ b/coordinator/impl/shard_controller.go
@@ -604,7 +604,7 @@ func (s *shardController) newTerm(ctx context.Context, node model.ServerAddress)
 		Shard:     s.shard,
 		Term:      s.shardMetadata.Term,
 		Options: &proto.NewTermOptions{
-			EnableNotifications: s.namespaceConfig.NotificationsEnabled.Get(),
+			EnableNotifications: s.namespaceConfig.GetNotificationEnabled(),
 		},
 	})
 	if err != nil {

--- a/coordinator/impl/shard_controller_test.go
+++ b/coordinator/impl/shard_controller_test.go
@@ -32,7 +32,7 @@ var namespaceConfig = &model.NamespaceConfig{
 	Name:                 "my-namespace",
 	InitialShardCount:    1,
 	ReplicationFactor:    3,
-	NotificationsEnabled: common.OptBooleanDefaultTrue{},
+	NotificationsEnabled: nil,
 }
 
 func TestShardController(t *testing.T) {
@@ -305,11 +305,12 @@ func TestShardController_NotificationsDisabled(t *testing.T) {
 	s2 := model.ServerAddress{Public: "s2:9091", Internal: "s2:8191"}
 	s3 := model.ServerAddress{Public: "s3:9091", Internal: "s3:8191"}
 
+	pFalse := false
 	namespaceConfig := &model.NamespaceConfig{
 		Name:                 "my-ns-2",
 		InitialShardCount:    1,
 		ReplicationFactor:    1,
-		NotificationsEnabled: common.Bool(false),
+		NotificationsEnabled: &pFalse,
 	}
 
 	sc := NewShardController(common.DefaultNamespace, shard, namespaceConfig, model.ShardMetadata{

--- a/coordinator/model/cluster_config.go
+++ b/coordinator/model/cluster_config.go
@@ -23,7 +23,7 @@ type NamespaceConfig struct {
 	Name                 string `json:"name" yaml:"name"`
 	InitialShardCount    uint32 `json:"initialShardCount" yaml:"initialShardCount"`
 	ReplicationFactor    uint32 `json:"replicationFactor" yaml:"replicationFactor"`
-	NotificationsEnabled *bool  `json:"notificationsEnabled,omitempty" yaml:"notificationsEnabled"`
+	NotificationsEnabled *bool  `json:"notificationsEnabled,omitempty" yaml:"notificationsEnabled,omitempty"`
 }
 
 func (nc *NamespaceConfig) GetNotificationEnabled() bool {

--- a/coordinator/model/cluster_config.go
+++ b/coordinator/model/cluster_config.go
@@ -14,16 +14,21 @@
 
 package model
 
-import "github.com/streamnative/oxia/common"
-
 type ClusterConfig struct {
 	Namespaces []NamespaceConfig `json:"namespaces" yaml:"namespaces"`
 	Servers    []ServerAddress   `json:"servers" yaml:"servers"`
 }
 
 type NamespaceConfig struct {
-	Name                 string                       `json:"name" yaml:"name"`
-	InitialShardCount    uint32                       `json:"initialShardCount" yaml:"initialShardCount"`
-	ReplicationFactor    uint32                       `json:"replicationFactor" yaml:"replicationFactor"`
-	NotificationsEnabled common.OptBooleanDefaultTrue `json:"notificationsEnabled" yaml:"notificationsEnabled"`
+	Name                 string `json:"name" yaml:"name"`
+	InitialShardCount    uint32 `json:"initialShardCount" yaml:"initialShardCount"`
+	ReplicationFactor    uint32 `json:"replicationFactor" yaml:"replicationFactor"`
+	NotificationsEnabled *bool  `json:"notificationsEnabled,omitempty" yaml:"notificationsEnabled"`
+}
+
+func (nc *NamespaceConfig) GetNotificationEnabled() bool {
+	if nc.NotificationsEnabled == nil {
+		return true
+	}
+	return *nc.NotificationsEnabled
 }


### PR DESCRIPTION
### Motivation

Currently, we are using `OptBooleanDefaultTrue` as the value for `NotificationsEnabled`. However, that is not very friendly for JSON/YAML struct. We should put an extra `val` key into the map. Such as:

```yaml
notificationsEnabled:
        val: "false"
```

Otherwise, the coordinator will get an error. `'Namespaces[0].NotificationsEnabled' expected a map`


This PR proposes using a pointer bool and adding a `GetNotificationEnabled` method to make it easier for the codec. 




### Modification

- change `NotificationsEnabled` type from `OptBooleanDefaultTrue` to pointer bool.