### PR TITLE
fix(server): allow higher term shard deleting

### DIFF
--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -749,7 +749,7 @@ func (fc *followerController) DeleteShard(request *proto.DeleteShardRequest) (*p
 	fc.Lock()
 	defer fc.Unlock()
 
-	if request.Term != fc.term {
+	if request.Term < fc.term {
 		fc.log.Warn("Invalid term when deleting shard",
 			slog.Int64("follower-term", fc.term),
 			slog.Int64("new-term", request.Term))

--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -824,12 +824,12 @@ func TestFollowerController_DeleteShard_WrongTerm(t *testing.T) {
 	walFactory := newTestWalFactory(t)
 
 	fc, _ := NewFollowerController(Config{}, common.DefaultNamespace, shardId, walFactory, kvFactory)
-	_, _ = fc.NewTerm(&proto.NewTermRequest{Term: 1})
+	_, _ = fc.NewTerm(&proto.NewTermRequest{Term: 2})
 
 	_, err := fc.DeleteShard(&proto.DeleteShardRequest{
 		Namespace: common.DefaultNamespace,
 		Shard:     shardId,
-		Term:      2,
+		Term:      1,
 	})
 
 	assert.ErrorIs(t, err, common.ErrorInvalidTerm)

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -1090,7 +1090,7 @@ func (lc *leaderController) DeleteShard(request *proto.DeleteShardRequest) (*pro
 	lc.Lock()
 	defer lc.Unlock()
 
-	if request.Term != lc.term {
+	if request.Term < lc.term {
 		lc.log.Warn("Invalid term when deleting shard",
 			slog.Int64("follower-term", lc.term),
 			slog.Int64("new-term", request.Term))


### PR DESCRIPTION
### Motivation

The coordinator will replace the ensemble when swapping the node. Therefore, the old node can't receive new term requests, and the actual shard term will be greater than the old server. and then the old server will keep printing 

```
Invalid term when deleting shard
```

### Modification

- Allow higher term shard deleting.

### Alternatives

- save the deleting term before the new ensemble is elected.