### PR TITLE
fix: add close latch when close session

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -172,7 +172,6 @@ func (s *session) waitForHeartbeats() {
 		s.latch.Done()
 	}()
 	for {
-
 		select {
 		case <-s.ctx.Done():
 			return


### PR DESCRIPTION
### Motivation

fixes #693. 

Introduce a latch for the session to make sure the background goroutine gracefully shuts down and does not touch the released resource.