### PR TITLE
fix: follow up #652 to return error directly

### DIFF
--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -272,6 +272,7 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 			"Failed to perform range-scan operation",
 			slog.Any("error", err),
 		)
+		return err
 	}
 
 	response := &proto.RangeScanResponse{}


### PR DESCRIPTION
### Motivation


follow up #651 #652. this is the simplest fix for no-response issue. 


### Modification

- return missing error directly.