### PR TITLE
feat: make the assignment information become debug level

### DIFF
--- a/oxiad/dataserver/assignment/assignment_dispatcher.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher.go
@@ -226,11 +226,11 @@ func (s *shardAssignmentDispatcher) updateShardAssignment(assignments *proto.Sha
 	defer s.Unlock()
 
 	if s.log.Enabled(s.ctx, slog.LevelDebug) {
-		s.log.Debug("Update shares assignments.",
+		s.log.Debug("Update shard assignments.",
 			slog.Any("previous", s.assignments),
 			slog.Any("current", assignments))
 	} else {
-		s.log.Info("Update shares assignments.")
+		s.log.Info("Update shard assignments.")
 	}
 
 	s.assignments = assignments


### PR DESCRIPTION
### Motivation

Making the assignment information become a debug level to avoid tons of logs. 

### Modification

- Change the log info level to debug level. 