### PR TITLE
feat: support `IncludeValue` for get operation

### DIFF
--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -920,3 +920,41 @@ func TestGetValueWithSessionId(t *testing.T) {
 	assert.NotEqualValues(t, 0, r0.Version.SessionId)
 	assert.EqualValues(t, r1.Version.SessionId, r0.Version.SessionId)
 }
+
+func TestGetWithoutValue(t *testing.T) {
+	standaloneServer, err := server.NewStandalone(server.NewTestConfig(t.TempDir()))
+	assert.NoError(t, err)
+
+	serviceAddress := fmt.Sprintf("localhost:%d", standaloneServer.RpcPort())
+	client, err := NewAsyncClient(serviceAddress)
+	assert.NoError(t, err)
+
+	key := "stream"
+
+	var keys []string
+
+	putResult := <-client.Put(key, []byte("0"), PartitionKey(key), SequenceKeysDeltas(1))
+	assert.NotNil(t, putResult.Key)
+	assert.NoError(t, putResult.Err)
+	keys = append(keys, putResult.Key)
+
+	putResult = <-client.Put(key, []byte("1"), PartitionKey(key), SequenceKeysDeltas(1))
+	assert.NotNil(t, putResult.Key)
+	assert.NoError(t, putResult.Err)
+	keys = append(keys, putResult.Key)
+
+	for _, subKey := range keys {
+		result := <-client.Get(subKey, PartitionKey(key), IncludeValue(true))
+		assert.NotNil(t, result.Value)
+		result = <-client.Get(subKey, PartitionKey(key), IncludeValue(false))
+		assert.Nil(t, result.Value)
+	}
+
+	result := <-client.Get(keys[0], PartitionKey(key), IncludeValue(false), ComparisonHigher())
+	assert.Nil(t, result.Value)
+	assert.Equal(t, result.Key, keys[1])
+
+	result = <-client.Get(keys[1], PartitionKey(key), IncludeValue(false), ComparisonLower())
+	assert.Nil(t, result.Value)
+	assert.Equal(t, result.Key, keys[0])
+}

--- a/oxia/async_client_impl_test.go
+++ b/oxia/async_client_impl_test.go
@@ -924,10 +924,12 @@ func TestGetValueWithSessionId(t *testing.T) {
 func TestGetWithoutValue(t *testing.T) {
 	standaloneServer, err := server.NewStandalone(server.NewTestConfig(t.TempDir()))
 	assert.NoError(t, err)
+	defer standaloneServer.Close()
 
 	serviceAddress := fmt.Sprintf("localhost:%d", standaloneServer.RpcPort())
 	client, err := NewAsyncClient(serviceAddress)
 	assert.NoError(t, err)
+	defer client.Close()
 
 	key := "stream"
 

--- a/oxia/internal/batch/read_batch_test.go
+++ b/oxia/internal/batch/read_batch_test.go
@@ -122,8 +122,9 @@ func TestReadBatchComplete(t *testing.T) {
 		}
 
 		batch.Add(model.GetCall{
-			Key:      "/a",
-			Callback: getCallback,
+			Key:          "/a",
+			Callback:     getCallback,
+			IncludeValue: true,
 		})
 		assert.Equal(t, 1, batch.Size())
 

--- a/oxia/internal/model/model.go
+++ b/oxia/internal/model/model.go
@@ -45,6 +45,7 @@ type DeleteRangeCall struct {
 type GetCall struct {
 	Key            string
 	ComparisonType proto.KeyComparisonType
+	IncludeValue   bool
 	Callback       func(*proto.GetResponse, error)
 }
 
@@ -79,7 +80,7 @@ func (r GetCall) ToProto() *proto.GetRequest {
 	return &proto.GetRequest{
 		Key:            r.Key,
 		ComparisonType: r.ComparisonType,
-		IncludeValue:   true,
+		IncludeValue:   r.IncludeValue,
 	}
 }
 

--- a/oxia/options_get.go
+++ b/oxia/options_get.go
@@ -19,6 +19,7 @@ import "github.com/streamnative/oxia/proto"
 type getOptions struct {
 	baseOptions
 	comparisonType proto.KeyComparisonType
+	includeValue   bool
 }
 
 // GetOption represents an option for the [SyncClient.Get] operation.
@@ -27,7 +28,9 @@ type GetOption interface {
 }
 
 func newGetOptions(opts []GetOption) *getOptions {
-	getOpts := &getOptions{}
+	getOpts := &getOptions{
+		includeValue: true,
+	}
 	for _, opt := range opts {
 		opt.applyGet(getOpts)
 	}
@@ -69,4 +72,19 @@ func ComparisonLower() GetOption {
 // key is strictly > to the supplied key.
 func ComparisonHigher() GetOption {
 	return &getComparisonType{proto.KeyComparisonType_HIGHER}
+}
+
+type includeValue struct {
+	includeValue bool
+}
+
+func (t *includeValue) applyGet(opts *getOptions) {
+	opts.includeValue = t.includeValue
+}
+
+// IncludeValue is a function that creates a GetOption for including or excluding a value.
+func IncludeValue(include bool) GetOption {
+	return &includeValue{
+		includeValue: include,
+	}
 }


### PR DESCRIPTION
### Motivation

Support `IncludeValue` to get the operation to have the ability to peek at the first or last key without extra cost.