### PR TITLE
fixes: flaky test - TestShardController_StartingWithLeaderAlreadyPresent

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,0 @@
-[tools]
-go = "1.25.2"
-golangci-lint = "latest"


### PR DESCRIPTION
### Motivation

The current implementation of `verifyCurrentEnsemble` needs to get the status from the ensemble. which will fail if we don't give any response. 

