### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -34,6 +34,8 @@ jobs:
   build:
     name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Potential fix for [https://github.com/streamnative/oxia/security/code-scanning/12](https://github.com/streamnative/oxia/security/code-scanning/12)

To fix the issue, we will add an explicit `permissions` block to the `build` job. Based on the steps in the `build` job, it only requires `contents: read` permissions to check out the repository and perform the build and test steps. This change will ensure that the job does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
