### PR TITLE
Clear pooled connection after node health checks

### DIFF
--- a/cmd/health/cmd.go
+++ b/cmd/health/cmd.go
@@ -67,10 +67,11 @@ func exec(*cobra.Command, []string) error {
 
 	serverAddress := fmt.Sprintf("%s:%d", config.Host, config.Port)
 
-	rpc, err := clientPool.GetHealthRpc(serverAddress)
+	rpc, closer, err := clientPool.GetHealthRpc(serverAddress)
 	if err != nil {
 		return err
 	}
+	defer closer.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 	defer cancel()

--- a/coordinator/impl/mock_test.go
+++ b/coordinator/impl/mock_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -214,6 +215,9 @@ type mockRpcProvider struct {
 	channels map[string]*mockPerNodeChannels
 }
 
+func (r *mockRpcProvider) ClearPooledConnections(node model.ServerAddress) {
+}
+
 func newMockRpcProvider() *mockRpcProvider {
 	return &mockRpcProvider{
 		channels: make(map[string]*mockPerNodeChannels),
@@ -380,8 +384,9 @@ func (r *mockRpcProvider) AddFollower(ctx context.Context, node model.ServerAddr
 	}
 }
 
-func (r *mockRpcProvider) GetHealthClient(node model.ServerAddress) (grpc_health_v1.HealthClient, error) {
-	return r.GetNode(node).healthClient, nil
+func (r *mockRpcProvider) GetHealthClient(node model.ServerAddress) (grpc_health_v1.HealthClient, io.Closer, error) {
+	c := r.GetNode(node).healthClient
+	return c, c, nil
 }
 
 type mockShardAssignmentClient struct {
@@ -452,6 +457,10 @@ type mockHealthClient struct {
 	status  grpc_health_v1.HealthCheckResponse_ServingStatus
 	err     error
 	watches []*mockHealthWatchClient
+}
+
+func (m *mockHealthClient) Close() error {
+	return nil
 }
 
 func newMockHealthClient() *mockHealthClient {


### PR DESCRIPTION
When using Istio between coordinator and storage node, we should discard all the pooled connections in the coordinator, after a node is declared failed (and then it recovers).

The problem is that the gRPC client is not able to detect that TCP has failed, because of the Istio proxy. eg: 
 * the istio is still setup to talk with the old pod
 * coordinator uses the pooled client and writes to a gRPC stream. There is no failure, even though the channel is not valid

In normal conditions, gRPC will process the TCP failure and open a new connection, though this does not work with Istio in between.

### Modifications

Force to discard all the pooled gRPC clients for target node once we have successfully reconnected with the new pod.