### PR TITLE
Reset backoff in replicate stream attempts only after an ack

### DIFF
--- a/server/follower_cursor.go
+++ b/server/follower_cursor.go
@@ -355,9 +355,6 @@ func (fc *followerCursor) streamEntriesLoop(ctx context.Context, reader wal.Read
 
 		fc.lastPushed.Store(le.Offset)
 		currentOffset = le.Offset
-
-		// Since we've made progress, we can reset the backoff to initial setting
-		fc.backoff.Reset()
 	}
 }
 
@@ -430,5 +427,8 @@ func (fc *followerCursor) receiveAcks(cancel context.CancelFunc, stream proto.Ox
 		fc.cursorAcker.Ack(res.Offset)
 
 		fc.ackOffset.Store(res.Offset)
+
+		// Since we've made progress, we can reset the backoff to initial setting
+		fc.backoff.Reset()
 	}
 }


### PR DESCRIPTION
When the replicate stream fails continuously on a follower, we are retrying every 100ms without exponential backoff.

The reason is that we're resetting the backoff when a new stream is re-established, although the acks on the stream are going to fail again.

Instead of resetting the backoff when the stream is re-established, wait for the first successful ack to come back before resetting.