### PR TITLE
feat: support tmate to debug ci failure

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -73,6 +73,10 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Setup tmate session
+        if: ${{ failure() }}
+        uses: mxschmitt/action-tmate@v3
+
   chaos-mesh:
     name: Run chaos-mesh
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Motivation

support tmate to debug some CI failures that do not provide useful information.  for example: `CatChen/check-git-status-action@v1`