### PR TITLE
feat: followup #662 to use stream callback for Read

### DIFF
--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -19,11 +19,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/streamnative/oxia/common/channel"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
+
+	"github.com/streamnative/oxia/common/channel"
 
 	"github.com/streamnative/oxia/common/entities"
 

--- a/server/leader_controller_test.go
+++ b/server/leader_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/streamnative/oxia/common/channel"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -70,13 +71,14 @@ func TestLeaderController_NotInitialized(t *testing.T) {
 	assert.Nil(t, res)
 	assert.Equal(t, common.CodeInvalidStatus, status.Code(err))
 
-	r := <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "a"}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.Nil(t, r.Response)
-	assert.Equal(t, common.CodeInvalidStatus, status.Code(r.Err))
+	_, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses)
+	assert.Equal(t, common.CodeInvalidStatus, status.Code(err))
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -192,15 +194,17 @@ func TestLeaderController_BecomeLeader_RF1(t *testing.T) {
 	assert.NotEqualValues(t, 0, res.Puts[0].Version.ModifiedTimestamp)
 	assert.EqualValues(t, res.Puts[0].Version.CreatedTimestamp, res.Puts[0].Version.ModifiedTimestamp)
 
-	// Read entry
-	r := <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "a", IncludeValue: true}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.NoError(t, r.Err)
-	assert.Equal(t, proto.Status_OK, r.Response.Status)
-	assert.Equal(t, []byte("value-a"), r.Response.Value)
+	results, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, proto.Status_OK, results[0].Status)
+	assert.Equal(t, []byte("value-a"), results[0].Value)
 	assert.EqualValues(t, 0, res.Puts[0].Version.VersionId)
 
 	// Set NewTerm to leader
@@ -227,13 +231,14 @@ func TestLeaderController_BecomeLeader_RF1(t *testing.T) {
 	assert.Nil(t, res3)
 	assert.Equal(t, common.CodeInvalidStatus, status.Code(err))
 
-	r = <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses = make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "a"}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.Nil(t, r.Response)
-	assert.Equal(t, common.CodeInvalidStatus, status.Code(r.Err))
+	_, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses)
+	assert.Equal(t, common.CodeInvalidStatus, status.Code(err))
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -296,15 +301,18 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 	assert.Equal(t, proto.Status_OK, res.Puts[0].Status)
 	assert.EqualValues(t, 0, res.Puts[0].Version.VersionId)
 
-	// Read entry
-	r := <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "a", IncludeValue: true}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.NoError(t, r.Err)
-	assert.Equal(t, proto.Status_OK, r.Response.Status)
-	assert.Equal(t, []byte("value-a"), r.Response.Value)
+	results, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses) // Read entry
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, proto.Status_OK, results[0].Status)
+	assert.Equal(t, []byte("value-a"), results[0].Value)
 	assert.EqualValues(t, 0, res.Puts[0].Version.VersionId)
 
 	// Set NewTerm to leader
@@ -331,13 +339,14 @@ func TestLeaderController_BecomeLeader_RF2(t *testing.T) {
 	assert.Nil(t, res3)
 	assert.Equal(t, common.CodeInvalidStatus, status.Code(err))
 
-	r = <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses = make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "a"}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.Nil(t, r.Response)
-	assert.Equal(t, common.CodeInvalidStatus, status.Code(r.Err))
+	_, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses)
+	assert.Equal(t, common.CodeInvalidStatus, status.Code(err))
 
 	close(rpc.ackResps)
 	assert.NoError(t, lc.Close())
@@ -835,15 +844,18 @@ func TestLeaderController_EntryVisibilityAfterBecomingLeader(t *testing.T) {
 	})
 
 	// We should be able to read the entry, even if it was not fully committed before the leader started
-	r := <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "my-key", IncludeValue: true}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.NoError(t, r.Err)
-	assert.Equal(t, proto.Status_OK, r.Response.Status)
-	assert.Equal(t, []byte("my-value"), r.Response.Value)
-	assert.EqualValues(t, 0, r.Response.Version.VersionId)
+	results, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, proto.Status_OK, results[0].Status)
+	assert.Equal(t, []byte("my-value"), results[0].Value)
+	assert.EqualValues(t, 0, results[0].Version.VersionId)
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())
@@ -1124,15 +1136,17 @@ func TestLeaderController_DeleteShard(t *testing.T) {
 		FollowerMaps:      nil,
 	})
 
-	// Read entry
-	r := <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "a", IncludeValue: true}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.NoError(t, r.Err)
-	assert.Equal(t, proto.Status_KEY_NOT_FOUND, r.Response.Status)
-	assert.Nil(t, r.Response.Value)
+	results, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses) // Read entry
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, proto.Status_KEY_NOT_FOUND, results[0].Status)
+	assert.Nil(t, results[0].Value)
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, walFactory.Close())
@@ -1275,26 +1289,29 @@ func TestLeaderController_WriteStream(t *testing.T) {
 
 	cancel()
 
-	// Read entry a
-	r := <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "a", IncludeValue: true}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.NoError(t, r.Err)
-	assert.Equal(t, proto.Status_OK, r.Response.Status)
-	assert.Equal(t, []byte("value-a"), r.Response.Value)
+	results, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses) // Read entry a
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, proto.Status_OK, results[0].Status)
+	assert.Equal(t, []byte("value-a"), results[0].Value)
 	assert.EqualValues(t, 0, res1.Puts[0].Version.VersionId)
 
-	// Read entry b
-	r = <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses = make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: "b", IncludeValue: true}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.NoError(t, r.Err)
-	assert.Equal(t, proto.Status_OK, r.Response.Status)
-	assert.Equal(t, []byte("value-b"), r.Response.Value)
+	results, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses) // Read entry a
+	assert.NoError(t, err)
+	assert.Equal(t, proto.Status_OK, results[0].Status)
+	assert.Equal(t, []byte("value-b"), results[0].Value)
 	assert.EqualValues(t, 0, res1.Puts[0].Version.VersionId)
 
 	// Set NewTerm to leader
@@ -1409,14 +1426,16 @@ func TestLeaderController_DuplicateNewTerm_WithSession(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	// Read entry
-	r := <-lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shard,
 		Gets:  []*proto.GetRequest{{Key: key}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
 
-	assert.NoError(t, r.Err)
-	assert.Equal(t, proto.Status_KEY_NOT_FOUND, r.Response.Status)
+	results, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses) // Read entry
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, proto.Status_KEY_NOT_FOUND, results[0].Status)
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvFactory.Close())

--- a/server/public_rpc_server.go
+++ b/server/public_rpc_server.go
@@ -161,7 +161,6 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 	return err
 }
 
-//nolint:revive
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {
 	s.log.Debug(
 		"Read request",

--- a/server/session_manager_test.go
+++ b/server/session_manager_test.go
@@ -21,11 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	pb "google.golang.org/protobuf/proto"
+
 	"github.com/streamnative/oxia/common/callback"
 	"github.com/streamnative/oxia/common/channel"
 	"github.com/streamnative/oxia/common/entities"
-	"github.com/stretchr/testify/assert"
-	pb "google.golang.org/protobuf/proto"
 
 	"github.com/streamnative/oxia/common"
 	"github.com/streamnative/oxia/proto"

--- a/server/session_manager_test.go
+++ b/server/session_manager_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/streamnative/oxia/common/callback"
+	"github.com/streamnative/oxia/common/channel"
+	"github.com/streamnative/oxia/common/entities"
 	"github.com/stretchr/testify/assert"
 	pb "google.golang.org/protobuf/proto"
 
@@ -405,7 +408,8 @@ func TestMultipleSessionsExpiry(t *testing.T) {
 		return getSessionMetadata(t, lc, sessionId2) == nil
 	}, 10*time.Second, 30*time.Millisecond)
 
-	readCh := lc.Read(context.Background(), &proto.ReadRequest{
+	responses := make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shardId,
 		Gets: []*proto.GetRequest{{
 			Key:          "/ephemeral-1",
@@ -414,26 +418,24 @@ func TestMultipleSessionsExpiry(t *testing.T) {
 			Key:          "/ephemeral-2",
 			IncludeValue: true,
 		}},
-	})
+	}, callback.ReadFromStreamCallback(responses))
+	results, err := channel.ReadAll[*proto.GetResponse](context.Background(), responses) // Read entry a
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(results))
 
 	// ephemeral-1
-	rr, ok := <-readCh
-	assert.True(t, ok)
-	assert.NoError(t, rr.Err)
-	assert.Equal(t, proto.Status_OK, rr.Response.Status)
+	assert.Equal(t, proto.Status_OK, results[0].Status)
 
 	// ephemeral-2
-	rr, ok = <-readCh
-	assert.True(t, ok)
-	assert.NoError(t, rr.Err)
-	assert.Equal(t, proto.Status_KEY_NOT_FOUND, rr.Response.Status)
+	assert.Equal(t, proto.Status_KEY_NOT_FOUND, results[1].Status)
 
 	// Now Let session-1 expire and verify its key was deleted
 	assert.Eventually(t, func() bool {
 		return getSessionMetadata(t, lc, sessionId1) == nil
 	}, 10*time.Second, 30*time.Millisecond)
 
-	readCh = lc.Read(context.Background(), &proto.ReadRequest{
+	responses = make(chan *entities.TWithError[*proto.GetResponse], 1000)
+	lc.Read(context.Background(), &proto.ReadRequest{
 		Shard: &shardId,
 		Gets: []*proto.GetRequest{{
 			Key:          "/ephemeral-1",
@@ -442,19 +444,15 @@ func TestMultipleSessionsExpiry(t *testing.T) {
 			Key:          "/ephemeral-2",
 			IncludeValue: true,
 		}},
-	})
-
+	}, callback.ReadFromStreamCallback(responses))
+	results, err = channel.ReadAll[*proto.GetResponse](context.Background(), responses)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(results))
 	// ephemeral-1
-	rr, ok = <-readCh
-	assert.True(t, ok)
-	assert.NoError(t, rr.Err)
-	assert.Equal(t, proto.Status_KEY_NOT_FOUND, rr.Response.Status)
+	assert.Equal(t, proto.Status_KEY_NOT_FOUND, results[0].Status)
 
 	// ephemeral-2
-	rr, ok = <-readCh
-	assert.True(t, ok)
-	assert.NoError(t, rr.Err)
-	assert.Equal(t, proto.Status_KEY_NOT_FOUND, rr.Response.Status)
+	assert.Equal(t, proto.Status_KEY_NOT_FOUND, results[1].Status)
 
 	assert.NoError(t, lc.Close())
 	assert.NoError(t, kvf.Close())


### PR DESCRIPTION
### Motivation

This PR is a follow-up to #662 to align the streaming callback for the Read endpoint. 

### Modification

- Use `StreamingCallback` for Read operation.