### PR TITLE
fix: dynamic log level changes now affect existing loggers

### DIFF
--- a/oxiad/common/logging/logger.go
+++ b/oxiad/common/logging/logger.go
@@ -39,6 +39,11 @@ var (
 	LogLevel slog.Level
 	// LogJSON Used for flags.
 	LogJSON bool
+
+	// logLevelVar is the shared atomic level variable passed to all handlers.
+	// This allows dynamic log level changes to take effect on all existing
+	// loggers, including those created via slog.With().
+	logLevelVar slog.LevelVar
 )
 
 // ParseLogLevel will convert the slog level configuration to slog.Level values.
@@ -59,19 +64,17 @@ func ParseLogLevel(levelStr string) (slog.Level, error) {
 
 func ReconfigureLogger(logOption *option.LogOptions) bool {
 	expectLevel, _ := ParseLogLevel(logOption.Level)
-	needReconfigure := false
-	if expectLevel != LogLevel {
-		needReconfigure = true
-		LogLevel = expectLevel
+	if expectLevel == LogLevel {
+		return false
 	}
-	if needReconfigure {
-		ConfigureLogger()
-		return true
-	}
-	return false
+	LogLevel = expectLevel
+	logLevelVar.Set(expectLevel)
+	return true
 }
 
 func ConfigureLogger() {
+	logLevelVar.Set(LogLevel)
+
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 	//nolint
 	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
@@ -111,7 +114,7 @@ func ConfigureLogger() {
 
 	slogLogger := slog.New(
 		slogzerolog.Option{
-			Level:  LogLevel,
+			Level:  &logLevelVar,
 			Logger: &zerologLogger,
 		}.NewZerologHandler(),
 	)

--- a/oxiad/common/logging/logger_test.go
+++ b/oxiad/common/logging/logger_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/oxiad/common/option"
+)
+
+func TestReconfigureLogger_DynamicLevelChange(t *testing.T) {
+	// Start with INFO level
+	LogLevel = slog.LevelInfo
+	LogJSON = true
+	ConfigureLogger()
+
+	// Create a derived logger before the level change, simulating
+	// component loggers created at startup via slog.With().
+	derivedLogger := slog.Default().With("component", "test")
+
+	// The derived logger should not enable DEBUG at INFO level
+	assert.False(t, derivedLogger.Enabled(context.Background(), slog.LevelDebug))
+	assert.True(t, derivedLogger.Enabled(context.Background(), slog.LevelInfo))
+
+	// Reconfigure to DEBUG level
+	changed := ReconfigureLogger(&option.LogOptions{Level: "debug"})
+	assert.True(t, changed)
+
+	// The derived logger (created before reconfigure) should now enable DEBUG
+	assert.True(t, derivedLogger.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestReconfigureLogger_NoChangeReturnsFalse(t *testing.T) {
+	LogLevel = slog.LevelInfo
+	LogJSON = true
+	ConfigureLogger()
+
+	changed := ReconfigureLogger(&option.LogOptions{Level: "info"})
+	assert.False(t, changed)
+}


### PR DESCRIPTION
## Summary

- Use a shared `slog.LevelVar` (atomic) instead of a concrete `slog.Level` when configuring the slog-zerolog handler, so all loggers (including derived ones from `slog.With()`) dynamically pick up level changes
- Simplify `ReconfigureLogger()` to atomically update the shared level variable instead of recreating the entire handler
- Add tests verifying derived loggers reflect dynamic level changes

## Test plan

- [x] `go test ./oxiad/common/logging/...` — new tests pass
- [x] `go test ./oxiad/dataserver/...` — all pass
- [x] `go test ./oxiad/coordinator/...` — all pass
- [x] `go test ./cmd/server/...` — passes
- [ ] Verify in a running instance that changing log level via config reload affects all component loggers
