### PR TITLE
fix: use deterministic protobuf marshaling for notification checksum

### DIFF
--- a/oxiad/dataserver/database/db.go
+++ b/oxiad/dataserver/database/db.go
@@ -315,7 +315,9 @@ func (d *db) ProcessWrite(b *proto.WriteRequest, commitOffset int64, timestamp u
 }
 
 func (*db) addNotifications(batch kvstore.WriteBatch, notifications *Notifications) error {
-	value, err := notifications.batch.MarshalVT()
+	// Use deterministic marshaling to ensure consistent serialization order
+	// for the Notifications map, which is critical for checksum reproducibility.
+	value, err := pb.MarshalOptions{Deterministic: true}.Marshal(&notifications.batch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Motivation

`TestDB_ChecksumDeterministic` is flaky because `NotificationBatch` contains a map field whose serialization order is non-deterministic in Go, causing identical write operations to produce different checksums across DB instances. This is also a correctness issue for cross-replica checksum verification.

Flaky test:
```
--- FAIL: TestDB_ChecksumDeterministic (0.02s)
    db_test.go:1269: 
            Error Trace:    /home/runner/work/oxia/oxia/oxiad/dataserver/database/db_test.go:1269
            Error:          Not equal: 
                            expected: 0x22a01d33
                            actual  : 0x12dff30b
            Test:           TestDB_ChecksumDeterministic
            Messages:       same operations should produce same checksum
```

### Modification

- Switch `addNotifications` from `MarshalVT()` to `proto.MarshalOptions{Deterministic: true}.Marshal()` which sorts map keys before serialization, ensuring checksum reproducibility.