### PR TITLE
Fixed issue with db iterator closed after the callback

### DIFF
--- a/server/leader_controller.go
+++ b/server/leader_controller.go
@@ -689,10 +689,6 @@ func (lc *leaderController) list(ctx context.Context, request *proto.ListRequest
 				return
 			}
 
-			defer func() {
-				_ = it.Close()
-			}()
-
 			for ; it.Valid(); it.Next() {
 				if err = cb.OnNext(it.Key()); err != nil {
 					break
@@ -701,6 +697,8 @@ func (lc *leaderController) list(ctx context.Context, request *proto.ListRequest
 					break
 				}
 			}
+
+			err = multierr.Combine(err, it.Close())
 			cb.OnComplete(err)
 		},
 	)
@@ -746,10 +744,6 @@ func (lc *leaderController) RangeScan(ctx context.Context, request *proto.RangeS
 				return
 			}
 
-			defer func() {
-				_ = it.Close()
-			}()
-
 			var gr *proto.GetResponse
 			for ; it.Valid(); it.Next() {
 				if gr, err = it.Value(); err != nil {
@@ -762,6 +756,8 @@ func (lc *leaderController) RangeScan(ctx context.Context, request *proto.RangeS
 					break
 				}
 			}
+
+			err = multierr.Combine(err, it.Close())
 			cb.OnComplete(err)
 		},
 	)


### PR DESCRIPTION
The db iterator needs to be closed before the callback is invoked, otherwise we get the risk of the iterator getting marked as leaked, eg.: 

```
--- FAIL: TestLeaderController_NotificationsDisabled (0.01s)
    leader_controller_test.go:1317: 
        	Error Trace:	/home/runner/work/oxia/oxia/server/leader_controller_test.go:1317
        	Error:      	Received unexpected error:
        	            	leaked iterators:
        	            	(1) attached stack trace
        	            	  -- stack trace:
        	            	  | github.com/cockroachdb/pebble/v2.(*DB).Close
        	            	  | 	/home/runner/go/pkg/mod/github.com/cockroachdb/pebble/v2@v2.1.0/db.go:1757
        	            	  | github.com/oxia-db/oxia/server/kv.(*Pebble).Close
        	            	  | 	/home/runner/work/oxia/oxia/server/kv/kv_pebble.go:378
        	            	  | github.com/oxia-db/oxia/server/kv.(*db).Close
        	            	  | 	/home/runner/work/oxia/oxia/server/kv/db.go:187
        	            	  | github.com/oxia-db/oxia/server.(*leaderController).close
        	            	  | 	/home/runner/work/oxia/oxia/server/leader_controller.go:969
        	            	  | github.com/oxia-db/oxia/server.(*leaderController).Close
        	            	  | 	/home/runner/work/oxia/oxia/server/leader_controller.go:941
        	            	  | github.com/oxia-db/oxia/server.TestLeaderController_NotificationsDisabled
        	            	  | 	/home/runner/work/oxia/oxia/server/leader_controller_test.go:1317
        	            	  | testing.tRunner
        	            	  | 	/opt/hostedtoolcache/go/1.25.3/x64/src/testing/testing.go:1934
        	            	  | runtime.goexit
        	            	  | 	/opt/hostedtoolcache/go/1.25.3/x64/src/runtime/asm_amd64.s:1693
        	            	Wraps: (2) leaked iterators:
        	            	  | L0.0:
        	            	  |   000004:[\x80\x01__oxia\xffterm#10,SET-\x80\x01__oxia\xffterm-options#11,SET]
        	            	Error types: (1) *withstack.withStack (2) *errutil.leafError
        	Test:       	TestLeaderController_NotificationsDisabled
            
```

This was happening because when we start the leader controller we start the session manager who does a list of active sessions. 

When the leader controller is ready, it gets closed very quickly since the test is fast, though the iterator was still not closed in the background go-routine.