### PR TITLE
feat: rename nodeController to dataserverController

### DIFF
--- a/oxiad/coordinator/controller/dataserver_controller_test.go
+++ b/oxiad/coordinator/controller/dataserver_controller_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/oxia-db/oxia/proto"
 )
 
-func TestNodeController_HealthCheck(t *testing.T) {
+func TestDataServerController_HealthCheck(t *testing.T) {
 	addr := model.Server{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
@@ -39,7 +39,7 @@ func TestNodeController_HealthCheck(t *testing.T) {
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newNodeController(context.Background(), addr, sap, nal, rpc, 1*time.Second)
+	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, 1*time.Second)
 
 	assert.Equal(t, Running, nc.Status())
 
@@ -67,7 +67,7 @@ func TestNodeController_HealthCheck(t *testing.T) {
 	assert.NoError(t, nc.Close())
 }
 
-func TestNodeController_ShardsAssignments(t *testing.T) {
+func TestDataServerController_ShardsAssignments(t *testing.T) {
 	addr := model.Server{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
@@ -76,7 +76,7 @@ func TestNodeController_ShardsAssignments(t *testing.T) {
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newNodeController(context.Background(), addr, sap, nal, rpc, 1*time.Second)
+	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, 1*time.Second)
 
 	node := rpc.GetNode(addr)
 

--- a/oxiad/coordinator/controller/dataserver_event_listener.go
+++ b/oxiad/coordinator/controller/dataserver_event_listener.go
@@ -16,6 +16,6 @@ package controller
 
 import "github.com/oxia-db/oxia/oxiad/coordinator/model"
 
-type NodeEventListener interface {
-	NodeBecameUnavailable(node model.Server)
+type DataServerEventListener interface {
+	BecameUnavailable(dataServer model.Server)
 }

--- a/oxiad/coordinator/controller/mock_test.go
+++ b/oxiad/coordinator/controller/mock_test.go
@@ -90,7 +90,7 @@ func newMockNodeAvailabilityListener() *mockNodeAvailabilityListener {
 	}
 }
 
-func (nal *mockNodeAvailabilityListener) NodeBecameUnavailable(node model.Server) {
+func (nal *mockNodeAvailabilityListener) BecameUnavailable(node model.Server) {
 	nal.events <- node
 }
 

--- a/oxiad/coordinator/controller/shard_controller_test.go
+++ b/oxiad/coordinator/controller/shard_controller_test.go
@@ -150,7 +150,7 @@ func TestShardController(t *testing.T) {
 
 	// Simulate the failure of the leader
 	rpc.FailNode(s1, errors.New("failed to connect"))
-	sc.NodeBecameUnavailable(s1)
+	sc.BecameUnavailable(s1)
 
 	rpc.GetNode(s1).expectNewTermRequest(t, shard, 3, true)
 	rpc.GetNode(s2).expectNewTermRequest(t, shard, 3, true)
@@ -167,7 +167,7 @@ func TestShardController(t *testing.T) {
 	assert.Equal(t, s2, *sc.Metadata().Leader())
 
 	// Simulate the failure of the leader
-	sc.NodeBecameUnavailable(s2)
+	sc.BecameUnavailable(s2)
 
 	rpc.FailNode(s2, errors.New("failed to connect"))
 	rpc.GetNode(s3).NewTermResponse(2, -1, nil)
@@ -565,7 +565,7 @@ func TestShardController_LeaderElectionShouldNotFailIfRemoveFails(t *testing.T) 
 	assert.NotNil(t, sc.Metadata().Leader())
 	assert.Equal(t, s1, *sc.Metadata().Leader())
 
-	// Now start the swap node, which will trigger a new election
+	// Now start the swap dataServer, which will trigger a new election
 	wg := concurrent.NewWaitGroup(1)
 	wg.Go(func() error {
 		action := action.NewChangeEnsembleAction(shard, s1, s4)
@@ -605,7 +605,7 @@ func TestShardController_LeaderElectionShouldNotFailIfRemoveFails(t *testing.T) 
 	assert.NotNil(t, sc.Metadata().Leader())
 	assert.Equal(t, s2, *sc.Metadata().Leader())
 
-	// The swap node should be free to complete as well
+	// The swap dataServer should be free to complete as well
 	assert.NoError(t, wg.Wait(context.Background()))
 
 	// Eventually, the shard should get deleted

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -395,7 +395,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 
 	// Trigger new leader election in order to have a new term
 	ns1Status = statusResource.Load().Namespaces["my-ns-1"]
-	coordinatorInstance.NodeBecameUnavailable(*ns1Status.Shards[0].Leader)
+	coordinatorInstance.BecameUnavailable(*ns1Status.Shards[0].Leader)
 
 	// Wait (again) for all shards to be ready
 	assert.Eventually(t, func() bool {


### PR DESCRIPTION
### Motivation

This is the follow-up for #806.  rename `nodeController` to `dataserverController`