### PR TITLE
fix: retry first Put in TestLeaderHintWithClient for shard assignment propagation

### DIFF
--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -128,8 +128,10 @@ func TestLeaderHintWithClient(t *testing.T) {
 	assert.NoError(t, err)
 	defer client.Close()
 
-	_, _, err = client.Put(t.Context(), "/key1", []byte("value"))
-	assert.NoError(t, err)
+	assert.Eventually(t, func() bool {
+		_, _, err = client.Put(t.Context(), "/key1", []byte("value"))
+		return err == nil
+	}, 5*time.Second, 100*time.Millisecond)
 
 	_, _, err = client.Put(t.Context(), "/key2", []byte("value"))
 	assert.NoError(t, err)


### PR DESCRIPTION
## Summary
- Fixes flaky `TestLeaderHintWithClient` test that intermittently fails with `EOF` on the first `Put` call
- The test connects a client to a non-leader server with `DizzyShardManager` failure injection; the non-leader may not have received shard assignments yet when the first `Put` is issued
- Wraps the first `Put` in `assert.Eventually` (5s timeout, 100ms poll) to allow time for shard assignment propagation before asserting success

## Test plan
- [ ] Verify `TestLeaderHintWithClient` passes consistently (no more EOF flakes)
- [ ] Verify `TestLeaderHintWithoutClient` is unaffected
- [ ] Run `go test ./tests/assignments/ -count=50 -run TestLeaderHintWithClient` to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)