### PR TITLE
fix: stabilize flaky TestLeaderHint tests

### DIFF
--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -53,10 +53,9 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		status := coordinatorInstance.StatusResource().Load()
-		shard := status.Namespaces["default"].Shards[0]
-		return shard.Leader != nil
-	}, time.Second, time.Millisecond*100)
+		shard := coordinatorInstance.StatusResource().Load().Namespaces["default"].Shards[0]
+		return shard.Status == model.ShardStatusSteadyState && shard.Leader != nil
+	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
 	status := coordinatorInstance.StatusResource().Load()
@@ -112,10 +111,9 @@ func TestLeaderHintWithClient(t *testing.T) {
 	defer coordinatorInstance.Close()
 
 	assert.Eventually(t, func() bool {
-		status := coordinatorInstance.StatusResource().Load()
-		shard := status.Namespaces["default"].Shards[0]
-		return shard.Leader != nil
-	}, time.Second, time.Millisecond*100)
+		shard := coordinatorInstance.StatusResource().Load().Namespaces["default"].Shards[0]
+		return shard.Status == model.ShardStatusSteadyState && shard.Leader != nil
+	}, 10*time.Second, 100*time.Millisecond)
 
 	target := sa1.Public
 	status := coordinatorInstance.StatusResource().Load()


### PR DESCRIPTION
## Summary

- Fix flaky `TestLeaderHintWithClient` and `TestLeaderHintWithoutClient` that intermittently fail with EOF / "node is not leader" errors
- Both tests only waited for `shard.Leader != nil` (with a 1s timeout), which is insufficient — the cluster may still be in election state with followers not yet having received shard assignments via the dispatcher
- Wait for `ShardStatusSteadyState` (with a 10s timeout) before performing operations, matching the established pattern used across all other integration tests

## Test plan

- [x] `go vet ./tests/assignments/...` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)