### PR TITLE
feat: introduce server identifier

### DIFF
--- a/cmd/coordinator/cmd_test.go
+++ b/cmd/coordinator/cmd_test.go
@@ -37,7 +37,7 @@ func TestCmd(t *testing.T) {
 			InitialShardCount:    2,
 			NotificationsEnabled: common.Bool(false),
 		}},
-		Servers: []model.ServerAddress{{
+		Servers: []model.Server{{
 			Public:   "public:1234",
 			Internal: "internal:5678",
 		}},
@@ -72,7 +72,7 @@ func TestCmd(t *testing.T) {
 				InitialShardCount:    2,
 				NotificationsEnabled: common.Bool(false),
 			}},
-			Servers: []model.ServerAddress{{
+			Servers: []model.Server{{
 				Public:   "public:1234",
 				Internal: "internal:5678",
 			},
@@ -89,7 +89,7 @@ func TestCmd(t *testing.T) {
 				InitialShardCount:    2,
 				NotificationsEnabled: common.Bool(false),
 			}},
-			Servers: []model.ServerAddress{{
+			Servers: []model.Server{{
 				Public:   "public:1234",
 				Internal: "internal:5678",
 			},
@@ -106,7 +106,7 @@ func TestCmd(t *testing.T) {
 				InitialShardCount:    2,
 				NotificationsEnabled: common.Bool(false),
 			}},
-			Servers: []model.ServerAddress{{
+			Servers: []model.Server{{
 				Public:   "public:1234",
 				Internal: "internal:5678",
 			},
@@ -123,7 +123,7 @@ func TestCmd(t *testing.T) {
 				InitialShardCount:    2,
 				NotificationsEnabled: common.Bool(false),
 			}},
-			Servers: []model.ServerAddress{{
+			Servers: []model.Server{{
 				Public:   "public:1234",
 				Internal: "internal:5678",
 			},
@@ -140,7 +140,7 @@ func TestCmd(t *testing.T) {
 				InitialShardCount:    2,
 				NotificationsEnabled: common.Bool(false),
 			}},
-			Servers: []model.ServerAddress{{
+			Servers: []model.Server{{
 				Public:   "public:1234",
 				Internal: "internal:5678",
 			},

--- a/coordinator/impl/cluster_rebalance.go
+++ b/coordinator/impl/cluster_rebalance.go
@@ -24,18 +24,18 @@ import (
 
 type SwapNodeAction struct {
 	Shard int64
-	From  model.ServerAddress
-	To    model.ServerAddress
+	From  model.Server
+	To    model.Server
 }
 
 type ServerContext struct {
-	Addr   model.ServerAddress
+	Server model.Server
 	Shards common.Set[int64]
 }
 
 // Make sure every server is assigned a similar number of shards
 // Output a list of actions to be taken to rebalance the cluster.
-func rebalanceCluster(servers []model.ServerAddress, currentStatus *model.ClusterStatus) []SwapNodeAction { //nolint:revive
+func rebalanceCluster(servers []model.Server, currentStatus *model.ClusterStatus) []SwapNodeAction { //nolint:revive
 	res := make([]SwapNodeAction, 0)
 
 	serversCount := len(servers)
@@ -48,16 +48,16 @@ outer:
 		for _, r := range rankings {
 			slog.Debug(
 				"",
-				slog.String("server", r.Addr.Internal),
+				slog.Any("server", r.Server),
 				slog.Int("count", r.Shards.Count()),
 			)
 		}
 		if len(deletedServers) > 0 {
 			slog.Debug("Deleted servers: ")
-			for id, context := range deletedServers {
+			for server, context := range deletedServers {
 				slog.Debug(
 					"",
-					slog.String("server", id),
+					slog.String("server", server),
 					slog.Int("count", context.Shards.Count()),
 				)
 			}
@@ -76,8 +76,8 @@ outer:
 				if !eligibleShards.IsEmpty() {
 					a := SwapNodeAction{
 						Shard: eligibleShards.GetSorted()[0],
-						From:  context.Addr,
-						To:    to.Addr,
+						From:  context.Server,
+						To:    to.Server,
 					}
 
 					context.Shards.Remove(a.Shard)
@@ -86,7 +86,7 @@ outer:
 					} else {
 						deletedServers[id] = context
 					}
-					shardsPerServer[a.To.Internal].Shards.Add(a.Shard)
+					shardsPerServer[a.To.GetIdentifier()].Shards.Add(a.Shard)
 
 					slog.Debug(
 						"Transfer from removed node",
@@ -118,12 +118,12 @@ outer:
 
 		a := SwapNodeAction{
 			Shard: eligibleShards.GetSorted()[0],
-			From:  mostLoaded.Addr,
-			To:    leastLoaded.Addr,
+			From:  mostLoaded.Server,
+			To:    leastLoaded.Server,
 		}
 
-		shardsPerServer[a.From.Internal].Shards.Remove(a.Shard)
-		shardsPerServer[a.To.Internal].Shards.Add(a.Shard)
+		shardsPerServer[a.From.GetIdentifier()].Shards.Remove(a.Shard)
+		shardsPerServer[a.To.GetIdentifier()].Shards.Add(a.Shard)
 
 		slog.Debug(
 			"Swapping nodes",
@@ -136,15 +136,15 @@ outer:
 	return res
 }
 
-func getShardsPerServer(servers []model.ServerAddress, currentStatus *model.ClusterStatus) (
+func getShardsPerServer(servers []model.Server, currentStatus *model.ClusterStatus) (
 	existingServers map[string]ServerContext,
 	deletedServers map[string]ServerContext) {
 	existingServers = map[string]ServerContext{}
 	deletedServers = map[string]ServerContext{}
 
 	for _, s := range servers {
-		existingServers[s.Internal] = ServerContext{
-			Addr:   s,
+		existingServers[s.GetIdentifier()] = ServerContext{
+			Server: s,
 			Shards: common.NewSet[int64](),
 		}
 	}
@@ -152,19 +152,19 @@ func getShardsPerServer(servers []model.ServerAddress, currentStatus *model.Clus
 	for _, nss := range currentStatus.Namespaces {
 		for shardId, shard := range nss.Shards {
 			for _, candidate := range shard.Ensemble {
-				if _, ok := existingServers[candidate.Internal]; ok {
-					existingServers[candidate.Internal].Shards.Add(shardId)
+				if _, ok := existingServers[candidate.GetIdentifier()]; ok {
+					existingServers[candidate.GetIdentifier()].Shards.Add(shardId)
 					continue
 				}
 
 				// This server is getting removed
-				if _, ok := deletedServers[candidate.Internal]; !ok {
-					deletedServers[candidate.Internal] = ServerContext{
-						Addr:   candidate,
+				if _, ok := deletedServers[candidate.GetIdentifier()]; !ok {
+					deletedServers[candidate.GetIdentifier()] = ServerContext{
+						Server: candidate,
 						Shards: common.NewSet[int64]()}
 				}
 
-				deletedServers[candidate.Internal].Shards.Add(shardId)
+				deletedServers[candidate.GetIdentifier()].Shards.Add(shardId)
 			}
 		}
 	}
@@ -188,7 +188,7 @@ func getServerRanking(shardsPerServer map[string]ServerContext) []ServerContext 
 		}
 
 		// Ensure predictable sorting
-		return res[i].Addr.Internal < res[j].Addr.Internal
+		return res[i].Server.GetIdentifier() < res[j].Server.GetIdentifier()
 	})
 	return res
 }

--- a/coordinator/impl/cluster_rebalance_test.go
+++ b/coordinator/impl/cluster_rebalance_test.go
@@ -35,7 +35,7 @@ func TestClusterRebalance_Count(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s1, s2, s3},
+						Ensemble: []model.Server{s1, s2, s3},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32,
@@ -50,7 +50,7 @@ func TestClusterRebalance_Count(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s4, s1, s2},
+						Ensemble: []model.Server{s4, s1, s2},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32 / 2,
@@ -60,7 +60,7 @@ func TestClusterRebalance_Count(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s3, s4, s1},
+						Ensemble: []model.Server{s3, s4, s1},
 						Int32HashRange: model.Int32HashRange{
 							Min: math.MaxUint32/2 + 1,
 							Max: math.MaxUint32,
@@ -71,7 +71,7 @@ func TestClusterRebalance_Count(t *testing.T) {
 		},
 	}
 
-	count, deletedServers := getShardsPerServer([]model.ServerAddress{s1, s2, s3, s4, s5}, cs)
+	count, deletedServers := getShardsPerServer([]model.Server{s1, s2, s3, s4, s5}, cs)
 
 	assert.Equal(t, map[string]ServerContext{
 		s1.Internal: {
@@ -109,7 +109,7 @@ func TestClusterRebalance_Single(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s1, s2, s3},
+						Ensemble: []model.Server{s1, s2, s3},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32,
@@ -124,7 +124,7 @@ func TestClusterRebalance_Single(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s4, s1, s2},
+						Ensemble: []model.Server{s4, s1, s2},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32 / 2,
@@ -134,7 +134,7 @@ func TestClusterRebalance_Single(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s3, s4, s1},
+						Ensemble: []model.Server{s3, s4, s1},
 						Int32HashRange: model.Int32HashRange{
 							Min: math.MaxUint32/2 + 1,
 							Max: math.MaxUint32,
@@ -145,7 +145,7 @@ func TestClusterRebalance_Single(t *testing.T) {
 		},
 	}
 
-	actions := rebalanceCluster([]model.ServerAddress{s1, s2, s3, s4, s5}, cs)
+	actions := rebalanceCluster([]model.Server{s1, s2, s3, s4, s5}, cs)
 	assert.Equal(t, []SwapNodeAction{{
 		Shard: 0,
 		From:  s1,
@@ -158,17 +158,17 @@ func TestClusterRebalance_Multiple(t *testing.T) {
 		Namespaces: map[string]model.NamespaceStatus{
 			"ns-1": {
 				Shards: map[int64]model.ShardMetadata{
-					0: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					1: {Ensemble: []model.ServerAddress{s2, s3, s4}},
-					2: {Ensemble: []model.ServerAddress{s4, s1, s2}},
-					3: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					4: {Ensemble: []model.ServerAddress{s2, s3, s4}},
+					0: {Ensemble: []model.Server{s1, s2, s3}},
+					1: {Ensemble: []model.Server{s2, s3, s4}},
+					2: {Ensemble: []model.Server{s4, s1, s2}},
+					3: {Ensemble: []model.Server{s1, s2, s3}},
+					4: {Ensemble: []model.Server{s2, s3, s4}},
 				},
 			},
 		},
 	}
 
-	actions := rebalanceCluster([]model.ServerAddress{s1, s2, s3, s4, s5}, cs)
+	actions := rebalanceCluster([]model.Server{s1, s2, s3, s4, s5}, cs)
 	slog.Info(
 		"actions",
 		slog.Any("actions", actions),
@@ -193,18 +193,18 @@ func TestClusterRebalance_DoubleSize(t *testing.T) {
 		Namespaces: map[string]model.NamespaceStatus{
 			"ns-1": {
 				Shards: map[int64]model.ShardMetadata{
-					0: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					1: {Ensemble: []model.ServerAddress{s2, s3, s1}},
-					2: {Ensemble: []model.ServerAddress{s3, s1, s2}},
-					3: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					4: {Ensemble: []model.ServerAddress{s2, s3, s1}},
-					5: {Ensemble: []model.ServerAddress{s3, s1, s2}},
+					0: {Ensemble: []model.Server{s1, s2, s3}},
+					1: {Ensemble: []model.Server{s2, s3, s1}},
+					2: {Ensemble: []model.Server{s3, s1, s2}},
+					3: {Ensemble: []model.Server{s1, s2, s3}},
+					4: {Ensemble: []model.Server{s2, s3, s1}},
+					5: {Ensemble: []model.Server{s3, s1, s2}},
 				},
 			},
 		},
 	}
 
-	actions := rebalanceCluster([]model.ServerAddress{s1, s2, s3, s4, s5, s6}, cs)
+	actions := rebalanceCluster([]model.Server{s1, s2, s3, s4, s5, s6}, cs)
 	slog.Info(
 		"actions",
 		slog.Any("actions", actions),
@@ -253,18 +253,18 @@ func TestClusterRebalance_ShrinkOne(t *testing.T) {
 		Namespaces: map[string]model.NamespaceStatus{
 			"ns-1": {
 				Shards: map[int64]model.ShardMetadata{
-					0: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					1: {Ensemble: []model.ServerAddress{s4, s5, s6}},
-					2: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					3: {Ensemble: []model.ServerAddress{s4, s5, s6}},
-					4: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					5: {Ensemble: []model.ServerAddress{s4, s5, s6}},
+					0: {Ensemble: []model.Server{s1, s2, s3}},
+					1: {Ensemble: []model.Server{s4, s5, s6}},
+					2: {Ensemble: []model.Server{s1, s2, s3}},
+					3: {Ensemble: []model.Server{s4, s5, s6}},
+					4: {Ensemble: []model.Server{s1, s2, s3}},
+					5: {Ensemble: []model.Server{s4, s5, s6}},
 				},
 			},
 		},
 	}
 
-	actions := rebalanceCluster([]model.ServerAddress{s1, s2, s3, s4, s5}, cs)
+	actions := rebalanceCluster([]model.Server{s1, s2, s3, s4, s5}, cs)
 	slog.Info(
 		"actions",
 		slog.Any("actions", actions),
@@ -289,18 +289,18 @@ func TestClusterRebalance_ShrinkToHalf(t *testing.T) {
 		Namespaces: map[string]model.NamespaceStatus{
 			"ns-1": {
 				Shards: map[int64]model.ShardMetadata{
-					0: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					1: {Ensemble: []model.ServerAddress{s4, s5, s6}},
-					2: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					3: {Ensemble: []model.ServerAddress{s4, s5, s6}},
-					4: {Ensemble: []model.ServerAddress{s1, s2, s3}},
-					5: {Ensemble: []model.ServerAddress{s4, s5, s6}},
+					0: {Ensemble: []model.Server{s1, s2, s3}},
+					1: {Ensemble: []model.Server{s4, s5, s6}},
+					2: {Ensemble: []model.Server{s1, s2, s3}},
+					3: {Ensemble: []model.Server{s4, s5, s6}},
+					4: {Ensemble: []model.Server{s1, s2, s3}},
+					5: {Ensemble: []model.Server{s4, s5, s6}},
 				},
 			},
 		},
 	}
 
-	actions := rebalanceCluster([]model.ServerAddress{s1, s2, s3}, cs)
+	actions := rebalanceCluster([]model.Server{s1, s2, s3}, cs)
 	slog.Info(
 		"actions",
 		slog.Any("actions", actions),

--- a/coordinator/impl/cluster_updates.go
+++ b/coordinator/impl/cluster_updates.go
@@ -19,9 +19,9 @@ import (
 	"github.com/streamnative/oxia/coordinator/model"
 )
 
-func getServers(servers []model.ServerAddress, startIdx uint32, count uint32) []model.ServerAddress {
+func getServers(servers []model.Server, startIdx uint32, count uint32) []model.Server {
 	n := len(servers)
-	res := make([]model.ServerAddress, count)
+	res := make([]model.Server, count)
 	for i := uint32(0); i < count; i++ {
 		res[i] = servers[int(startIdx+i)%n]
 	}

--- a/coordinator/impl/cluster_updates_test.go
+++ b/coordinator/impl/cluster_updates_test.go
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	s1 = model.ServerAddress{Public: "s1:6648", Internal: "s1:6649"}
-	s2 = model.ServerAddress{Public: "s2:6648", Internal: "s2:6649"}
-	s3 = model.ServerAddress{Public: "s3:6648", Internal: "s3:6649"}
-	s4 = model.ServerAddress{Public: "s4:6648", Internal: "s4:6649"}
-	s5 = model.ServerAddress{Public: "s5:6648", Internal: "s5:6649"}
-	s6 = model.ServerAddress{Public: "s6:6648", Internal: "s6:6649"}
+	s1 = model.Server{Public: "s1:6648", Internal: "s1:6649"}
+	s2 = model.Server{Public: "s2:6648", Internal: "s2:6649"}
+	s3 = model.Server{Public: "s3:6648", Internal: "s3:6649"}
+	s4 = model.Server{Public: "s4:6648", Internal: "s4:6649"}
+	s5 = model.Server{Public: "s5:6648", Internal: "s5:6649"}
+	s6 = model.Server{Public: "s6:6648", Internal: "s6:6649"}
 )
 
 func TestClientUpdates_ClusterInit(t *testing.T) {
@@ -44,7 +44,7 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 			InitialShardCount: 2,
 			ReplicationFactor: 3,
 		}},
-		Servers: []model.ServerAddress{s1, s2, s3, s4},
+		Servers: []model.Server{s1, s2, s3, s4},
 	}, model.NewClusterStatus())
 
 	assert.Equal(t, &model.ClusterStatus{
@@ -56,7 +56,7 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s1, s2, s3},
+						Ensemble: []model.Server{s1, s2, s3},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32,
@@ -71,7 +71,7 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s4, s1, s2},
+						Ensemble: []model.Server{s4, s1, s2},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32 / 2,
@@ -81,7 +81,7 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s3, s4, s1},
+						Ensemble: []model.Server{s3, s4, s1},
 						Int32HashRange: model.Int32HashRange{
 							Min: math.MaxUint32/2 + 1,
 							Max: math.MaxUint32,
@@ -112,7 +112,7 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 			InitialShardCount: 2,
 			ReplicationFactor: 3,
 		}},
-		Servers: []model.ServerAddress{s1, s2, s3, s4},
+		Servers: []model.Server{s1, s2, s3, s4},
 	}, &model.ClusterStatus{Namespaces: map[string]model.NamespaceStatus{
 		"ns-1": {
 			ReplicationFactor: 3,
@@ -121,7 +121,7 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 					Status:   model.ShardStatusUnknown,
 					Term:     -1,
 					Leader:   nil,
-					Ensemble: []model.ServerAddress{s1, s2, s3},
+					Ensemble: []model.Server{s1, s2, s3},
 					Int32HashRange: model.Int32HashRange{
 						Min: 0,
 						Max: math.MaxUint32,
@@ -141,8 +141,8 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 						Status:       model.ShardStatusUnknown,
 						Term:         -1,
 						Leader:       nil,
-						Ensemble:     []model.ServerAddress{s1, s2, s3},
-						RemovedNodes: []model.ServerAddress{},
+						Ensemble:     []model.Server{s1, s2, s3},
+						RemovedNodes: []model.Server{},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32,
@@ -157,7 +157,7 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s4, s1, s2},
+						Ensemble: []model.Server{s4, s1, s2},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32 / 2,
@@ -167,7 +167,7 @@ func TestClientUpdates_NamespaceAdded(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s3, s4, s1},
+						Ensemble: []model.Server{s3, s4, s1},
 						Int32HashRange: model.Int32HashRange{
 							Min: math.MaxUint32/2 + 1,
 							Max: math.MaxUint32,
@@ -193,7 +193,7 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 			InitialShardCount: 1,
 			ReplicationFactor: 3,
 		}},
-		Servers: []model.ServerAddress{s1, s2, s3, s4},
+		Servers: []model.Server{s1, s2, s3, s4},
 	}, &model.ClusterStatus{
 		Namespaces: map[string]model.NamespaceStatus{
 			"ns-1": {
@@ -203,7 +203,7 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s1, s2, s3},
+						Ensemble: []model.Server{s1, s2, s3},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32,
@@ -218,7 +218,7 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s4, s1, s2},
+						Ensemble: []model.Server{s4, s1, s2},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32 / 2,
@@ -228,7 +228,7 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 						Status:   model.ShardStatusUnknown,
 						Term:     -1,
 						Leader:   nil,
-						Ensemble: []model.ServerAddress{s3, s4, s1},
+						Ensemble: []model.Server{s3, s4, s1},
 						Int32HashRange: model.Int32HashRange{
 							Min: math.MaxUint32/2 + 1,
 							Max: math.MaxUint32,
@@ -249,8 +249,8 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 						Status:       model.ShardStatusUnknown,
 						Term:         -1,
 						Leader:       nil,
-						Ensemble:     []model.ServerAddress{s1, s2, s3},
-						RemovedNodes: []model.ServerAddress{},
+						Ensemble:     []model.Server{s1, s2, s3},
+						RemovedNodes: []model.Server{},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32,
@@ -265,8 +265,8 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 						Status:       model.ShardStatusDeleting,
 						Term:         -1,
 						Leader:       nil,
-						Ensemble:     []model.ServerAddress{s4, s1, s2},
-						RemovedNodes: []model.ServerAddress{},
+						Ensemble:     []model.Server{s4, s1, s2},
+						RemovedNodes: []model.Server{},
 						Int32HashRange: model.Int32HashRange{
 							Min: 0,
 							Max: math.MaxUint32 / 2,
@@ -276,8 +276,8 @@ func TestClientUpdates_NamespaceRemoved(t *testing.T) {
 						Status:       model.ShardStatusDeleting,
 						Term:         -1,
 						Leader:       nil,
-						Ensemble:     []model.ServerAddress{s3, s4, s1},
-						RemovedNodes: []model.ServerAddress{},
+						Ensemble:     []model.Server{s3, s4, s1},
+						RemovedNodes: []model.Server{},
 						Int32HashRange: model.Int32HashRange{
 							Min: math.MaxUint32/2 + 1,
 							Max: math.MaxUint32,

--- a/coordinator/impl/coordinator_e2e_test.go
+++ b/coordinator/impl/coordinator_e2e_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/streamnative/oxia/server"
 )
 
-func newServer(t *testing.T) (s *server.Server, addr model.ServerAddress) {
+func newServer(t *testing.T) (s *server.Server, addr model.Server) {
 	t.Helper()
 
 	var err error
@@ -47,7 +47,7 @@ func newServer(t *testing.T) (s *server.Server, addr model.ServerAddress) {
 
 	assert.NoError(t, err)
 
-	addr = model.ServerAddress{
+	addr = model.Server{
 		Public:   fmt.Sprintf("localhost:%d", s.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s.InternalPort()),
 	}
@@ -67,7 +67,7 @@ func TestCoordinatorE2E(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -105,7 +105,7 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 4,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -145,7 +145,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	s1, sa1 := newServer(t)
 	s2, sa2 := newServer(t)
 	s3, sa3 := newServer(t)
-	servers := map[model.ServerAddress]*server.Server{
+	servers := map[model.Server]*server.Server{
 		sa1: s1,
 		sa2: s2,
 		sa3: s3,
@@ -158,7 +158,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -178,7 +178,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	nsStatus = cs.Namespaces[common.DefaultNamespace]
 
 	leader := *nsStatus.Shards[0].Leader
-	var follower model.ServerAddress
+	var follower model.Server
 	for serverObj := range servers {
 		if serverObj != leader {
 			follower = serverObj
@@ -241,7 +241,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	s1, sa1 := newServer(t)
 	s2, sa2 := newServer(t)
 	s3, sa3 := newServer(t)
-	servers := map[model.ServerAddress]*server.Server{
+	servers := map[model.Server]*server.Server{
 		sa1: s1,
 		sa2: s2,
 		sa3: s3,
@@ -262,7 +262,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 			ReplicationFactor: 2,
 			InitialShardCount: 3,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -340,7 +340,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	s1, sa1 := newServer(t)
 	s2, sa2 := newServer(t)
 	s3, sa3 := newServer(t)
-	servers := map[model.ServerAddress]*server.Server{
+	servers := map[model.Server]*server.Server{
 		sa1: s1,
 		sa2: s2,
 		sa3: s3,
@@ -353,7 +353,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 			ReplicationFactor: 1,
 			InitialShardCount: 2,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -399,7 +399,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 
 	newClusterConfig := model.ClusterConfig{
 		Namespaces: []model.NamespaceConfig{},
-		Servers:    []model.ServerAddress{sa1, sa2, sa3},
+		Servers:    []model.Server{sa1, sa2, sa3},
 	}
 
 	slog.Info("Restarting coordinator")
@@ -423,7 +423,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	s1, sa1 := newServer(t)
 	s2, sa2 := newServer(t)
 	s3, sa3 := newServer(t)
-	servers := map[model.ServerAddress]*server.Server{
+	servers := map[model.Server]*server.Server{
 		sa1: s1,
 		sa2: s2,
 		sa3: s3,
@@ -436,7 +436,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 			ReplicationFactor: 1,
 			InitialShardCount: 2,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -510,7 +510,7 @@ func TestCoordinator_RebalanceCluster(t *testing.T) {
 	s2, sa2 := newServer(t)
 	s3, sa3 := newServer(t)
 	s4, sa4 := newServer(t)
-	servers := map[model.ServerAddress]*server.Server{
+	servers := map[model.Server]*server.Server{
 		sa1: s1,
 		sa2: s2,
 		sa3: s3,
@@ -524,7 +524,7 @@ func TestCoordinator_RebalanceCluster(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 2,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 	mutex := &sync.Mutex{}
@@ -563,12 +563,12 @@ func TestCoordinator_RebalanceCluster(t *testing.T) {
 	ns1Status = coordinator.ClusterStatus().Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 3, ns1Status.ReplicationFactor)
-	checkServerLists(t, []model.ServerAddress{sa1, sa2, sa3}, ns1Status.Shards[0].Ensemble)
-	checkServerLists(t, []model.ServerAddress{sa1, sa2, sa3}, ns1Status.Shards[1].Ensemble)
+	checkServerLists(t, []model.Server{sa1, sa2, sa3}, ns1Status.Shards[0].Ensemble)
+	checkServerLists(t, []model.Server{sa1, sa2, sa3}, ns1Status.Shards[1].Ensemble)
 
 	// Add `s4` and remove `s1` from the cluster config
 	mutex.Lock()
-	clusterConfig.Servers = []model.ServerAddress{sa2, sa3, sa4}
+	clusterConfig.Servers = []model.Server{sa2, sa3, sa4}
 	mutex.Unlock()
 
 	configChangesCh <- nil
@@ -590,8 +590,8 @@ func TestCoordinator_RebalanceCluster(t *testing.T) {
 	ns1Status = coordinator.ClusterStatus().Namespaces["my-ns-1"]
 	assert.EqualValues(t, 2, len(ns1Status.Shards))
 	assert.EqualValues(t, 3, ns1Status.ReplicationFactor)
-	checkServerLists(t, []model.ServerAddress{sa2, sa3, sa4}, ns1Status.Shards[0].Ensemble)
-	checkServerLists(t, []model.ServerAddress{sa2, sa3, sa4}, ns1Status.Shards[1].Ensemble)
+	checkServerLists(t, []model.Server{sa2, sa3, sa4}, ns1Status.Shards[0].Ensemble)
+	checkServerLists(t, []model.Server{sa2, sa3, sa4}, ns1Status.Shards[1].Ensemble)
 
 	assert.NoError(t, coordinator.Close())
 	assert.NoError(t, clientPool.Close())
@@ -607,7 +607,7 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	s3, sa3 := newServer(t)
 	s4, sa4 := newServer(t)
 	s5, sa5 := newServer(t)
-	servers := map[model.ServerAddress]*server.Server{
+	servers := map[model.Server]*server.Server{
 		sa1: s1,
 		sa2: s2,
 		sa3: s3,
@@ -622,7 +622,7 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 			ReplicationFactor: 1,
 			InitialShardCount: 2,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -670,7 +670,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	s2, sa2 := newServer(t)
 	s3, sa3 := newServer(t)
 	s4, sa4 := newServer(t)
-	servers := map[model.ServerAddress]*server.Server{
+	servers := map[model.Server]*server.Server{
 		sa1: s1,
 		sa2: s2,
 		sa3: s3,
@@ -684,7 +684,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 			ReplicationFactor: 1,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3, sa4},
+		Servers: []model.Server{sa1, sa2, sa3, sa4},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 
@@ -750,7 +750,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	}
 }
 
-func checkServerLists(t *testing.T, expected, actual []model.ServerAddress) {
+func checkServerLists(t *testing.T, expected, actual []model.Server) {
 	t.Helper()
 
 	assert.Equal(t, len(expected), len(actual))
@@ -784,7 +784,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	configChangesCh := make(chan any)
 	c, err := NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) {
@@ -806,9 +806,9 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	// change the localhost to 127.0.0.1
-	clusterServer := make([]model.ServerAddress, 0)
+	clusterServer := make([]model.Server, 0)
 	for _, sv := range clusterConfig.Servers {
-		clusterServer = append(clusterServer, model.ServerAddress{
+		clusterServer = append(clusterServer, model.Server{
 			Public:   strings.ReplaceAll(sv.Public, "localhost", "127.0.0.1"),
 			Internal: sv.Internal,
 		})

--- a/coordinator/impl/mock_test.go
+++ b/coordinator/impl/mock_test.go
@@ -79,16 +79,16 @@ func (sap *mockShardAssignmentsProvider) WaitForNextUpdate(ctx context.Context, 
 }
 
 type mockNodeAvailabilityListener struct {
-	events chan model.ServerAddress
+	events chan model.Server
 }
 
 func newMockNodeAvailabilityListener() *mockNodeAvailabilityListener {
 	return &mockNodeAvailabilityListener{
-		events: make(chan model.ServerAddress, 100),
+		events: make(chan model.Server, 100),
 	}
 }
 
-func (nal *mockNodeAvailabilityListener) NodeBecameUnavailable(node model.ServerAddress) {
+func (nal *mockNodeAvailabilityListener) NodeBecameUnavailable(node model.Server) {
 	nal.events <- node
 }
 
@@ -215,7 +215,7 @@ type mockRpcProvider struct {
 	channels map[string]*mockPerNodeChannels
 }
 
-func (r *mockRpcProvider) ClearPooledConnections(node model.ServerAddress) {
+func (r *mockRpcProvider) ClearPooledConnections(node model.Server) {
 }
 
 func newMockRpcProvider() *mockRpcProvider {
@@ -224,7 +224,7 @@ func newMockRpcProvider() *mockRpcProvider {
 	}
 }
 
-func (r *mockRpcProvider) FailNode(node model.ServerAddress, err error) {
+func (r *mockRpcProvider) FailNode(node model.Server, err error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -232,7 +232,7 @@ func (r *mockRpcProvider) FailNode(node model.ServerAddress, err error) {
 	n.err = err
 }
 
-func (r *mockRpcProvider) RecoverNode(node model.ServerAddress) {
+func (r *mockRpcProvider) RecoverNode(node model.Server) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -240,14 +240,14 @@ func (r *mockRpcProvider) RecoverNode(node model.ServerAddress) {
 	n.err = nil
 }
 
-func (r *mockRpcProvider) GetNode(node model.ServerAddress) *mockPerNodeChannels {
+func (r *mockRpcProvider) GetNode(node model.Server) *mockPerNodeChannels {
 	r.Lock()
 	defer r.Unlock()
 
 	return r.getNode(node)
 }
 
-func (r *mockRpcProvider) getNode(node model.ServerAddress) *mockPerNodeChannels {
+func (r *mockRpcProvider) getNode(node model.Server) *mockPerNodeChannels {
 	res, ok := r.channels[node.Internal]
 	if ok {
 		return res
@@ -258,7 +258,7 @@ func (r *mockRpcProvider) getNode(node model.ServerAddress) *mockPerNodeChannels
 	return res
 }
 
-func (r *mockRpcProvider) PushShardAssignments(ctx context.Context, node model.ServerAddress) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
+func (r *mockRpcProvider) PushShardAssignments(ctx context.Context, node model.Server) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -269,7 +269,7 @@ func (r *mockRpcProvider) PushShardAssignments(ctx context.Context, node model.S
 	return n.shardAssignmentsStream, nil
 }
 
-func (r *mockRpcProvider) NewTerm(ctx context.Context, node model.ServerAddress, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
+func (r *mockRpcProvider) NewTerm(ctx context.Context, node model.Server, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -292,7 +292,7 @@ func (r *mockRpcProvider) NewTerm(ctx context.Context, node model.ServerAddress,
 	}
 }
 
-func (r *mockRpcProvider) BecomeLeader(ctx context.Context, node model.ServerAddress, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
+func (r *mockRpcProvider) BecomeLeader(ctx context.Context, node model.Server, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -315,7 +315,7 @@ func (r *mockRpcProvider) BecomeLeader(ctx context.Context, node model.ServerAdd
 	}
 }
 
-func (r *mockRpcProvider) GetStatus(ctx context.Context, node model.ServerAddress, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
+func (r *mockRpcProvider) GetStatus(ctx context.Context, node model.Server, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -338,7 +338,7 @@ func (r *mockRpcProvider) GetStatus(ctx context.Context, node model.ServerAddres
 	}
 }
 
-func (r *mockRpcProvider) DeleteShard(ctx context.Context, node model.ServerAddress, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
+func (r *mockRpcProvider) DeleteShard(ctx context.Context, node model.Server, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -361,7 +361,7 @@ func (r *mockRpcProvider) DeleteShard(ctx context.Context, node model.ServerAddr
 	}
 }
 
-func (r *mockRpcProvider) AddFollower(ctx context.Context, node model.ServerAddress, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
+func (r *mockRpcProvider) AddFollower(ctx context.Context, node model.Server, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
 	r.Lock()
 
 	s := r.getNode(node)
@@ -384,7 +384,7 @@ func (r *mockRpcProvider) AddFollower(ctx context.Context, node model.ServerAddr
 	}
 }
 
-func (r *mockRpcProvider) GetHealthClient(node model.ServerAddress) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *mockRpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error) {
 	c := r.GetNode(node).healthClient
 	return c, c, nil
 }

--- a/coordinator/impl/node_controller_test.go
+++ b/coordinator/impl/node_controller_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestNodeController_HealthCheck(t *testing.T) {
-	addr := model.ServerAddress{
+	addr := model.Server{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}
@@ -65,7 +65,7 @@ func TestNodeController_HealthCheck(t *testing.T) {
 }
 
 func TestNodeController_ShardsAssignments(t *testing.T) {
-	addr := model.ServerAddress{
+	addr := model.Server{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
 	}

--- a/coordinator/impl/rpc_provider.go
+++ b/coordinator/impl/rpc_provider.go
@@ -29,16 +29,16 @@ import (
 const rpcTimeout = 30 * time.Second
 
 type RpcProvider interface {
-	PushShardAssignments(ctx context.Context, node model.ServerAddress) (proto.OxiaCoordination_PushShardAssignmentsClient, error)
-	NewTerm(ctx context.Context, node model.ServerAddress, req *proto.NewTermRequest) (*proto.NewTermResponse, error)
-	BecomeLeader(ctx context.Context, node model.ServerAddress, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error)
-	AddFollower(ctx context.Context, node model.ServerAddress, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error)
-	GetStatus(ctx context.Context, node model.ServerAddress, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
-	DeleteShard(ctx context.Context, node model.ServerAddress, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error)
+	PushShardAssignments(ctx context.Context, node model.Server) (proto.OxiaCoordination_PushShardAssignmentsClient, error)
+	NewTerm(ctx context.Context, node model.Server, req *proto.NewTermRequest) (*proto.NewTermResponse, error)
+	BecomeLeader(ctx context.Context, node model.Server, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error)
+	AddFollower(ctx context.Context, node model.Server, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error)
+	GetStatus(ctx context.Context, node model.Server, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
+	DeleteShard(ctx context.Context, node model.Server, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error)
 
-	GetHealthClient(node model.ServerAddress) (grpc_health_v1.HealthClient, io.Closer, error)
+	GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error)
 
-	ClearPooledConnections(node model.ServerAddress)
+	ClearPooledConnections(node model.Server)
 }
 
 type rpcProvider struct {
@@ -49,7 +49,7 @@ func NewRpcProvider(pool common.ClientPool) RpcProvider {
 	return &rpcProvider{pool: pool}
 }
 
-func (r *rpcProvider) PushShardAssignments(ctx context.Context, node model.ServerAddress) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
+func (r *rpcProvider) PushShardAssignments(ctx context.Context, node model.Server) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
 	rpc, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (r *rpcProvider) PushShardAssignments(ctx context.Context, node model.Serve
 	return rpc.PushShardAssignments(ctx)
 }
 
-func (r *rpcProvider) NewTerm(ctx context.Context, node model.ServerAddress, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
+func (r *rpcProvider) NewTerm(ctx context.Context, node model.Server, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
 	rpc, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func (r *rpcProvider) NewTerm(ctx context.Context, node model.ServerAddress, req
 	return rpc.NewTerm(ctx, req)
 }
 
-func (r *rpcProvider) BecomeLeader(ctx context.Context, node model.ServerAddress, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
+func (r *rpcProvider) BecomeLeader(ctx context.Context, node model.Server, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
 	rpc, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -82,7 +82,7 @@ func (r *rpcProvider) BecomeLeader(ctx context.Context, node model.ServerAddress
 	return rpc.BecomeLeader(ctx, req)
 }
 
-func (r *rpcProvider) AddFollower(ctx context.Context, node model.ServerAddress, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
+func (r *rpcProvider) AddFollower(ctx context.Context, node model.Server, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
 	rpc, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -94,7 +94,7 @@ func (r *rpcProvider) AddFollower(ctx context.Context, node model.ServerAddress,
 	return rpc.AddFollower(ctx, req)
 }
 
-func (r *rpcProvider) GetStatus(ctx context.Context, node model.ServerAddress, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
+func (r *rpcProvider) GetStatus(ctx context.Context, node model.Server, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
 	rpc, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (r *rpcProvider) GetStatus(ctx context.Context, node model.ServerAddress, r
 	return rpc.GetStatus(ctx, req)
 }
 
-func (r *rpcProvider) DeleteShard(ctx context.Context, node model.ServerAddress, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
+func (r *rpcProvider) DeleteShard(ctx context.Context, node model.Server, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
 	rpc, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -118,10 +118,10 @@ func (r *rpcProvider) DeleteShard(ctx context.Context, node model.ServerAddress,
 	return rpc.DeleteShard(ctx, req)
 }
 
-func (r *rpcProvider) GetHealthClient(node model.ServerAddress) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (r *rpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error) {
 	return r.pool.GetHealthRpc(node.Internal)
 }
 
-func (r *rpcProvider) ClearPooledConnections(node model.ServerAddress) {
+func (r *rpcProvider) ClearPooledConnections(node model.Server) {
 	r.pool.Clear(node.Internal)
 }

--- a/coordinator/impl/shard_controller_test.go
+++ b/coordinator/impl/shard_controller_test.go
@@ -38,61 +38,61 @@ var namespaceConfig = &model.NamespaceConfig{
 func TestLeaderElection_ShouldChooseHighestTerm(t *testing.T) {
 	tests := []struct {
 		name                   string
-		candidates             map[model.ServerAddress]*proto.EntryId
-		expectedLeader         model.ServerAddress
+		candidates             map[model.Server]*proto.EntryId
+		expectedLeader         model.Server
 		expectedFollowersCount int
-		expectedFollowers      map[model.ServerAddress]*proto.EntryId
+		expectedFollowers      map[model.Server]*proto.EntryId
 	}{
 		{
 			name: "Choose highest term",
-			candidates: map[model.ServerAddress]*proto.EntryId{
+			candidates: map[model.Server]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 2480},
 				{Public: "2", Internal: "2"}: {Term: 200, Offset: 2500},
 				{Public: "3", Internal: "3"}: {Term: 198, Offset: 3000},
 			},
-			expectedLeader:         model.ServerAddress{Public: "2", Internal: "2"},
+			expectedLeader:         model.Server{Public: "2", Internal: "2"},
 			expectedFollowersCount: 2,
-			expectedFollowers: map[model.ServerAddress]*proto.EntryId{
+			expectedFollowers: map[model.Server]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 2480},
 				{Public: "3", Internal: "3"}: {Term: 198, Offset: 3000},
 			},
 		},
 		{
 			name: "Same term, different offsets",
-			candidates: map[model.ServerAddress]*proto.EntryId{
+			candidates: map[model.Server]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 1000},
 				{Public: "2", Internal: "2"}: {Term: 200, Offset: 2000},
 				{Public: "3", Internal: "3"}: {Term: 200, Offset: 1500},
 			},
-			expectedLeader:         model.ServerAddress{Public: "2", Internal: "2"},
+			expectedLeader:         model.Server{Public: "2", Internal: "2"},
 			expectedFollowersCount: 2,
-			expectedFollowers: map[model.ServerAddress]*proto.EntryId{
+			expectedFollowers: map[model.Server]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 1000},
 				{Public: "3", Internal: "3"}: {Term: 200, Offset: 1500},
 			},
 		},
 		{
 			name: "Different terms, same offsets",
-			candidates: map[model.ServerAddress]*proto.EntryId{
+			candidates: map[model.Server]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 1500},
 				{Public: "2", Internal: "2"}: {Term: 198, Offset: 1500},
 				{Public: "3", Internal: "3"}: {Term: 199, Offset: 1500},
 			},
-			expectedLeader:         model.ServerAddress{Public: "1", Internal: "1"},
+			expectedLeader:         model.Server{Public: "1", Internal: "1"},
 			expectedFollowersCount: 2,
-			expectedFollowers: map[model.ServerAddress]*proto.EntryId{
+			expectedFollowers: map[model.Server]*proto.EntryId{
 				{Public: "2", Internal: "2"}: {Term: 198, Offset: 1500},
 				{Public: "3", Internal: "3"}: {Term: 199, Offset: 1500},
 			},
 		},
 		{
 			name: "Single candidate",
-			candidates: map[model.ServerAddress]*proto.EntryId{
+			candidates: map[model.Server]*proto.EntryId{
 				{Public: "1", Internal: "1"}: {Term: 200, Offset: 1500},
 			},
-			expectedLeader:         model.ServerAddress{Public: "1", Internal: "1"},
+			expectedLeader:         model.Server{Public: "1", Internal: "1"},
 			expectedFollowersCount: 0,
-			expectedFollowers:      map[model.ServerAddress]*proto.EntryId{},
+			expectedFollowers:      map[model.Server]*proto.EntryId{},
 		},
 	}
 
@@ -120,15 +120,15 @@ func TestShardController(t *testing.T) {
 	rpc := newMockRpcProvider()
 	coordinator := newMockCoordinator()
 
-	s1 := model.ServerAddress{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := model.ServerAddress{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := model.ServerAddress{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := model.Server{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := model.Server{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := model.Server{Public: "s3:9091", Internal: "s3:8191"}
 
 	sc := NewShardController(common.DefaultNamespace, shard, namespaceConfig, model.ShardMetadata{
 		Status:   model.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []model.ServerAddress{s1, s2, s3},
+		Ensemble: []model.Server{s1, s2, s3},
 	}, rpc, coordinator)
 
 	// Shard controller should initiate a leader election
@@ -194,15 +194,15 @@ func TestShardController_StartingWithLeaderAlreadyPresent(t *testing.T) {
 	rpc := newMockRpcProvider()
 	coordinator := newMockCoordinator()
 
-	s1 := model.ServerAddress{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := model.ServerAddress{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := model.ServerAddress{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := model.Server{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := model.Server{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := model.Server{Public: "s3:9091", Internal: "s3:8191"}
 
 	sc := NewShardController(common.DefaultNamespace, shard, namespaceConfig, model.ShardMetadata{
 		Status:   model.ShardStatusSteadyState,
 		Term:     1,
 		Leader:   &s1,
-		Ensemble: []model.ServerAddress{s1, s2, s3},
+		Ensemble: []model.Server{s1, s2, s3},
 	}, rpc, coordinator)
 
 	select {
@@ -225,15 +225,15 @@ func TestShardController_NewTermWithNonRespondingServer(t *testing.T) {
 	rpc := newMockRpcProvider()
 	coordinator := newMockCoordinator()
 
-	s1 := model.ServerAddress{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := model.ServerAddress{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := model.ServerAddress{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := model.Server{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := model.Server{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := model.Server{Public: "s3:9091", Internal: "s3:8191"}
 
 	sc := NewShardController(common.DefaultNamespace, shard, namespaceConfig, model.ShardMetadata{
 		Status:   model.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []model.ServerAddress{s1, s2, s3},
+		Ensemble: []model.Server{s1, s2, s3},
 	}, rpc, coordinator)
 
 	timeStart := time.Now()
@@ -271,15 +271,15 @@ func TestShardController_NewTermFollowerUntilItRecovers(t *testing.T) {
 	rpc := newMockRpcProvider()
 	coordinator := newMockCoordinator()
 
-	s1 := model.ServerAddress{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := model.ServerAddress{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := model.ServerAddress{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := model.Server{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := model.Server{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := model.Server{Public: "s3:9091", Internal: "s3:8191"}
 
 	sc := NewShardController(common.DefaultNamespace, shard, namespaceConfig, model.ShardMetadata{
 		Status:   model.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []model.ServerAddress{s1, s2, s3},
+		Ensemble: []model.Server{s1, s2, s3},
 	}, rpc, coordinator)
 
 	// s3 is failing, though we can still elect a leader
@@ -322,9 +322,9 @@ func TestShardController_VerifyFollowersWereAllFenced(t *testing.T) {
 	rpc := newMockRpcProvider()
 	coordinator := newMockCoordinator()
 
-	s1 := model.ServerAddress{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := model.ServerAddress{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := model.ServerAddress{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := model.Server{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := model.Server{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := model.Server{Public: "s3:9091", Internal: "s3:8191"}
 	n1 := rpc.GetNode(s1)
 	n2 := rpc.GetNode(s2)
 	n3 := rpc.GetNode(s3)
@@ -333,7 +333,7 @@ func TestShardController_VerifyFollowersWereAllFenced(t *testing.T) {
 		Status:   model.ShardStatusSteadyState,
 		Term:     4,
 		Leader:   &s1,
-		Ensemble: []model.ServerAddress{s1, s2, s3},
+		Ensemble: []model.Server{s1, s2, s3},
 	}, rpc, coordinator)
 
 	r1 := <-n1.getStatusRequests
@@ -386,9 +386,9 @@ func TestShardController_NotificationsDisabled(t *testing.T) {
 	rpc := newMockRpcProvider()
 	coordinator := newMockCoordinator()
 
-	s1 := model.ServerAddress{Public: "s1:9091", Internal: "s1:8191"}
-	s2 := model.ServerAddress{Public: "s2:9091", Internal: "s2:8191"}
-	s3 := model.ServerAddress{Public: "s3:9091", Internal: "s3:8191"}
+	s1 := model.Server{Public: "s1:9091", Internal: "s1:8191"}
+	s2 := model.Server{Public: "s2:9091", Internal: "s2:8191"}
+	s3 := model.Server{Public: "s3:9091", Internal: "s3:8191"}
 
 	namespaceConfig := &model.NamespaceConfig{
 		Name:                 "my-ns-2",
@@ -401,7 +401,7 @@ func TestShardController_NotificationsDisabled(t *testing.T) {
 		Status:   model.ShardStatusUnknown,
 		Term:     1,
 		Leader:   nil,
-		Ensemble: []model.ServerAddress{s1, s2, s3},
+		Ensemble: []model.Server{s1, s2, s3},
 	}, rpc, coordinator)
 
 	// Shard controller should initiate a leader election
@@ -450,7 +450,7 @@ func (m *mockCoordinator) WaitForNextUpdate(ctx context.Context, currentValue *p
 	panic("not implemented")
 }
 
-func (m *mockCoordinator) FindServerAddressByInternalAddress(_ string) (*model.ServerAddress, bool) {
+func (m *mockCoordinator) FindServerByIdentifier(_ string) (*model.Server, bool) {
 	return nil, false
 }
 
@@ -487,6 +487,6 @@ func (m *mockCoordinator) ShardDeleted(namespace string, shard int64) error {
 	return nil
 }
 
-func (m *mockCoordinator) NodeBecameUnavailable(node model.ServerAddress) {
+func (m *mockCoordinator) NodeBecameUnavailable(node model.Server) {
 	panic("not implemented")
 }

--- a/coordinator/model/cluster_common.go
+++ b/coordinator/model/cluster_common.go
@@ -1,3 +1,17 @@
+// Copyright 2025 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package model
 
 type Server struct {

--- a/coordinator/model/cluster_common.go
+++ b/coordinator/model/cluster_common.go
@@ -2,7 +2,7 @@ package model
 
 type Server struct {
 	// Name is the unique identification for clusters
-	Name *string `json:"id" yaml:"id"`
+	Name *string `json:"name" yaml:"name"`
 
 	// Public is the endpoint that is advertised to clients
 	Public string `json:"public" yaml:"public"`

--- a/coordinator/model/cluster_common.go
+++ b/coordinator/model/cluster_common.go
@@ -1,0 +1,19 @@
+package model
+
+type Server struct {
+	// Name is the unique identification for clusters
+	Name *string `json:"id" yaml:"id"`
+
+	// Public is the endpoint that is advertised to clients
+	Public string `json:"public" yaml:"public"`
+
+	// Internal is the endpoint for server->server RPCs
+	Internal string `json:"internal" yaml:"internal"`
+}
+
+func (sv *Server) GetIdentifier() string {
+	if sv.Name == nil {
+		return sv.Internal
+	}
+	return *sv.Name
+}

--- a/coordinator/model/cluster_config.go
+++ b/coordinator/model/cluster_config.go
@@ -18,7 +18,7 @@ import "github.com/streamnative/oxia/common"
 
 type ClusterConfig struct {
 	Namespaces []NamespaceConfig `json:"namespaces" yaml:"namespaces"`
-	Servers    []ServerAddress   `json:"servers" yaml:"servers"`
+	Servers    []Server          `json:"servers" yaml:"servers"`
 }
 
 type NamespaceConfig struct {

--- a/coordinator/model/cluster_config_test.go
+++ b/coordinator/model/cluster_config_test.go
@@ -27,7 +27,7 @@ func TestClusterConfig(t *testing.T) {
 			InitialShardCount: 2,
 			ReplicationFactor: 3,
 		}},
-		Servers: []ServerAddress{{
+		Servers: []Server{{
 			Public:   "f1",
 			Internal: "f1",
 		}, {
@@ -42,7 +42,7 @@ func TestClusterConfig(t *testing.T) {
 			InitialShardCount: 2,
 			ReplicationFactor: 3,
 		}},
-		Servers: []ServerAddress{{
+		Servers: []Server{{
 			Public:   "f1",
 			Internal: "f1",
 		}, {

--- a/coordinator/model/cluster_status.go
+++ b/coordinator/model/cluster_status.go
@@ -14,14 +14,6 @@
 
 package model
 
-type ServerAddress struct {
-	// Public is the endpoint that is advertised to clients
-	Public string `json:"public" yaml:"public"`
-
-	// Internal is the endpoint for server->server RPCs
-	Internal string `json:"internal" yaml:"internal"`
-}
-
 type Int32HashRange struct {
 	// The minimum inclusive hash that the shard can contain
 	Min uint32 `json:"min"`
@@ -31,12 +23,12 @@ type Int32HashRange struct {
 }
 
 type ShardMetadata struct {
-	Status         ShardStatus     `json:"status" yaml:"status"`
-	Term           int64           `json:"term" yaml:"term"`
-	Leader         *ServerAddress  `json:"leader" yaml:"leader"`
-	Ensemble       []ServerAddress `json:"ensemble" yaml:"ensemble"`
-	RemovedNodes   []ServerAddress `json:"removedNodes" yaml:"removedNodes"`
-	Int32HashRange Int32HashRange  `json:"int32HashRange" yaml:"int32HashRange"`
+	Status         ShardStatus    `json:"status" yaml:"status"`
+	Term           int64          `json:"term" yaml:"term"`
+	Leader         *Server        `json:"leader" yaml:"leader"`
+	Ensemble       []Server       `json:"ensemble" yaml:"ensemble"`
+	RemovedNodes   []Server       `json:"removedNodes" yaml:"removedNodes"`
+	Int32HashRange Int32HashRange `json:"int32HashRange" yaml:"int32HashRange"`
 }
 
 type NamespaceStatus struct {
@@ -70,8 +62,8 @@ func (sm ShardMetadata) Clone() ShardMetadata {
 		Status:         sm.Status,
 		Term:           sm.Term,
 		Leader:         sm.Leader,
-		Ensemble:       make([]ServerAddress, len(sm.Ensemble)),
-		RemovedNodes:   make([]ServerAddress, len(sm.RemovedNodes)),
+		Ensemble:       make([]Server, len(sm.Ensemble)),
+		RemovedNodes:   make([]Server, len(sm.RemovedNodes)),
 		Int32HashRange: sm.Int32HashRange.Clone(),
 	}
 

--- a/coordinator/model/cluster_status_test.go
+++ b/coordinator/model/cluster_status_test.go
@@ -29,11 +29,11 @@ func TestClusterStatus_Clone(t *testing.T) {
 					0: {
 						Status: ShardStatusSteadyState,
 						Term:   1,
-						Leader: &ServerAddress{
+						Leader: &Server{
 							Public:   "l1",
 							Internal: "l1",
 						},
-						Ensemble: []ServerAddress{{
+						Ensemble: []Server{{
 							Public:   "f1",
 							Internal: "f1",
 						}, {
@@ -41,7 +41,7 @@ func TestClusterStatus_Clone(t *testing.T) {
 							Internal: "f2",
 						}},
 						Int32HashRange: Int32HashRange{},
-						RemovedNodes: []ServerAddress{{
+						RemovedNodes: []Server{{
 							Public:   "r1",
 							Internal: "r1",
 						}},

--- a/maelstrom/coordinator_rpc_client.go
+++ b/maelstrom/coordinator_rpc_client.go
@@ -43,7 +43,7 @@ type maelstromCoordinatorRpcProvider struct {
 	assignmentStreams map[int64]*maelstromShardAssignmentClient
 }
 
-func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node model.ServerAddress) {
+func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node model.Server) {
 }
 
 func newRpcProvider(dispatcher *dispatcher) impl.RpcProvider {
@@ -53,11 +53,11 @@ func newRpcProvider(dispatcher *dispatcher) impl.RpcProvider {
 	}
 }
 
-func (m *maelstromCoordinatorRpcProvider) PushShardAssignments(ctx context.Context, node model.ServerAddress) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
+func (m *maelstromCoordinatorRpcProvider) PushShardAssignments(ctx context.Context, node model.Server) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
 	return newShardAssignmentClient(ctx, m, node.Internal), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) NewTerm(ctx context.Context, node model.ServerAddress, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
+func (m *maelstromCoordinatorRpcProvider) NewTerm(ctx context.Context, node model.Server, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
 	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeNewTermRequest, req)
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (m *maelstromCoordinatorRpcProvider) NewTerm(ctx context.Context, node mode
 	return res.(*proto.NewTermResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) BecomeLeader(ctx context.Context, node model.ServerAddress, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
+func (m *maelstromCoordinatorRpcProvider) BecomeLeader(ctx context.Context, node model.Server, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error) {
 	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeBecomeLeaderRequest, req)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (m *maelstromCoordinatorRpcProvider) BecomeLeader(ctx context.Context, node
 	return res.(*proto.BecomeLeaderResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) AddFollower(ctx context.Context, node model.ServerAddress, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
+func (m *maelstromCoordinatorRpcProvider) AddFollower(ctx context.Context, node model.Server, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error) {
 	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeAddFollowerRequest, req)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ func (m *maelstromCoordinatorRpcProvider) AddFollower(ctx context.Context, node 
 	return res.(*proto.AddFollowerResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetStatus(ctx context.Context, node model.ServerAddress, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
+func (m *maelstromCoordinatorRpcProvider) GetStatus(ctx context.Context, node model.Server, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error) {
 	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeGetStatusRequest, req)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func (m *maelstromCoordinatorRpcProvider) GetStatus(ctx context.Context, node mo
 	return res.(*proto.GetStatusResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) DeleteShard(ctx context.Context, node model.ServerAddress, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
+func (m *maelstromCoordinatorRpcProvider) DeleteShard(ctx context.Context, node model.Server, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {
 	res, err := m.dispatcher.RpcRequest(ctx, node.Internal, MsgTypeDeleteShardRequest, req)
 	if err != nil {
 		return nil, err
@@ -102,7 +102,7 @@ func (m *maelstromCoordinatorRpcProvider) DeleteShard(ctx context.Context, node 
 	return res.(*proto.DeleteShardResponse), nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node model.ServerAddress) (grpc_health_v1.HealthClient, io.Closer, error) {
+func (m *maelstromCoordinatorRpcProvider) GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error) {
 	c := &maelstromHealthCheckClient{
 		provider: m,
 		node:     node.Internal,

--- a/maelstrom/main.go
+++ b/maelstrom/main.go
@@ -141,10 +141,10 @@ func main() {
 	replicationGrpcProvider := newMaelstromReplicationRpcProvider()
 	dispatcher := newDispatcher(grpcProvider, replicationGrpcProvider)
 
-	var servers []model.ServerAddress
+	var servers []model.Server
 	for _, node := range allNodes {
 		if node != thisNode {
-			servers = append(servers, model.ServerAddress{
+			servers = append(servers, model.Server{
 				Public:   node,
 				Internal: node,
 			})

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -60,7 +60,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 		AuthOptions:                authParams,
 	})
 	assert.NoError(t, err)
-	s1Addr := model.ServerAddress{
+	s1Addr := model.Server{
 		Public:   fmt.Sprintf("localhost:%d", s1.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s1.InternalPort()),
 	}
@@ -74,7 +74,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 		AuthOptions:                authParams,
 	})
 	assert.NoError(t, err)
-	s2Addr := model.ServerAddress{
+	s2Addr := model.Server{
 		Public:   fmt.Sprintf("localhost:%d", s2.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s2.InternalPort()),
 	}
@@ -88,7 +88,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 		AuthOptions:                authParams,
 	})
 	assert.NoError(t, err)
-	s3Addr := model.ServerAddress{
+	s3Addr := model.Server{
 		Public:   fmt.Sprintf("localhost:%d", s3.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s3.InternalPort()),
 	}
@@ -100,7 +100,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{s1Addr, s2Addr, s3Addr},
+		Servers: []model.Server{s1Addr, s2Addr, s3Addr},
 	}
 
 	clientPool := common.NewClientPool(nil, nil)

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -67,14 +67,14 @@ func getClientTLSOption() (*security.TLSOption, error) {
 	return &clientOption, nil
 }
 
-func newTLSServer(t *testing.T) (s *server.Server, addr model.ServerAddress) {
+func newTLSServer(t *testing.T) (s *server.Server, addr model.Server) {
 	t.Helper()
 	return newTLSServerWithInterceptor(t, func(config *server.Config) {
 
 	})
 }
 
-func newTLSServerWithInterceptor(t *testing.T, interceptor func(config *server.Config)) (s *server.Server, addr model.ServerAddress) {
+func newTLSServerWithInterceptor(t *testing.T, interceptor func(config *server.Config)) (s *server.Server, addr model.Server) {
 	t.Helper()
 	option, err := getPeerTLSOption()
 	assert.NoError(t, err)
@@ -102,7 +102,7 @@ func newTLSServerWithInterceptor(t *testing.T, interceptor func(config *server.C
 
 	assert.NoError(t, err)
 
-	addr = model.ServerAddress{
+	addr = model.Server{
 		Public:   fmt.Sprintf("localhost:%d", s.PublicPort()),
 		Internal: fmt.Sprintf("localhost:%d", s.InternalPort()),
 	}
@@ -125,7 +125,7 @@ func TestClusterHandshakeSuccess(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	option, err := getPeerTLSOption()
 	assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestClientHandshakeFailByNoTlsConfig(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	option, err := getPeerTLSOption()
 	assert.NoError(t, err)
@@ -189,7 +189,7 @@ func TestClientHandshakeByAuthFail(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	option, err := getPeerTLSOption()
 	assert.NoError(t, err)
@@ -229,7 +229,7 @@ func TestClientHandshakeWithInsecure(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	option, err := getPeerTLSOption()
 	assert.NoError(t, err)
@@ -270,7 +270,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	option, err := getPeerTLSOption()
 	assert.NoError(t, err)
@@ -312,7 +312,7 @@ func TestOnlyEnablePublicTls(t *testing.T) {
 			ReplicationFactor: 3,
 			InitialShardCount: 1,
 		}},
-		Servers: []model.ServerAddress{sa1, sa2, sa3},
+		Servers: []model.Server{sa1, sa2, sa3},
 	}
 	clientPool := common.NewClientPool(nil, nil)
 	defer clientPool.Close()


### PR DESCRIPTION
### Motivation

Introduce server identifiers to support unique names that do not bind to internal or public addresses. 


### Modification

- rename `ServerAddress` => `Server`
- use `GetIdentifier` method instead of using `Internal` address directly.
- use the internal address as an identifier by default for backwards compatibility, and I will introduce the special `Equals` method for migration from internal address to name as an identifier in the next PR.

