### PR TITLE
fix: improve leader rebalance candidate selection to prevent stuck states

### DIFF
--- a/oxiad/coordinator/balancer/scheduler.go
+++ b/oxiad/coordinator/balancer/scheduler.go
@@ -449,8 +449,7 @@ func (r *nodeBasedBalancer) rebalanceLeader() {
 			r.Info("quarantine the shard due to no leader changed", slog.Int64("shard", shard), slog.Any("old-leader", maxLeadersNodeID), slog.Any("new-leader", leader))
 			continue
 		}
-		maxLeaders--
-		continue
+		break
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Exclude current leader from candidate evaluation**: The candidate check included the current leader node in `minCandidateLeaders`, making it think no better candidate existed when ensemble members had similar leader counts.
- **Relax quarantine threshold**: The old check `minCandidateLeaders+1 == maxLeaders` was too conservative, quarantining shards even when a candidate had fewer leaders. Now only quarantines when no candidate has strictly fewer leaders than the current max.
- **Continue on election failure, break on success**: On failure (same leader re-elected), continue trying other shards. On success, break to re-evaluate with fresh state in the next pass, preventing over-correction from stale `nodeLeaders` data.

## Test plan
- [x] `TestLeaderBalancedNodeAdded` passed 20/20 runs with `-race` (previously failed ~80% on `main`)
- [x] Full balancer test suite passed 19/20 runs (1 failure was pre-existing flaky `TestPolicyBasedShardBalancer`)
- [x] All other integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)