### PR TITLE
fix: prevent panic when reading empty WAL index file (#737)

### DIFF
--- a/oxiad/dataserver/wal/codec/v2.go
+++ b/oxiad/dataserver/wal/codec/v2.go
@@ -183,6 +183,9 @@ func (v *V2) ReadIndex(path string) ([]byte, error) {
 	if err = idFile.Close(); err != nil {
 		return nil, errors.Wrapf(err, "failed to close segment index file %s", path)
 	}
+	if len(indexBuf) < int(v.GetIndexHeaderSize()) {
+		return nil, errors.Wrapf(ErrDataCorrupted, "index file %s is too short: %d bytes", path, len(indexBuf))
+	}
 	expectedCrc := ReadInt(indexBuf, 0)
 	actualCrc := Checksum(0).Update(indexBuf[v.GetIndexHeaderSize():]).Value()
 	if expectedCrc != actualCrc {

--- a/oxiad/dataserver/wal/codec/v2_test.go
+++ b/oxiad/dataserver/wal/codec/v2_test.go
@@ -308,6 +308,32 @@ func TestV2_IndexBroken(t *testing.T) {
 	assert.ErrorIs(t, err, ErrDataCorrupted)
 }
 
+func TestV2_ReadEmptyIndex(t *testing.T) {
+	dir := os.TempDir()
+	fileName := "empty-index"
+	p := path.Join(dir, fileName+v2.GetIdxExtension())
+
+	// Create empty file
+	err := os.WriteFile(p, []byte{}, 0644)
+	assert.NoError(t, err)
+
+	_, err = v2.ReadIndex(p)
+	assert.ErrorIs(t, err, ErrDataCorrupted)
+}
+
+func TestV2_ReadShortIndex(t *testing.T) {
+	dir := os.TempDir()
+	fileName := "short-index"
+	p := path.Join(dir, fileName+v2.GetIdxExtension())
+
+	// Create file with only 2 bytes (less than header size of 4)
+	err := os.WriteFile(p, []byte{0x00, 0x01}, 0644)
+	assert.NoError(t, err)
+
+	_, err = v2.ReadIndex(p)
+	assert.ErrorIs(t, err, ErrDataCorrupted)
+}
+
 func TestV2_ReadWithValidation(t *testing.T) {
 	buf := make([]byte, 15)
 	payloadSize := uint32(len(buf)) - v2.HeaderSize


### PR DESCRIPTION
## Problem

When the .idxx index file is empty (0 bytes), `ReadIndex()` would panic with `slice bounds out of range [4:0]` when trying to read the CRC at offset 0.

Stack trace from #737:
```
github.com/streamnative/oxia/server/wal/codec.(*V2).ReadIndex
    /src/oxia/server/wal/codec/v2.go:189 +0x47d
```

## Solution

Added a length check before reading the index. If the file is shorter than the header size (4 bytes), it returns `ErrDataCorrupted` instead of panicking, allowing the caller (`readonly_segment.go`) to rebuild the index from the txn file.

## Changes

- `oxiad/dataserver/wal/codec/v2.go`: Added length check in `ReadIndex()`
- `oxiad/dataserver/wal/codec/v2_test.go`: Added tests for empty and short index files

## Test Plan

```bash
go test -v ./oxiad/dataserver/wal/codec/... -run "TestV2_ReadEmptyIndex|TestV2_ReadShortIndex"
```

Both tests pass:
- `TestV2_ReadEmptyIndex`: verifies empty file (0 bytes) returns `ErrDataCorrupted`
- `TestV2_ReadShortIndex`: verifies short file (<4 bytes) returns `ErrDataCorrupted`

Fixes #737