### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -120,6 +120,9 @@ jobs:
   maelstrom:
     name: Maelstrom
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Potential fix for [https://github.com/streamnative/oxia/security/code-scanning/14](https://github.com/streamnative/oxia/security/code-scanning/14)

To fix the issue, we will add a `permissions` block to the `maelstrom` job to explicitly define the minimal permissions required. Based on the job's operations, it appears to need:
- `contents: read` to access the repository's contents.
- `actions: write` to upload artifacts using the `actions/upload-artifact` action.

This change will ensure the job adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
