### PR TITLE
feat: support shares assignments logs

### DIFF
--- a/coordinator/impl/node_controller.go
+++ b/coordinator/impl/node_controller.go
@@ -356,7 +356,7 @@ func (n *nodeController) sendAssignmentsUpdates(backoff backoff.BackOff) error {
 				return err
 			}
 
-			n.log.Debug("Sent assignments to stream")
+			n.log.Info("Sent new shareds assignments.", slog.Any("assignments", assignments))
 			backoff.Reset()
 		}
 	}

--- a/server/assignment_dispatcher.go
+++ b/server/assignment_dispatcher.go
@@ -221,6 +221,10 @@ func (s *shardAssignmentDispatcher) updateShardAssignment(assignments *proto.Sha
 	// considered "ready" and it will be able to respond to service discovery requests
 	s.healthServer.SetServingStatus(container.ReadinessProbeService, grpc_health_v1.HealthCheckResponse_SERVING)
 
+	s.log.Info("Update shares assignments.",
+		slog.Any("previous", s.assignments),
+		slog.Any("current", assignments))
+
 	s.Lock()
 	defer s.Unlock()
 

--- a/server/assignment_dispatcher_test.go
+++ b/server/assignment_dispatcher_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
+	pb "google.golang.org/protobuf/proto"
 
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/common/container"
@@ -268,7 +269,7 @@ func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
 	wg.Wait()
 
 	response := mockClient.GetResponse()
-	assert.Equal(t, &proto.ShardAssignments{
+	assert.True(t, pb.Equal(&proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			"test-ns-1": {
 				Assignments: []*proto.ShardAssignment{
@@ -278,7 +279,7 @@ func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
 				ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,
 			},
 		},
-	}, response)
+	}, response))
 
 	// If namespace is not passed, it will use "default"
 	mockClient = newMockShardAssignmentClientStream()
@@ -295,7 +296,7 @@ func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
 	wg.Wait()
 
 	response = mockClient.GetResponse()
-	assert.Equal(t, &proto.ShardAssignments{
+	assert.True(t, pb.Equal(&proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			"default": {
 				Assignments: []*proto.ShardAssignment{
@@ -305,7 +306,7 @@ func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
 				ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,
 			},
 		},
-	}, response)
+	}, response))
 
 	// If the namespace is not valid, we'll get an error
 	mockClient = newMockShardAssignmentClientStream()

--- a/server/assignment_dispatcher_test.go
+++ b/server/assignment_dispatcher_test.go
@@ -170,7 +170,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 	}()
 
 	response := mockClient.GetResponse()
-	assert.Equal(t, request, response)
+	assert.True(t, pb.Equal(request, response))
 
 	request = &proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
@@ -187,7 +187,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 
 	// Should get the assignment update as they arrived from controller
 	response = mockClient.GetResponse()
-	assert.Equal(t, request, response)
+	assert.True(t, pb.Equal(request, response))
 
 	mockClient.cancel()
 	wg.Wait()
@@ -205,7 +205,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 	}()
 
 	response = mockClient.GetResponse()
-	assert.Equal(t, request, response)
+	assert.True(t, pb.Equal(request, response))
 
 	mockClient.cancel()
 	wg.Wait()


### PR DESCRIPTION
### Motivation

Adding assignments updates log on both the coordinator and server-side because it's a critical path.

### Modification

- Adding info logs on the assignment of the shares dispatching path.