### PR TITLE
Fix WriteStream regression: don't send an error client close

### DIFF
--- a/common/channel/noblock.go
+++ b/common/channel/noblock.go
@@ -14,7 +14,7 @@
 
 package channel
 
-func PushNoBlock[T any](ch chan T, t T) bool {
+func PushNoBlock[T any](ch chan<- T, t T) bool {
 	select {
 	case ch <- t:
 		return true

--- a/server/public_rpc_server_test.go
+++ b/server/public_rpc_server_test.go
@@ -24,13 +24,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/streamnative/oxia/common/logging"
-	"github.com/streamnative/oxia/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/streamnative/oxia/common/logging"
+	"github.com/streamnative/oxia/proto"
 )
 
 func init() {

--- a/server/public_rpc_server_test.go
+++ b/server/public_rpc_server_test.go
@@ -1,0 +1,90 @@
+// Copyright 2023 StreamNative, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Additional attributions:
+// Copyright 2025 Maurice Barnum
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/streamnative/oxia/common/logging"
+	"github.com/streamnative/oxia/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+func init() {
+	logging.LogJSON = false
+	logging.ConfigureLogger()
+}
+
+func TestWriteClientClose(t *testing.T) {
+	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
+	assert.NoError(t, err)
+	defer standaloneServer.Close()
+
+	serviceAddress := fmt.Sprintf("localhost:%d", standaloneServer.RpcPort())
+
+	// Connect to the standalone server
+	conn, err := grpc.NewClient(serviceAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "Failed to connect to %s", serviceAddress)
+	defer conn.Close()
+
+	client := proto.NewOxiaClientClient(conn)
+	ctx := metadata.NewOutgoingContext(context.Background(), metadata.New(map[string]string{
+		"shard-id":  "0",
+		"namespace": "default",
+	}))
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	stream, err := client.WriteStream(ctx)
+	require.NoError(t, err, "Failed to create write stream")
+
+	// Send a Put request
+	putReq := &proto.WriteRequest{
+		Puts: []*proto.PutRequest{
+			{
+				Key:   "test-key",
+				Value: []byte("test-value"),
+			},
+		},
+	}
+	err = stream.Send(putReq)
+	require.NoError(t, err, "Failed to send put request")
+
+	// Validate the request succeeded
+	resp, err := stream.Recv()
+	require.NoError(t, err, "Failed to receive response")
+	assert.Len(t, resp.Puts, 1)
+	assert.Equal(t, proto.Status_OK, resp.Puts[0].Status)
+
+	// Close the client side of the stream, and then expect no more responses
+	err = stream.CloseSend()
+	require.NoError(t, err, "Failed to close send")
+
+	resp, err = stream.Recv()
+	t.Logf("resp %v err %v", resp, err)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, io.EOF)
+}


### PR DESCRIPTION
## Summary
commit 93101002e1e1888eb4181b6ffb19b3a27e52016e
Author: mauricebarnum <maurice.barnum@gmail.com>
Date:   Tue Jun 10 19:33:06 2025 -0700

    public_rpc_server_test: test handling of a client closing a WriteStream
    
    After a client sends a write request, receives a response, and closes
    the write end of the stream, reading from the stream should yield an EOF

commit 4a56ff8d237b8e04f47a9425c065fbadc49413d8
Author: mauricebarnum <maurice.barnum@gmail.com>
Date:   Tue Jun 10 19:37:13 2025 -0700

    Fix WriteStream regression: don't send an error client close
    
    The refactoring in c90c79172d6cda7ae9ff199a8a9bf8a275fd5d61 makes
    a change that sends an unknown error message to the client when it
    encounters either a read EOF or an internal context is closed.  This
    can confuse a client that doesn't expect to see any more messages
    after closing the request side of the stream.
    
    This change suppresses the message upon EOF.
## Test output
```
20:00:12 > git rebase  --autosquash --update-refs -x 'go test ./server -run TestWriteClientClose' upstream/main
Executing: go test ./server -run TestWriteClientClose
Jun 10 20:00:33.369445 INF Starting Oxia standalone config={"AuthOptions":{"ProviderName":"","ProviderParams":""},"DataDir":"/var/folders/c_/ffflkqfj25d590trtpmzss0w0000gn/T/TestWriteClientClose554734378/001/db","DbBlockCacheMB":0,"InternalServerTLS":null,"InternalServiceAddr":"localhost:0","MetricsServiceAddr":"","NotificationsEnabled":true,"NotificationsRetentionTime":0,"NumShards":1,"PeerTLS":null,"PublicServiceAddr":"localhost:0","ServerTLS":null,"WalDir":"/var/folders/c_/ffflkqfj25d590trtpmzss0w0000gn/T/TestWriteClientClose554734378/001/wal","WalRetentionTime":0,"WalSyncData":false}
Jun 10 20:00:33.500406 INF Created leader controller component=leader-controller namespace=default shard=0 term=-1
Jun 10 20:00:33.511769 INF Leader successfully initialized in new term component=leader-controller last-entry={"offset":"-1","term":"-1"} namespace=default shard=0 term=0
Jun 10 20:00:33.512651 INF Applying all pending entries to database commit-offset=-1 component=leader-controller head-offset=-1 namespace=default shard=0 term=0
Jun 10 20:00:33.513782 INF All sessions component=session-manager count=0 namespace=default shard=0 term=0
Jun 10 20:00:33.514752 INF Started leading the shard component=leader-controller head-offset=-1 namespace=default shard=0 term=0
Jun 10 20:00:33.525032 INF Started Grpc server bindAddress=127.0.0.1:52943 grpc-server=public
Jun 10 20:00:33.533394 INF Update shares assignments. component=shard-assignment-dispatcher current={"namespaces":{"default":{"assignments":[{"int32HashRange":{"maxHashInclusive":4294967295,"minHashInclusive":0},"leader":"","shard":"0"}],"shardKeyRouter":"XXHASH3"}}} previous={"namespaces":{}}
Jun 10 20:00:43.967716 WRN Failed to perform write operation error={"error":"EOF","kind":"*errors.errorString","stack":null} component=public-rpc-server
Jun 10 20:00:43.974064 INF Closing leader controller component=leader-controller namespace=default shard=0 term=0
Jun 10 20:00:44.011775 INF Stopped Grpc server bindAddress=127.0.0.1:52943 grpc-server=public
--- FAIL: TestWriteClientClose (10.66s)
    public_rpc_server_test.go:70: resp <nil> err rpc error: code = Unknown desc = EOF
    public_rpc_server_test.go:72:
                Error Trace:    /Users/pixi/src/streamnative/oxia/no-push-eof/server/public_rpc_server_test.go:72
                Error:          Target error should be in err chain:
                                expected: "EOF"
                                in chain: "rpc error: code = Unknown desc = EOF"
                Test:           TestWriteClientClose
FAIL
FAIL    github.com/streamnative/oxia/server     11.029s
FAIL
warning: execution failed: go test ./server -run TestWriteClientClose
You can fix the problem, and then run

  git rebase --continue


~/src/streamnative/oxia/no-push-eof on  HEAD (581a485) (REBASING 2/4)
20:00:44 > git rebase --continue
Executing: go test ./server -run TestWriteClientClose
ok      github.com/streamnative/oxia/server     (cached)
Successfully rebased and updated refs/heads/no-push-eof.
```
