### PR TITLE
Set the global Otel meter provider

### DIFF
--- a/common/metric/counter.go
+++ b/common/metric/counter.go
@@ -40,7 +40,7 @@ func (c *counter) Add(incr int) {
 }
 
 func NewCounter(name string, description string, unit Unit, labels map[string]any) Counter {
-	sc, err := meter.Int64Counter(name,
+	sc, err := GetMeter().Int64Counter(name,
 		metric.WithUnit(string(unit)),
 		metric.WithDescription(description))
 	fatalOnErr(err, name)
@@ -80,7 +80,7 @@ func (c *upDownCounter) Sub(diff int) {
 }
 
 func NewUpDownCounter(name string, description string, unit Unit, labels map[string]any) UpDownCounter {
-	sc, err := meter.Int64UpDownCounter(name,
+	sc, err := GetMeter().Int64UpDownCounter(name,
 		metric.WithUnit(string(unit)),
 		metric.WithDescription(description))
 	fatalOnErr(err, name)

--- a/common/metric/gauge.go
+++ b/common/metric/gauge.go
@@ -44,7 +44,7 @@ func (g *gauge) Unregister() {
 }
 
 func NewGauge(name string, description string, unit Unit, labels map[string]any, callback func() int64) Gauge {
-	g, err := meter.Int64ObservableGauge(name,
+	g, err := GetMeter().Int64ObservableGauge(name,
 		metric.WithUnit(string(unit)),
 		metric.WithDescription(description),
 	)

--- a/common/metric/histogram.go
+++ b/common/metric/histogram.go
@@ -52,7 +52,7 @@ func NewBytesHistogram(name string, description string, labels map[string]any) H
 }
 
 func newHistogram(name string, unit Unit, description string, labels map[string]any) Histogram {
-	h, err := meter.Int64Histogram(
+	h, err := GetMeter().Int64Histogram(
 		name,
 		metric.WithUnit(string(unit)),
 		metric.WithDescription(description),

--- a/common/metric/latency_histogram.go
+++ b/common/metric/latency_histogram.go
@@ -52,7 +52,7 @@ func (t *latencyHistogram) Timer() Timer {
 }
 
 func NewLatencyHistogram(name string, description string, labels map[string]any) LatencyHistogram {
-	h, err := meter.Float64Histogram(
+	h, err := GetMeter().Float64Histogram(
 		name,
 		metric.WithUnit(string(Milliseconds)),
 		metric.WithDescription(description),

--- a/common/metric/meters.go
+++ b/common/metric/meters.go
@@ -18,12 +18,26 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
-var meter metric.Meter
+var (
+	meter metric.Meter
+	once  sync.Once
+)
+
+func GetMeter() metric.Meter {
+	once.Do(func() {
+		meter = otel.GetMeterProvider().Meter(
+			"oxia",
+		)
+	})
+	return meter
+}
 
 func LabelsForShard(namespace string, shard int64) map[string]any {
 	return map[string]any{

--- a/common/metric/metrics.go
+++ b/common/metric/metrics.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
 
@@ -82,7 +83,9 @@ func init() {
 
 	provider := metric.NewMeterProvider(metric.WithReader(exporter),
 		metric.WithView(latencyHistogramView, sizeHistogramView, countHistogramView, defaultView))
-	meter = provider.Meter("oxia")
+
+	// Set as the default provider
+	otel.SetMeterProvider(provider)
 }
 
 type PrometheusMetrics struct {


### PR DESCRIPTION
Instead of just exposing the `meter` object, set the global OTel provider, so that it works when using NoOp provider as well.