### PR TITLE
fix: add read lock to WAL segment Flush to prevent data race with Close

### DIFF
--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -168,6 +168,11 @@ func (ms *readWriteSegment) Append(offset int64, data []byte) error {
 }
 
 func (ms *readWriteSegment) Flush() error {
+	ms.RLock()
+	defer ms.RUnlock()
+	if ms.txnMappedFile == nil {
+		return nil
+	}
 	return ms.txnMappedFile.Flush()
 }
 


### PR DESCRIPTION
### Motivation

`TestCoordinatorE2E` is flaky due to a data race between the WAL `runSync` goroutine calling `segment.Flush()` (which reads the mmap) and `wal.Close()` calling `segment.Close()` → `MMap.Unmap()` (which writes/invalidates the mmap). The race was latent in the WAL code and surfaced after the follower controller lifecycle refactor in #887 changed shutdown timing.

CI failure: https://github.com/oxia-db/oxia/actions/runs/22312993235/job/64549930899

### Modification

- Add `RLock`/`RUnlock` to `readWriteSegment.Flush()` to synchronize against the write lock already held by `Close()`. This ensures either `Flush()` completes before `Unmap()` begins, or `Unmap()` completes first and `Flush()` sees `txnMappedFile == nil` and returns safely.