### PR TITLE
feat: run profiler first to avoid any blockers on process

### DIFF
--- a/common/run.go
+++ b/common/run.go
@@ -21,6 +21,7 @@ import (
 )
 
 func RunProcess(startProcess func() (io.Closer, error)) {
+	profiler := RunProfiling()
 	process, err := startProcess()
 	if err != nil {
 		slog.Error(
@@ -29,8 +30,6 @@ func RunProcess(startProcess func() (io.Closer, error)) {
 		)
 		os.Exit(1)
 	}
-
-	profiler := RunProfiling()
 
 	WaitUntilSignal(
 		process,


### PR DESCRIPTION
### Motivation

We can run `RunProfiling` before the actual process to detect any blockers on the process.


### Modification

- move  `RunProfiling` before the actual process