### PR TITLE
fix: fix docker file error to unblock publish job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ ENV PATH=$PATH:/oxia/bin
 
 RUN oxia completion bash > ~/.bashrc
 
-CMD /bin/bash
+CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.23-alpine as build
+FROM golang:1.23-alpine AS build
 
 RUN apk add --no-cache make git build-base bash
 


### PR DESCRIPTION
### Motivation

The release published job has failed. FYI: https://github.com/streamnative/oxia/actions/runs/12945972752/job/36110457948

I tried some fixes for the warning log. Then it works.  https://github.com/streamnative/oxia/actions/runs/12946570181

