### PR TITLE
feat: reduce delete range time complexity

### DIFF
--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -51,6 +51,7 @@ const (
 type UpdateOperationCallback interface {
 	OnPut(batch WriteBatch, req *proto.PutRequest, se *proto.StorageEntry) (proto.Status, error)
 	OnDelete(batch WriteBatch, key string) error
+	OnDeleteWithEntry(batch WriteBatch, key string, value *proto.StorageEntry) error
 	OnDeleteRange(batch WriteBatch, keyStartInclusive string, keyEndExclusive string) error
 }
 
@@ -608,10 +609,20 @@ func (d *db) applyDeleteRange(batch WriteBatch, notifications *notifications, de
 	var validKeysNum = 0
 	for ; it.Valid(); it.Next() {
 		validKeysNum++
+		key := it.Key()
 		if validKeysNum <= DeleteRangeThreshold {
-			validKeys = append(validKeys, it.Key())
+			validKeys = append(validKeys, key)
 		}
-		if err = updateOperationCallback.OnDelete(batch, it.Key()); err != nil {
+		value, err := it.Value()
+		if err != nil {
+			return nil, errors.Wrap(multierr.Combine(err, it.Close()), "oxia db: failed to get value on delete range")
+		}
+		se := proto.StorageEntryFromVTPool()
+		defer se.ReturnToVTPool()
+		if err = Deserialize(value, se); err != nil {
+			return nil, err
+		}
+		if err = updateOperationCallback.OnDeleteWithEntry(batch, key, se); err != nil {
 			return nil, errors.Wrap(multierr.Combine(err, it.Close()), "oxia db: failed to callback on delete range")
 		}
 	}
@@ -743,6 +754,10 @@ func (d *db) ReadNextNotifications(ctx context.Context, startOffset int64) ([]*p
 }
 
 type noopCallback struct{}
+
+func (c *noopCallback) OnDeleteWithEntry(batch WriteBatch, key string, value *proto.StorageEntry) error {
+	return nil
+}
 
 func (*noopCallback) OnPut(_ WriteBatch, _ *proto.PutRequest, _ *proto.StorageEntry) (proto.Status, error) {
 	return proto.Status_OK, nil

--- a/server/session_manager.go
+++ b/server/session_manager.go
@@ -365,6 +365,11 @@ func (*sessionManagerUpdateOperationCallbackS) OnDelete(batch kv.WriteBatch, key
 	return err
 }
 
+func (*sessionManagerUpdateOperationCallbackS) OnDeleteWithEntry(batch kv.WriteBatch, key string, value *proto.StorageEntry) error {
+	_, err := deleteShadow(batch, key, value)
+	return err
+}
+
 func (*sessionManagerUpdateOperationCallbackS) OnDeleteRange(batch kv.WriteBatch, keyStartInclusive string, keyEndExclusive string) error {
 	it, err := batch.RangeScan(keyStartInclusive, keyEndExclusive)
 	if err != nil {


### PR DESCRIPTION
### Motivation

Avoid calling every callback to range scan to reduce the time complexity. 


### Modification

- Extract the same ranges can logic out of callback.
- Introduce `onDeleteWithEntry` method.