### PR TITLE
feat: configure default grpc server keepalive enforcement policy

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/x86_64
+          platforms: linux/x86_64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/x86_64,linux/arm64
+          platforms: linux/x86_64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/common/container/container.go
+++ b/common/container/container.go
@@ -36,10 +36,10 @@ import (
 )
 
 const (
-	maxGrpcFrameSize                   = 256 * 1024 * 1024
-	DefaultGrpcKeepAliveMinTime        = 5 * time.Second
-	DefaultGrpcKeepPermitWithoutStream = true
-	ReadinessProbeService              = "oxia-readiness"
+	maxGrpcFrameSize                         = 256 * 1024 * 1024
+	defaultGrpcServerKeepAliveMinTime        = 5 * time.Second
+	defaultGrpcServerKeepPermitWithoutStream = true
+	ReadinessProbeService                    = "oxia-readiness"
 )
 
 type GrpcServer interface {
@@ -106,8 +106,8 @@ func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.Ser
 			grpc.ChainUnaryInterceptor(unaryInterceptors...),
 			grpc.MaxRecvMsgSize(maxGrpcFrameSize),
 			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
-				MinTime:             DefaultGrpcKeepAliveMinTime,
-				PermitWithoutStream: DefaultGrpcKeepPermitWithoutStream,
+				MinTime:             defaultGrpcServerKeepAliveMinTime,
+				PermitWithoutStream: defaultGrpcServerKeepPermitWithoutStream,
 			}),
 		),
 	}

--- a/common/container/container.go
+++ b/common/container/container.go
@@ -17,10 +17,12 @@ package container
 import (
 	"context"
 	"crypto/tls"
+	"google.golang.org/grpc/keepalive"
 	"io"
 	"log/slog"
 	"net"
 	"os"
+	"time"
 
 	"github.com/streamnative/oxia/server/auth"
 
@@ -34,9 +36,10 @@ import (
 )
 
 const (
-	maxGrpcFrameSize = 256 * 1024 * 1024
-
-	ReadinessProbeService = "oxia-readiness"
+	maxGrpcFrameSize                   = 256 * 1024 * 1024
+	DefaultGrpcKeepAliveMinTime        = 5 * time.Second
+	DefaultGrpcKeepPermitWithoutStream = true
+	ReadinessProbeService              = "oxia-readiness"
 )
 
 type GrpcServer interface {
@@ -102,6 +105,10 @@ func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.Ser
 			grpc.ChainStreamInterceptor(streamInterceptors...),
 			grpc.ChainUnaryInterceptor(unaryInterceptors...),
 			grpc.MaxRecvMsgSize(maxGrpcFrameSize),
+			grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+				MinTime:             DefaultGrpcKeepAliveMinTime,
+				PermitWithoutStream: DefaultGrpcKeepPermitWithoutStream,
+			}),
 		),
 	}
 	registerFunc(c.server)


### PR DESCRIPTION
### Motivation

configure default grpc server keepalive enforcement policy

### Modification

- DefaultGrpcKeepAliveMinTime        = 5 * time.Second
- DefaultGrpcKeepPermitWithoutStream = true
- DefaultGrpcClientKeepAliveTime       = time.Second * 10
- DefaultGrpcClientKeepAliveTimeout    = time.Second * 5
- DefaultGrpcClientPermitWithoutStream = true