### PR TITLE
feat: make addFollower idempotent to avoid FollowerAlreadyPresent

### DIFF
--- a/common/error_codes.go
+++ b/common/error_codes.go
@@ -32,7 +32,6 @@ const (
 	CodeInvalidSessionTimeout   codes.Code = 109
 	CodeNamespaceNotFound       codes.Code = 110
 	CodeNotificationsNotEnabled codes.Code = 111
-	CodeFollowerAlreadyPresent  codes.Code = 112
 	CodeFollowerAlreadyFenced   codes.Code = 113
 )
 
@@ -49,6 +48,5 @@ var (
 	ErrorInvalidSessionTimeout   = status.Error(CodeInvalidSessionTimeout, "oxia: invalid session timeout")
 	ErrorNamespaceNotFound       = status.Error(CodeNamespaceNotFound, "oxia: namespace not found")
 	ErrorNotificationsNotEnabled = status.Error(CodeNotificationsNotEnabled, "oxia: notifications not enabled on namespace")
-	ErrorFollowerAlreadyPresent  = status.Error(CodeFollowerAlreadyPresent, "oxia: follower is already present")
 	ErrorFollowerAlreadyFenced   = status.Error(CodeFollowerAlreadyFenced, "oxia: follower is already fenced")
 )

--- a/coordinator/impl/shard_controller.go
+++ b/coordinator/impl/shard_controller.go
@@ -512,7 +512,7 @@ func (s *shardController) internalNewTermAndAddFollower(ctx context.Context, nod
 	if err = s.addFollower(*s.shardMetadata.Leader, node.Internal, &proto.EntryId{
 		Term:   fr.Term,
 		Offset: fr.Offset,
-	}); err != nil && status.Code(err) != common.CodeFollowerAlreadyPresent {
+	}); err != nil {
 		res <- err
 		return
 	}

--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -378,7 +378,7 @@ func (lc *leaderController) AddFollower(req *proto.AddFollowerRequest) (*proto.A
 	}
 
 	if _, followerAlreadyPresent := lc.followers[req.FollowerName]; followerAlreadyPresent {
-		return nil, errors.Wrapf(common.ErrorFollowerAlreadyPresent, "follower: %s", req.FollowerName)
+		return &proto.AddFollowerResponse{}, nil
 	}
 
 	if len(lc.followers) == int(lc.replicationFactor)-1 {

--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -589,8 +589,8 @@ func TestLeaderController_AddFollowerRepeated(t *testing.T) {
 		FollowerName:        "f1",
 		FollowerHeadEntryId: InvalidEntryId,
 	})
-	assert.Nil(t, afRes)
-	assert.Error(t, err)
+	assert.Nil(t, err)
+	assert.Equal(t, &proto.AddFollowerResponse{}, afRes)
 
 	_, err = lc.AddFollower(&proto.AddFollowerRequest{
 		Shard:               shard,
@@ -598,8 +598,8 @@ func TestLeaderController_AddFollowerRepeated(t *testing.T) {
 		FollowerName:        "f1",
 		FollowerHeadEntryId: InvalidEntryId,
 	})
-	assert.Error(t, err)
-	assert.Equal(t, common.CodeFollowerAlreadyPresent, status.Code(err))
+	assert.Nil(t, err)
+	assert.Equal(t, &proto.AddFollowerResponse{}, afRes)
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())

--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -526,8 +526,8 @@ func TestLeaderController_AddFollower(t *testing.T) {
 		FollowerName:        "f1",
 		FollowerHeadEntryId: InvalidEntryId,
 	})
-	assert.Nil(t, afRes)
-	assert.Error(t, err)
+	assert.Equal(t, &proto.AddFollowerResponse{}, afRes)
+	assert.Nil(t, err)
 
 	_, err = lc.AddFollower(&proto.AddFollowerRequest{
 		Shard:               shard,


### PR DESCRIPTION
### Motivation

Align the behaviour as #602. we can also make the `addFollower` idempotent to avoid extra error handling.