### PR TITLE
Revert "fix: no response when range scan return err (#651)"

### DIFF
--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -1052,12 +1052,12 @@ func TestLeaderController_RangeScan(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	ch, errCh := lc.RangeScan(context.Background(), &proto.RangeScanRequest{
+	ch, _, err := lc.RangeScan(context.Background(), &proto.RangeScanRequest{
 		Shard:          &shard,
 		StartInclusive: "/a",
 		EndExclusive:   "/c",
 	})
-	assert.Empty(t, errCh)
+	assert.NoError(t, err)
 
 	gr, more := <-ch
 	assert.Equal(t, "/a", *gr.Key)
@@ -1069,12 +1069,12 @@ func TestLeaderController_RangeScan(t *testing.T) {
 	assert.Nil(t, gr)
 	assert.False(t, more)
 
-	ch, errCh = lc.RangeScan(context.Background(), &proto.RangeScanRequest{
+	ch, _, err = lc.RangeScan(context.Background(), &proto.RangeScanRequest{
 		Shard:          &shard,
 		StartInclusive: "/y",
 		EndExclusive:   "/z",
 	})
-	assert.Empty(t, errCh)
+	assert.NoError(t, err)
 
 	gr, more = <-ch
 	assert.Nil(t, gr)

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -260,25 +260,30 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 		slog.String("peer", common.GetPeer(stream.Context())),
 		slog.Any("req", request),
 	)
-	ctx := stream.Context()
+
 	lc, err := s.getLeader(*request.Shard)
 	if err != nil {
 		return err
 	}
 
-	ch, errCh := lc.RangeScan(ctx, request)
+	ch, errCh, err := lc.RangeScan(stream.Context(), request)
+	if err != nil {
+		s.log.Warn(
+			"Failed to perform range-scan operation",
+			slog.Any("error", err),
+		)
+	}
+
 	response := &proto.RangeScanResponse{}
 	var totalSize int
+
 	for {
 		select {
 		case err := <-errCh:
 			if err != nil {
-				s.log.Warn(
-					"Failed to perform range-scan operation",
-					slog.Any("error", err),
-				)
 				return err
 			}
+
 		case gr, more := <-ch:
 			if !more {
 				if len(response.Records) > 0 {
@@ -300,8 +305,8 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 			response.Records = append(response.Records, gr)
 			totalSize += size
 
-		case <-ctx.Done():
-			return ctx.Err()
+		case <-stream.Context().Done():
+			return stream.Context().Err()
 		}
 	}
 }

--- a/server/secondary_indexes_test.go
+++ b/server/secondary_indexes_test.go
@@ -165,13 +165,13 @@ func TestSecondaryIndices_RangeScan(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	ch, errCh := lc.RangeScan(ctx, &proto.RangeScanRequest{
+	ch, errCh, err := lc.RangeScan(ctx, &proto.RangeScanRequest{
 		Shard:              &shard,
 		StartInclusive:     "1",
 		EndExclusive:       "3",
 		SecondaryIndexName: pb.String("my-idx"),
 	})
-	assert.Empty(t, errCh)
+	assert.NoError(t, err)
 
 	gr := <-ch
 	assert.Equal(t, "/b", *gr.Key)
@@ -184,14 +184,15 @@ func TestSecondaryIndices_RangeScan(t *testing.T) {
 	assert.NoError(t, <-errCh)
 
 	// Wrong index
-	ch, errCh = lc.RangeScan(ctx, &proto.RangeScanRequest{
+	ch, errCh, err = lc.RangeScan(ctx, &proto.RangeScanRequest{
 		Shard:              &shard,
 		StartInclusive:     "/a",
 		EndExclusive:       "/d",
 		SecondaryIndexName: pb.String("wrong-idx"),
 	})
+	assert.NoError(t, err)
 	assert.Empty(t, ch)
-	assert.Empty(t, errCh)
+	assert.NoError(t, <-errCh)
 
 	// Individual delete
 	_, err = lc.Write(context.Background(), &proto.WriteRequest{
@@ -200,13 +201,13 @@ func TestSecondaryIndices_RangeScan(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	ch, errCh = lc.RangeScan(ctx, &proto.RangeScanRequest{
+	ch, errCh, err = lc.RangeScan(ctx, &proto.RangeScanRequest{
 		Shard:              &shard,
 		StartInclusive:     "0",
 		EndExclusive:       "99999",
 		SecondaryIndexName: pb.String("my-idx"),
 	})
-	assert.Empty(t, errCh)
+	assert.NoError(t, err)
 
 	gr = <-ch
 	assert.Equal(t, "/a", *gr.Key)
@@ -231,14 +232,13 @@ func TestSecondaryIndices_RangeScan(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	ch, errCh = lc.RangeScan(ctx, &proto.RangeScanRequest{
+	ch, errCh, err = lc.RangeScan(ctx, &proto.RangeScanRequest{
 		Shard:              &shard,
 		StartInclusive:     "0",
 		EndExclusive:       "99999",
 		SecondaryIndexName: pb.String("my-idx"),
 	})
 	assert.NoError(t, err)
-	assert.Empty(t, errCh)
 
 	gr = <-ch
 	assert.Equal(t, "/d", *gr.Key)


### PR DESCRIPTION
This reverts commit 1600877bb0d0c90bed8fb33dcd9a1e2d3f2866fd.

This PR is reverting to PR #651, which introduces another deadlock. I will push another PR to simply fix the no-response issue first, then consider the code refactor. :/ 

```
11 @ 0x4773ae 0x40b30d 0x40af77 0x1bb4845 0x1bbac43 0x9e2527 0x9c47d2 0x9b2d47 0x9b495a 0x9ad6ff 0x47f661
# labels: {"bind":"[::]:6648", "oxia":"public"}
#	0x1bb4844	github.com/streamnative/oxia/server.(*leaderController).RangeScan+0x224					/src/oxia/server/leader_controller.go:712
#	0x1bbac42	github.com/streamnative/oxia/server.(*publicRpcServer).RangeScan+0x202					/src/oxia/server/public_rpc_server.go:269
#	0x9e2526	github.com/streamnative/oxia/proto._OxiaClient_RangeScan_Handler+0x106					/src/oxia/proto/client_grpc.pb.go:528
#	0x9c47d1	github.com/grpc-ecosystem/go-grpc-prometheus.init.(*ServerMetrics).StreamServerInterceptor.func4+0xd1	/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:121
#	0x9b2d46	google.golang.org/grpc.(*Server).processStreamingRPC+0x11e6						/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1695
#	0x9b4959	google.golang.org/grpc.(*Server).handleStream+0xe39							/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1809
#	0x9ad6fe	google.golang.org/grpc.(*Server).serveStreams.func2.1+0x7e						/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1029
```