### PR TITLE
fix: move the version id generation behind error handling

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     name: Build
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -487,7 +487,6 @@ func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *pr
 
 	versionId := wal.InvalidOffset
 	if !internal {
-		versionId = d.versionIdTracker.Add(1)
 		// No version conflict
 		status, err := updateOperationCallback.OnPut(batch, putReq, se)
 		if err != nil {
@@ -498,6 +497,7 @@ func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *pr
 				Status: status,
 			}, nil
 		}
+		versionId = d.versionIdTracker.Add(1)
 	}
 
 	if se == nil {

--- a/server/kv/db.go
+++ b/server/kv/db.go
@@ -485,9 +485,9 @@ func (d *db) applyPut(batch WriteBatch, notifications *notifications, putReq *pr
 		return nil, errors.Wrap(err, "oxia db: failed to apply batch")
 	}
 
+	// No version conflict
 	versionId := wal.InvalidOffset
 	if !internal {
-		// No version conflict
 		status, err := updateOperationCallback.OnPut(batch, putReq, se)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Motivation

Move version ID generation behind the callback validation to avoid any potential inconsistency by abnormal conditions.

### Modification

- Move version ID generation behind the callback handling