### PR TITLE
fix: continue trying other shards when quarantining in leader rebalance

### DIFF
--- a/oxiad/coordinator/balancer/scheduler.go
+++ b/oxiad/coordinator/balancer/scheduler.go
@@ -429,7 +429,7 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 		if minCandidateLeaders == maxLeaders || minCandidateLeaders+1 == maxLeaders {
 			r.Info("quarantine the shard due to no valid candidates", slog.Int64("shard", shard), slog.Any("leader", maxLeadersNodeID))
 			r.shardQuarantineShardMap.Store(shard, time.Now())
-			break
+			continue
 		}
 
 		latch := &sync.WaitGroup{}


### PR DESCRIPTION
## Summary
- In `rebalanceLeader()`, when a shard has no valid candidate for leader transfer (all ensemble members have similar leader counts), the shard is quarantined. Previously, this also `break`ed out of the entire loop, preventing other shards on the same max-leaders node from being tried.
- Changed `break` to `continue` so the function tries the next shard instead of giving up entirely.

**Root cause of flaky `TestLeaderBalancedNodeAdded`**: After expanding from 3→6 nodes, shards have different ensemble compositions. Some shards' ensembles may consist entirely of high-leader-count nodes (no valid transfer target), while other shards on the same node have ensemble members with fewer leaders. The `break` caused the balancer to give up after the first unmovable shard, never attempting the movable ones.

## Test plan
- [x] `go test -race -count=3 ./tests/balancer/...` — all pass (173s)
- [x] `go test -race -count=3 -run TestLeaderBalancedNodeAdded ./tests/balancer/...` — all pass
- [x] `go test -race -count=3 -run TestLeaderBalanced$ ./tests/balancer/...` — all pass
- [x] `go test -race ./oxiad/coordinator/balancer/...` — unit tests pass
