### PR TITLE
fix: reduce quarantine time and increase timeout in TestLeaderBalancedNodeAdded

### DIFF
--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -232,7 +232,7 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 		},
 		Servers: []model.Server{s1ad, s2ad, s3ad},
 		LoadBalancer: &model.LoadBalancer{
-			QuarantineTime: 5 * time.Second,
+			QuarantineTime: 1 * time.Second,
 		},
 	}
 
@@ -291,5 +291,5 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 			}
 		}
 		return true
-	}, 1*time.Minute, 1*time.Second)
+	}, 2*time.Minute, 1*time.Second)
 }


### PR DESCRIPTION
## Summary
- Reduce `QuarantineTime` from 5s to 1s to match the sibling test `TestLeaderBalancedNodeCrashAndBack`, allowing faster retry after failed elections or shard swaps
- Increase the final `assert.Eventually` timeout from 1 minute to 2 minutes to give adequate margin for the complex 3→6 node rebalancing scenario (ensemble rebalancing must complete before leader rebalancing, and each cycle only processes one shard)

## Test plan
- [ ] CI passes with the updated test
- [ ] Verify `TestLeaderBalancedNodeAdded` no longer times out


🤖 Generated with [Claude Code](https://claude.com/claude-code)