### PR TITLE
fix(wal): fix wrong overflow validation calculation

### DIFF
--- a/server/wal/codec/v2.go
+++ b/server/wal/codec/v2.go
@@ -116,7 +116,7 @@ func (v *V2) ReadHeaderWithValidation(buf []byte, startFileOffset uint32) (paylo
 
 	expectSize := payloadSize + v.HeaderSize
 	// overflow checking
-	actualBufSize := bufSize - (startFileOffset + headerOffset)
+	actualBufSize := bufSize - startFileOffset
 	if expectSize > actualBufSize {
 		return payloadSize, previousCrc, payloadCrc,
 			errors.Wrapf(ErrOffsetOutOfBounds, "expected payload size: %d. actual buf size: %d ", expectSize, bufSize)

--- a/server/wal/codec/v2_test.go
+++ b/server/wal/codec/v2_test.go
@@ -15,6 +15,7 @@
 package codec
 
 import (
+	"bytes"
 	"encoding/binary"
 	"github.com/google/uuid"
 	"os"
@@ -307,4 +308,14 @@ func TestV2_IndexBroken(t *testing.T) {
 
 	_, err = v2.ReadIndex(p)
 	assert.ErrorIs(t, err, ErrDataCorrupted)
+}
+
+func TestV2_ReadWithValidation(t *testing.T) {
+	buf := make([]byte, 15)
+	payloadSize := uint32(len(buf)) - v2.HeaderSize
+	payload := bytes.Repeat([]byte("A"), int(payloadSize))
+	_, wPayloadCrc := v2.WriteRecord(buf, 0, 0, payload)
+	_, _, rPayloadCrc, err := v2.ReadHeaderWithValidation(buf, 0)
+	assert.NoError(t, err)
+	assert.EqualValues(t, wPayloadCrc, rPayloadCrc)
 }


### PR DESCRIPTION
### Motivation


The calculation of the actual buf remain size should not include a header.

```
actualBufSize := bufSize - startFileOffset
```