### PR TITLE
fixes: configurable WAL sync

### DIFF
--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -75,7 +75,7 @@ func NewWithGrpcProvider(options *option.Options, provider rpc2.GrpcProvider, re
 			BaseWalDir:  storage.WAL.Dir,
 			Retention:   storage.WAL.Retention,
 			SegmentSize: wal.DefaultFactoryOptions.SegmentSize,
-			SyncData:    true,
+			SyncData:    storage.WAL.IsSyncEnabled(),
 		}),
 		kvFactory:    kvFactory,
 		healthServer: rpc2.NewClosableHealthServer(context.Background()),


### PR DESCRIPTION
### Motivation

#367 introduced the option to disable WAL, but it didn't take effect for the dataserver.