### PR TITLE
feat: avoid extra version check cost for internal keys

### DIFF
--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -484,7 +484,9 @@ func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *pr
 		return nil, errors.Wrap(err, "oxia db: failed to apply batch")
 	}
 
+	versionId := wal.InvalidOffset
 	if !internal {
+		versionId = d.versionIdTracker.Add(1)
 		// No version conflict
 		status, err := updateOperationCallback.OnPut(batch, putReq, se)
 		if err != nil {
@@ -495,13 +497,6 @@ func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *pr
 				Status: status,
 			}, nil
 		}
-	}
-
-	var versionId int64
-	if internal {
-		versionId = wal.InvalidOffset
-	} else {
-		versionId = d.versionIdTracker.Add(1)
 	}
 
 	if se == nil {

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -471,7 +471,7 @@ func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *pr
 	if len(putReq.GetSequenceKeyDelta()) > 0 {
 		newKey, err = generateUniqueKeyFromSequences(batch, putReq)
 		putReq.Key = newKey
-	} else {
+	} else if !internal {
 		se, err = checkExpectedVersionId(batch, putReq.Key, putReq.ExpectedVersionId)
 	}
 
@@ -484,15 +484,17 @@ func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *pr
 		return nil, errors.Wrap(err, "oxia db: failed to apply batch")
 	}
 
-	// No version conflict
-	status, err := updateOperationCallback.OnPut(batch, putReq, se)
-	if err != nil {
-		return nil, err
-	}
-	if status != proto.Status_OK {
-		return &proto.PutResponse{
-			Status: status,
-		}, nil
+	if !internal {
+		// No version conflict
+		status, err := updateOperationCallback.OnPut(batch, putReq, se)
+		if err != nil {
+			return nil, err
+		}
+		if status != proto.Status_OK {
+			return &proto.PutResponse{
+				Status: status,
+			}, nil
+		}
 	}
 
 	var versionId int64


### PR DESCRIPTION
### Motivation

We haven't updated the version for internal keys. therefore, we can also avoid extra version check cost for internal keys. especially for `commit-offset` and `last-version-id` keys.

### Modification

- only check versions if the key is not internal.