### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -76,6 +76,8 @@ jobs:
   chaos-mesh:
     name: Run chaos-mesh
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - name: Build docker


### PR DESCRIPTION
Potential fix for [https://github.com/streamnative/oxia/security/code-scanning/13](https://github.com/streamnative/oxia/security/code-scanning/13)

To fix the issue, we will add a `permissions` block to the `chaos-mesh` job. Based on the workflow's steps, it primarily interacts with the repository's contents (e.g., checking out the code) and uses external tools like Docker, Helm, and Kubernetes. Therefore, the minimal required permission is `contents: read`. This ensures that the job has only the necessary permissions to perform its tasks.

The `permissions` block will be added under the `chaos-mesh` job definition, specifying `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
