### PR TITLE
feat: disable debug log for testing

### DIFF
--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -38,7 +38,6 @@ var testKVOptions = &kv.FactoryOptions{
 }
 
 func init() {
-	common.LogLevel = slog.LevelDebug
 	common.ConfigureLogger()
 }
 

--- a/server/follower_controller_test.go
+++ b/server/follower_controller_test.go
@@ -17,7 +17,6 @@ package server
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sync"
 	"testing"
 	"time"


### PR DESCRIPTION
### Motivation

We can disable the debug log to reduce the CI pressure. and then we can enable it when we debug the issue. 

### Modification

- disblae debug level on testing.