### PR TITLE
fix(server): fix the deadlock by writeStream

### DIFF
--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -891,6 +891,7 @@ func (lc *leaderController) WriteStream(stream proto.OxiaClient_WriteStreamServe
 	}
 }
 
+//nolint:cognitive-complexity
 func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stream proto.OxiaClient_WriteStreamServer) {
 	lastCallbackError := atomic.Pointer[error]{}
 	for {

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -919,20 +919,20 @@ func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stre
 			lc.quorumAckTracker.WaitForCommitOffsetAsync(stream.Context(), offset, func(_ context.Context, innerErr error) {
 				if innerErr != nil {
 					latencyTimer.Done()
-					slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
+					slog.Debug("Got an callback error when commit async", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				var writeResponse *proto.WriteResponse
 				if writeResponse, err = lc.db.ProcessWrite(writeRequest, offset, timestamp, WrapperUpdateOperationCallback); err != nil {
 					latencyTimer.Done()
-					slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
+					slog.Debug("Got an callback error when write to DB", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				if err = stream.Send(writeResponse); err != nil {
 					latencyTimer.Done()
-					slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
+					slog.Debug("Got an callback error when write response to client", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -891,7 +891,7 @@ func (lc *leaderController) WriteStream(stream proto.OxiaClient_WriteStreamServe
 	}
 }
 
-// nolint:cognitive-complexity
+// nolint:revive
 func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stream proto.OxiaClient_WriteStreamServer) {
 	lastCallbackError := atomic.Pointer[error]{}
 	for {
@@ -911,27 +911,27 @@ func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stre
 		slog.Debug("Got request in stream", slog.Any("req", writeRequest))
 		lc.appendToWalStreamRequest(writeRequest, func(offset int64, timestamp uint64, err error) {
 			if err != nil {
-				latencyTimer.Done() // nolint:contextcheck
+				latencyTimer.Done()
 				slog.Debug("Got an error when write to wal", slog.Any("error", err))
 				lastCallbackError.Store(&err)
 				return
 			}
 			lc.quorumAckTracker.WaitForCommitOffsetAsync(stream.Context(), offset, func(_ context.Context, innerErr error) {
 				if innerErr != nil {
-					latencyTimer.Done() // nolint:contextcheck
+					latencyTimer.Done()
 					slog.Debug("Got an error when commit async", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				var writeResponse *proto.WriteResponse
 				if writeResponse, err = lc.db.ProcessWrite(writeRequest, offset, timestamp, WrapperUpdateOperationCallback); err != nil {
-					latencyTimer.Done() // nolint:contextcheck
+					latencyTimer.Done()
 					slog.Debug("Got an error when write to DB", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				if err = stream.Send(writeResponse); err != nil {
-					latencyTimer.Done() // nolint:contextcheck
+					latencyTimer.Done()
 					slog.Debug("Got an error when write response to client", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -891,7 +891,7 @@ func (lc *leaderController) WriteStream(stream proto.OxiaClient_WriteStreamServe
 	}
 }
 
-//nolint:cognitive-complexity
+// nolint:cognitive-complexity
 func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stream proto.OxiaClient_WriteStreamServer) {
 	lastCallbackError := atomic.Pointer[error]{}
 	for {
@@ -911,27 +911,27 @@ func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stre
 		slog.Debug("Got request in stream", slog.Any("req", writeRequest))
 		lc.appendToWalStreamRequest(writeRequest, func(offset int64, timestamp uint64, err error) {
 			if err != nil {
-				latencyTimer.Done()
+				latencyTimer.Done() // nolint:contextcheck
 				slog.Debug("Got an error when write to wal", slog.Any("error", err))
 				lastCallbackError.Store(&err)
 				return
 			}
 			lc.quorumAckTracker.WaitForCommitOffsetAsync(stream.Context(), offset, func(_ context.Context, innerErr error) {
 				if innerErr != nil {
-					latencyTimer.Done()
+					latencyTimer.Done() // nolint:contextcheck
 					slog.Debug("Got an error when commit async", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				var writeResponse *proto.WriteResponse
 				if writeResponse, err = lc.db.ProcessWrite(writeRequest, offset, timestamp, WrapperUpdateOperationCallback); err != nil {
-					latencyTimer.Done()
+					latencyTimer.Done() // nolint:contextcheck
 					slog.Debug("Got an error when write to DB", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				if err = stream.Send(writeResponse); err != nil {
-					latencyTimer.Done()
+					latencyTimer.Done() // nolint:contextcheck
 					slog.Debug("Got an error when write response to client", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -912,27 +912,27 @@ func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stre
 		lc.appendToWalStreamRequest(writeRequest, func(offset int64, timestamp uint64, err error) {
 			if err != nil {
 				latencyTimer.Done()
-				slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
+				slog.Debug("Got an error when write to wal", slog.Any("error", err))
 				lastCallbackError.Store(&err)
 				return
 			}
 			lc.quorumAckTracker.WaitForCommitOffsetAsync(stream.Context(), offset, func(_ context.Context, innerErr error) {
 				if innerErr != nil {
 					latencyTimer.Done()
-					slog.Debug("Got an callback error when commit async", slog.Any("error", err))
+					slog.Debug("Got an error when commit async", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				var writeResponse *proto.WriteResponse
 				if writeResponse, err = lc.db.ProcessWrite(writeRequest, offset, timestamp, WrapperUpdateOperationCallback); err != nil {
 					latencyTimer.Done()
-					slog.Debug("Got an callback error when write to DB", slog.Any("error", err))
+					slog.Debug("Got an error when write to DB", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				if err = stream.Send(writeResponse); err != nil {
 					latencyTimer.Done()
-					slog.Debug("Got an callback error when write response to client", slog.Any("error", err))
+					slog.Debug("Got an error when write response to client", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -897,7 +897,7 @@ func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stre
 	for {
 		if lastCallbackError.Load() != nil {
 			closeStreamSignal <- *lastCallbackError.Load()
-			break
+			return
 		}
 
 		var writeRequest *proto.WriteRequest

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -912,23 +912,27 @@ func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stre
 		lc.appendToWalStreamRequest(writeRequest, func(offset int64, timestamp uint64, err error) {
 			if err != nil {
 				latencyTimer.Done()
+				slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
 				lastCallbackError.Store(&err)
 				return
 			}
 			lc.quorumAckTracker.WaitForCommitOffsetAsync(stream.Context(), offset, func(_ context.Context, innerErr error) {
 				if innerErr != nil {
 					latencyTimer.Done()
+					slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				var writeResponse *proto.WriteResponse
 				if writeResponse, err = lc.db.ProcessWrite(writeRequest, offset, timestamp, WrapperUpdateOperationCallback); err != nil {
 					latencyTimer.Done()
+					slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}
 				if err = stream.Send(writeResponse); err != nil {
 					latencyTimer.Done()
+					slog.Debug("Got an callback error when write to wal", slog.Any("error", err))
 					lastCallbackError.Store(&err)
 					return
 				}

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -891,7 +891,7 @@ func (lc *leaderController) WriteStream(stream proto.OxiaClient_WriteStreamServe
 	}
 }
 
-// nolint:revive
+// nolint:revive,contextcheck
 func (lc *leaderController) handleWriteStream(closeStreamSignal chan error, stream proto.OxiaClient_WriteStreamServer) {
 	lastCallbackError := atomic.Pointer[error]{}
 	for {

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -141,14 +141,13 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 		return err
 	}
 
-	err = lc.WriteStream(stream)
-	if err != nil &&
-		!errors.Is(err, io.EOF) &&
-		!errors.Is(err, context.Canceled) {
-		log.Warn(
-			"Write stream failed",
-			slog.Any("error", err),
-		)
+	if err = lc.WriteStream(stream); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+			log.Info("Write stream closed")
+			return nil
+		}
+		log.Warn("Write stream unexpected closed", slog.Any("error", err))
+		return err
 	}
 	return err
 }

--- a/server/quorum_ack_tracker.go
+++ b/server/quorum_ack_tracker.go
@@ -68,7 +68,7 @@ type QuorumAckTracker interface {
 }
 
 type quorumAckTracker struct {
-	sync.RWMutex
+	sync.Mutex
 	waitingRequests   []waitingRequest
 	waitForHeadOffset common.ConditionContext
 
@@ -154,19 +154,16 @@ func (q *quorumAckTracker) HeadOffset() int64 {
 }
 
 func (q *quorumAckTracker) WaitForHeadOffset(ctx context.Context, offset int64) error {
-	for {
-		q.RLock()
-		// safe judge if current tracker is closed
-		if q.closed {
-			return nil
-		}
-		q.RUnlock()
-		if q.headOffset.Load() < offset {
-			if err := q.waitForHeadOffset.Wait(ctx); err != nil {
-				return err
-			}
+	q.Lock()
+	defer q.Unlock()
+
+	for !q.closed && q.headOffset.Load() < offset {
+		if err := q.waitForHeadOffset.Wait(ctx); err != nil {
+			return err
 		}
 	}
+
+	return nil
 }
 
 func (q *quorumAckTracker) WaitForCommitOffset(ctx context.Context, offset int64, f func() (*proto.WriteResponse, error)) (*proto.WriteResponse, error) {

--- a/server/quorum_ack_tracker_test.go
+++ b/server/quorum_ack_tracker_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/streamnative/oxia/proto"
 	"github.com/streamnative/oxia/server/wal"
 )
 
@@ -188,8 +187,9 @@ func TestQuorumAckTracker_WaitForCommitOffset(t *testing.T) {
 	ch := make(chan error)
 
 	go func() {
-		_, err := at.WaitForCommitOffset(context.Background(), 2, func() (*proto.WriteResponse, error) {
-			return nil, nil //nolint:nilnil
+		var err error
+		at.WaitForCommitOffset(context.Background(), 2, func(_ context.Context, innerErr error) {
+			err = innerErr
 		})
 		ch <- err
 	}()


### PR DESCRIPTION
### Motivation

We used the `write stream` for the put and delete operations. And async waits for the `wal-sync` goroutine to finish the replication and to do the callback to store data into the DB. 

The key point is here. If the `notifyCommitOffsetAdvanced` is blocked by `closeStreamCh`. all the related goroutine can also be stuck by channel.

the stuck goroutines and stacks:

```
// first stuck goroutine

3 @ 0x44352e 0x40c1cd 0x40be37 0x1b3ab3d 0x1b40c1a 0x1b40c76 0x1b41305 0x1b411a7 0x1b2ff31 0x1b2fd85 0xa72973 0xa69cdd 0xa728f6 0x47b061
#	0x1b3ab3c	github.com/streamnative/oxia/server.(*leaderController).handleWalSynced.func2+0x9c		/src/oxia/server/leader_controller.go:926
#	0x1b40c19	github.com/streamnative/oxia/server.(*quorumAckTracker).WaitForCommitOffsetAsync.func1+0x39	/src/oxia/server/quorum_ack_tracker.go:219
#	0x1b40c75	github.com/streamnative/oxia/server.(*quorumAckTracker).notifyCommitOffsetAdvanced+0x35		/src/oxia/server/quorum_ack_tracker.go:234
#	0x1b41304	github.com/streamnative/oxia/server.(*cursorAcker).ack+0xa4					/src/oxia/server/quorum_ack_tracker.go:297
#	0x1b411a6	github.com/streamnative/oxia/server.(*cursorAcker).Ack+0x86					/src/oxia/server/quorum_ack_tracker.go:278
#	0x1b2ff30	github.com/streamnative/oxia/server.(*followerCursor).receiveAcks+0x130				/src/oxia/server/follower_cursor.go:430
#	0x1b2fd84	github.com/streamnative/oxia/server.(*followerCursor).streamEntries.func1+0x24			/src/oxia/server/follower_cursor.go:390
#	0xa72972	github.com/streamnative/oxia/common.DoWithLabels.func1+0x12					/src/oxia/common/pprof.go:46
#	0xa69cdc	runtime/pprof.Do+0x9c										/usr/local/go/src/runtime/pprof/runtime.go:51
#	0xa728f5	github.com/streamnative/oxia/common.DoWithLabels+0x355						/src/oxia/common/pprof.go:42

// second stuck goroutine
1 @ 0x44352e 0x4563a5 0x456374 0x477105 0x48685d 0x1b403c7 0x1b403ac 0x1b3b285 0xaf968c 0xa72973 0xa69cdd 0xa728f6 0x47b061
#	0x477104	sync.runtime_SemacquireMutex+0x24								/usr/local/go/src/runtime/sema.go:77
#	0x48685c	sync.(*Mutex).lockSlow+0x15c									/usr/local/go/src/sync/mutex.go:171
#	0x1b403c6	sync.(*Mutex).Lock+0x46										/usr/local/go/src/sync/mutex.go:90
#	0x1b403ab	github.com/streamnative/oxia/server.(*quorumAckTracker).AdvanceHeadOffset+0x2b			/src/oxia/server/quorum_ack_tracker.go:127
#	0x1b3b284	github.com/streamnative/oxia/server.(*leaderController).appendToWalStreamRequest.func1+0x84	/src/oxia/server/leader_controller.go:976
#	0xaf968b	github.com/streamnative/oxia/server/wal.(*wal).runSync+0x36b					/src/oxia/server/wal/wal_impl.go:380
#	0xa72972	github.com/streamnative/oxia/common.DoWithLabels.func1+0x12					/src/oxia/common/pprof.go:46
#	0xa69cdc	runtime/pprof.Do+0x9c										/usr/local/go/src/runtime/pprof/runtime.go:51
#	0xa728f5	github.com/streamnative/oxia/common.DoWithLabels+0x355						/src/oxia/common/pprof.go:42


// Third stuck goroutine
1 @ 0x44352e 0x4563a5 0x456374 0x477105 0x48685d 0x487d31 0x487d12 0x1b3ac6b 0x1b3a4dd 0x1b3a445 0xa72973 0xa69cdd 0xa728f6 0x47b061
#	0x477104	sync.runtime_SemacquireMutex+0x24							/usr/local/go/src/runtime/sema.go:77
#	0x48685c	sync.(*Mutex).lockSlow+0x15c								/usr/local/go/src/sync/mutex.go:171
#	0x487d30	sync.(*Mutex).Lock+0x30									/usr/local/go/src/sync/mutex.go:90
#	0x487d11	sync.(*RWMutex).Lock+0x11								/usr/local/go/src/sync/rwmutex.go:146
#	0x1b3ac6a	github.com/streamnative/oxia/server.(*leaderController).appendToWalStreamRequest+0x4a	/src/oxia/server/leader_controller.go:935
#	0x1b3a4dc	github.com/streamnative/oxia/server.(*leaderController).handleWriteStream+0x7c		/src/oxia/server/leader_controller.go:900
#	0x1b3a444	github.com/streamnative/oxia/server.(*leaderController).WriteStream.func1+0x24		/src/oxia/server/leader_controller.go:870
#	0xa72972	github.com/streamnative/oxia/common.DoWithLabels.func1+0x12				/src/oxia/common/pprof.go:46
#	0xa69cdc	runtime/pprof.Do+0x9c									/usr/local/go/src/runtime/pprof/runtime.go:51
#	0xa728f5	github.com/streamnative/oxia/common.DoWithLabels+0x355					/src/oxia/common/pprof.go:42

// then the leaderController lock has been locked forever.
```


### Modification

- Avoid passing the channel for the deeper callback.
- Refactor `WriteStream` logic by closure to avoid many callbacks.
