### PR TITLE
Allow to override version id and modification count

### DIFF
--- a/common/proto/client.pb.go
+++ b/common/proto/client.pb.go
@@ -884,8 +884,12 @@ type PutRequest struct {
 	// based on adding the delta to the current highest key with the same prefix
 	SequenceKeyDelta []uint64          `protobuf:"varint,7,rep,packed,name=sequence_key_delta,json=sequenceKeyDelta,proto3" json:"sequence_key_delta,omitempty"`
 	SecondaryIndexes []*SecondaryIndex `protobuf:"bytes,8,rep,name=secondary_indexes,json=secondaryIndexes,proto3" json:"secondary_indexes,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Optional overrides for version metadata, used during data migration.
+	// When set, the server will use these values instead of auto-generating them.
+	OverrideVersionId          *int64 `protobuf:"varint,9,opt,name=override_version_id,json=overrideVersionId,proto3,oneof" json:"override_version_id,omitempty"`
+	OverrideModificationsCount *int64 `protobuf:"varint,10,opt,name=override_modifications_count,json=overrideModificationsCount,proto3,oneof" json:"override_modifications_count,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *PutRequest) Reset() {
@@ -972,6 +976,20 @@ func (x *PutRequest) GetSecondaryIndexes() []*SecondaryIndex {
 		return x.SecondaryIndexes
 	}
 	return nil
+}
+
+func (x *PutRequest) GetOverrideVersionId() int64 {
+	if x != nil && x.OverrideVersionId != nil {
+		return *x.OverrideVersionId
+	}
+	return 0
+}
+
+func (x *PutRequest) GetOverrideModificationsCount() int64 {
+	if x != nil && x.OverrideModificationsCount != nil {
+		return *x.OverrideModificationsCount
+	}
+	return 0
 }
 
 // *
@@ -2354,7 +2372,7 @@ const file_client_proto_rawDesc = "" +
 	"\x0eSecondaryIndex\x12\x1d\n" +
 	"\n" +
 	"index_name\x18\x01 \x01(\tR\tindexName\x12#\n" +
-	"\rsecondary_key\x18\x02 \x01(\tR\fsecondaryKey\"\xaf\x03\n" +
+	"\rsecondary_key\x18\x02 \x01(\tR\fsecondaryKey\"\xe4\x04\n" +
 	"\n" +
 	"PutRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
@@ -2365,11 +2383,16 @@ const file_client_proto_rawDesc = "" +
 	"\x0fclient_identity\x18\x05 \x01(\tH\x02R\x0eclientIdentity\x88\x01\x01\x12(\n" +
 	"\rpartition_key\x18\x06 \x01(\tH\x03R\fpartitionKey\x88\x01\x01\x12,\n" +
 	"\x12sequence_key_delta\x18\a \x03(\x04R\x10sequenceKeyDelta\x12M\n" +
-	"\x11secondary_indexes\x18\b \x03(\v2 .io.oxia.proto.v1.SecondaryIndexR\x10secondaryIndexesB\x16\n" +
+	"\x11secondary_indexes\x18\b \x03(\v2 .io.oxia.proto.v1.SecondaryIndexR\x10secondaryIndexes\x123\n" +
+	"\x13override_version_id\x18\t \x01(\x03H\x04R\x11overrideVersionId\x88\x01\x01\x12E\n" +
+	"\x1coverride_modifications_count\x18\n" +
+	" \x01(\x03H\x05R\x1aoverrideModificationsCount\x88\x01\x01B\x16\n" +
 	"\x14_expected_version_idB\r\n" +
 	"\v_session_idB\x12\n" +
 	"\x10_client_identityB\x10\n" +
-	"\x0e_partition_key\"\x93\x01\n" +
+	"\x0e_partition_keyB\x16\n" +
+	"\x14_override_version_idB\x1f\n" +
+	"\x1d_override_modifications_count\"\x93\x01\n" +
 	"\vPutResponse\x120\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x18.io.oxia.proto.v1.StatusR\x06status\x123\n" +
 	"\aversion\x18\x02 \x01(\v2\x19.io.oxia.proto.v1.VersionR\aversion\x12\x15\n" +

--- a/common/proto/client.proto
+++ b/common/proto/client.proto
@@ -264,6 +264,11 @@ message PutRequest {
   repeated uint64 sequence_key_delta = 7;
 
   repeated SecondaryIndex secondary_indexes = 8;
+
+  // Optional overrides for version metadata, used during data migration.
+  // When set, the server will use these values instead of auto-generating them.
+  optional int64 override_version_id = 9;
+  optional int64 override_modifications_count = 10;
 }
 
 /**

--- a/common/proto/client_vtproto.pb.go
+++ b/common/proto/client_vtproto.pb.go
@@ -320,6 +320,14 @@ func (m *PutRequest) CloneVT() *PutRequest {
 		}
 		r.SecondaryIndexes = tmpContainer
 	}
+	if rhs := m.OverrideVersionId; rhs != nil {
+		tmpVal := *rhs
+		r.OverrideVersionId = &tmpVal
+	}
+	if rhs := m.OverrideModificationsCount; rhs != nil {
+		tmpVal := *rhs
+		r.OverrideModificationsCount = &tmpVal
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1266,6 +1274,12 @@ func (this *PutRequest) EqualVT(that *PutRequest) bool {
 				return false
 			}
 		}
+	}
+	if p, q := this.OverrideVersionId, that.OverrideVersionId; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
+	}
+	if p, q := this.OverrideModificationsCount, that.OverrideModificationsCount; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -2427,6 +2441,16 @@ func (m *PutRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.OverrideModificationsCount != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OverrideModificationsCount))
+		i--
+		dAtA[i] = 0x50
+	}
+	if m.OverrideVersionId != nil {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(*m.OverrideVersionId))
+		i--
+		dAtA[i] = 0x48
 	}
 	if len(m.SecondaryIndexes) > 0 {
 		for iNdEx := len(m.SecondaryIndexes) - 1; iNdEx >= 0; iNdEx-- {
@@ -3892,6 +3916,12 @@ func (m *PutRequest) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	if m.OverrideVersionId != nil {
+		n += 1 + protohelpers.SizeOfVarint(uint64(*m.OverrideVersionId))
+	}
+	if m.OverrideModificationsCount != nil {
+		n += 1 + protohelpers.SizeOfVarint(uint64(*m.OverrideModificationsCount))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5856,6 +5886,46 @@ func (m *PutRequest) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OverrideVersionId", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.OverrideVersionId = &v
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OverrideModificationsCount", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.OverrideModificationsCount = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -10091,6 +10161,46 @@ func (m *PutRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OverrideVersionId", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.OverrideVersionId = &v
+		case 10:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field OverrideModificationsCount", wireType)
+			}
+			var v int64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.OverrideModificationsCount = &v
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -565,7 +565,11 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 				Status: status,
 			}, nil
 		}
-		versionId = baseVersionId.Add(1)
+		if putReq.OverrideVersionId != nil {
+			versionId = *putReq.OverrideVersionId
+		} else {
+			versionId = baseVersionId.Add(1)
+		}
 	}
 
 	if se == nil {
@@ -586,6 +590,10 @@ func (d *db) applyPut(batch kvstore.WriteBatch, baseVersionId *atomic.Int64, not
 		se.SessionId = putReq.SessionId
 		se.ClientIdentity = putReq.ClientIdentity
 		se.PartitionKey = putReq.PartitionKey
+	}
+
+	if putReq.OverrideModificationsCount != nil {
+		se.ModificationsCount = *putReq.OverrideModificationsCount
 	}
 
 	se.SecondaryIndexes = putReq.SecondaryIndexes


### PR DESCRIPTION
During migrations to Oxia, it would be useful to preserve the original version id and modification counts of records.

This will only be exposed in Java client API.