### PR TITLE
fix: don't crash if client does not send shard id

### DIFF
--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protowire"
@@ -164,6 +165,10 @@ func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClie
 		slog.Any("req", request),
 	)
 
+	if request.Shard == nil {
+		return status.Error(codes.InvalidArgument, "shard id is required")
+	}
+
 	lc, err := s.getLeader(*request.Shard)
 	if err != nil {
 		return err
@@ -211,6 +216,10 @@ func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClie
 		slog.String("peer", common.GetPeer(stream.Context())),
 		slog.Any("req", request),
 	)
+
+	if request.Shard == nil {
+		return status.Error(codes.InvalidArgument, "shard id is required")
+	}
 
 	lc, err := s.getLeader(*request.Shard)
 	if err != nil {
@@ -263,6 +272,10 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 		slog.String("peer", common.GetPeer(stream.Context())),
 		slog.Any("req", request),
 	)
+
+	if request.Shard == nil {
+		return status.Error(codes.InvalidArgument, "shard id is required")
+	}
 
 	lc, err := s.getLeader(*request.Shard)
 	if err != nil {


### PR DESCRIPTION
A client that does not include a shard id with a read request will crash the server.

  - return codes.InvalidArgument if a ReadRequest does not include shard id

*Note*: despite the comment in client.proto, the Shard field is not actually optional. This commit does not change the protobuf definition as the comment suggests this is subject to change.

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x102208274]

goroutine 102 [running]:
github.com/streamnative/oxia/server.(*publicRpcServer).Read(0x140001e51c0, 0x140002e83c0, {0x102c0f5b0, 0x14000694380})
        /Users/pixi/src/streamnative/oxia/server/public_rpc_server.go:167 +0x124
github.com/streamnative/oxia/proto._OxiaClient_Read_Handler({0x102ac1380, 0x140001e51c0}, {0x102c0d328, 0x1400048e450})
        /Users/pixi/src/streamnative/oxia/proto/client_grpc.pb.go:486 +0x11c
github.com/grpc-ecosystem/go-grpc-prometheus.init.(*ServerMetrics).StreamServerInterceptor.func4({0x102ac1380, 0x140001e51c0}, {0x102c0d490, 0x140006a80f0}, 0x1400048e438, 0x102bdd860)
        /Users/pixi/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-prometheus@v1.2.0/server_metrics.go:121 +0xc8
google.golang.org/grpc.(*Server).processStreamingRPC(0x14000239600, {0x102c07258, 0x140006aa2a0}, {0x102c12660, 0x14000444340}, 0x140001fc5a0, 0x14000520d80, 0x103cdb020, 0x0)
        /Users/pixi/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1695 +0xe30
google.golang.org/grpc.(*Server).handleStream(0x14000239600, {0x102c12660, 0x14000444340}, 0x140001fc5a0)
        /Users/pixi/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1809 +0xad4
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /Users/pixi/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1029 +0x84
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 101
        /Users/pixi/go/pkg/mod/google.golang.org/grpc@v1.68.0/server.go:1040 +0x138
```