### PR TITLE
Fixed data race in TestFollower

### DIFF
--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -133,11 +133,11 @@ func TestFollower(t *testing.T) {
 
 	assert.Equal(t, proto.ServingStatus_FOLLOWER, fc.Status())
 	stream = newMockServerReplicateStream()
-	wg = common.NewWaitGroup(1)
+	wg2 := common.NewWaitGroup(1)
 	go func() {
 		err := fc.Replicate(stream)
 		assert.ErrorIs(t, err, context.Canceled)
-		wg.Done()
+		wg2.Done()
 	}()
 	stream.AddRequest(createAddRequest(t, 2, 0, map[string]string{"a": "0", "b": "1"}, wal.InvalidOffset))
 	// Wait for response
@@ -180,7 +180,7 @@ func TestFollower(t *testing.T) {
 	assert.NoError(t, kvFactory.Close())
 	assert.NoError(t, walFactory.Close())
 
-	_ = wg.Wait(context.Background())
+	_ = wg2.Wait(context.Background())
 }
 
 func TestReadingUpToCommitOffset(t *testing.T) {


### PR DESCRIPTION
Fix data race in test code: 


```
==================
WARNING: DATA RACE
Write at 0x00c00028aa30 by goroutine 44:
  github.com/streamnative/oxia/server.TestFollower()
      /home/runner/work/oxia/oxia/server/follower_controller_test.go:136 +0x18bc
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44

Previous read at 0x00c00028aa30 by goroutine 61:
  github.com/streamnative/oxia/server.TestFollower.func1()
      /home/runner/work/oxia/oxia/server/follower_controller_test.go:91 +0x86

Goroutine 44 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x825
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:2168 +0x85
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.runTests()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:2166 +0x8be
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:2034 +0xf17
  main.main()
      _testmain.go:201 +0x164

Goroutine 61 (finished) created at:
  github.com/streamnative/oxia/server.TestFollower()
      /home/runner/work/oxia/oxia/server/follower_controller_test.go:89 +0xab5
  testing.tRunner()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1690 +0x226
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.23.3/x64/src/testing/testing.go:1743 +0x44
==================
```
