### PR TITLE
Return specific error code on duplicated newTerm

### DIFF
--- a/common/error_codes.go
+++ b/common/error_codes.go
@@ -33,6 +33,7 @@ const (
 	CodeNamespaceNotFound       codes.Code = 110
 	CodeNotificationsNotEnabled codes.Code = 111
 	CodeFollowerAlreadyPresent  codes.Code = 112
+	CodeFollowerAlreadyFenced   codes.Code = 113
 )
 
 var (
@@ -49,4 +50,5 @@ var (
 	ErrorNamespaceNotFound       = status.Error(CodeNamespaceNotFound, "oxia: namespace not found")
 	ErrorNotificationsNotEnabled = status.Error(CodeNotificationsNotEnabled, "oxia: notifications not enabled on namespace")
 	ErrorFollowerAlreadyPresent  = status.Error(CodeFollowerAlreadyPresent, "oxia: follower is already present")
+	ErrorFollowerAlreadyFenced   = status.Error(CodeFollowerAlreadyFenced, "oxia: follower is already fenced")
 )

--- a/coordinator/impl/shard_controller.go
+++ b/coordinator/impl/shard_controller.go
@@ -498,7 +498,7 @@ func (s *shardController) newTermAndAddFollower(ctx context.Context, node model.
 
 func (s *shardController) internalNewTermAndAddFollower(ctx context.Context, node model.ServerAddress, res chan error) {
 	fr, err := s.newTerm(ctx, node)
-	if err != nil {
+	if err != nil && status.Code(err) != common.CodeFollowerAlreadyFenced {
 		res <- err
 		return
 	}

--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -275,7 +275,7 @@ func (fc *followerController) NewTerm(req *proto.NewTermRequest) (*proto.NewTerm
 			slog.Int64("new-term", req.Term),
 			slog.Any("status", fc.status),
 		)
-		return nil, common.ErrorInvalidStatus
+		return nil, common.ErrorFollowerAlreadyFenced
 	}
 
 	if fc.db == nil {


### PR DESCRIPTION
If the follower has already been fenced and added as a follower to the leader, we can return a specific error to the coordinator when it retries the fencing. 

This will allow the coordinator to recognize that the straggler node is actually already set in the right state, and it will stop the retry process.