### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker_publish.yaml
+++ b/.github/workflows/docker_publish.yaml
@@ -33,6 +33,9 @@ jobs:
   publish-docker:
     name: Publish docker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
Potential fix for [https://github.com/streamnative/oxia/security/code-scanning/11](https://github.com/streamnative/oxia/security/code-scanning/11)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations (e.g., checking out code, interacting with DockerHub), the following permissions are likely needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for pushing Docker images to DockerHub.

The `permissions` block will be added at the job level (`publish-docker`) to limit its scope to this specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
