### PR TITLE
fix(server): fix data race in follower controller

### DIFF
--- a/server/follower_controller.go
+++ b/server/follower_controller.go
@@ -189,13 +189,14 @@ func (fc *followerController) isClosed() bool {
 }
 
 func (fc *followerController) Close() error {
-	fc.log.Debug("Closing follower controller")
 	fc.cancel()
 
 	<-fc.applyEntriesDone
 
 	fc.Lock()
 	defer fc.Unlock()
+
+	fc.log.Debug("Closing follower controller")
 	return fc.close()
 }
 


### PR DESCRIPTION
### Motivation

```
WARNING: DATA RACE
Write at 0x00c000676410 by goroutine 408:
  github.com/streamnative/oxia/server.(*followerController).setLogger()
      /home/runner/work/oxia/oxia/server/follower_controller.go:179 +0x2d2
  github.com/streamnative/oxia/server.(*followerController).NewTerm()
      /home/runner/work/oxia/oxia/server/follower_controller.go:296 +0x4c4
  github.com/streamnative/oxia/server.(*internalRpcServer).NewTerm()
      /home/runner/work/oxia/oxia/server/internal_rpc_server.go:125 +0x941
  github.com/streamnative/oxia/proto._OxiaCoordination_NewTerm_Handler.func1()
      /home/runner/work/oxia/oxia/proto/replication_grpc.pb.go:207 +0xbe
  github.com/grpc-ecosystem/go-grpc-prometheus.init.(*ServerMetrics).UnaryServerInterceptor.func3()
      /home/runner/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:107 +0xbb
  github.com/streamnative/oxia/proto._OxiaCoordination_NewTerm_Handler()
      /home/runner/work/oxia/oxia/proto/replication_grpc.pb.go:209 +0x1f3
  google.golang.org/grpc.(*Server).processUnaryRPC()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1394 +0x1b4b
  google.golang.org/grpc.(*Server).handleStream()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1805 +0x1824
  google.golang.org/grpc.(*Server).serveStreams.func2.1()
      /home/runner/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1029 +0x158

Previous read at 0x00c000676410 by goroutine 23:
  github.com/streamnative/oxia/server.(*followerController).Close()
      /home/runner/work/oxia/oxia/server/follower_controller.go:192 +0x50
  github.com/streamnative/oxia/server.(*shardsDirector).Close()
      /home/runner/work/oxia/oxia/server/shards_director.go:243 +0x30b
  github.com/streamnative/oxia/server.(*Server).Close()
      /home/runner/work/oxia/oxia/server/server.go:134 +0xba
  github.com/streamnative/oxia/tests/security/auth.newOxiaClusterWithAuth.func2()
      /home/runner/work/oxia/oxia/tests/security/auth/auth_oidc_test.go:116 +0x78
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.23.3/x64/src/runtime/panic.go:605 +0x5d
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44
```