### PR TITLE
fix: eliminate data race in maelstrom message parsing

### DIFF
--- a/oxiad/maelstrom/messages.go
+++ b/oxiad/maelstrom/messages.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"reflect"
 
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
@@ -250,10 +251,11 @@ func parseRequest(line string) (msgType MsgType, msg any, protoMsg pb.Message) {
 
 	msg = frame
 	msgType = frame.Body.Type
-	sm, ok := jsonMsgMapping[frame.Body.Type]
+	prototype, ok := jsonMsgMapping[frame.Body.Type]
 	if ok {
-		// Deserialize json again with specific type
-		// Deserialize again with the proper struct
+		// Create a fresh instance to avoid data races with goroutines
+		// that may still be reading a previously parsed message.
+		sm := reflect.New(reflect.TypeOf(prototype).Elem()).Interface()
 		if err := json.Unmarshal([]byte(line), sm); err != nil {
 			slog.Error(
 				"failed to unmarshal the proper struct",
@@ -265,8 +267,9 @@ func parseRequest(line string) (msgType MsgType, msg any, protoMsg pb.Message) {
 		msg = sm
 	}
 
-	protoMsg, ok = protoMsgMapping[frame.Body.Type]
+	protoPrototype, ok := protoMsgMapping[frame.Body.Type]
 	if ok {
+		protoMsg = reflect.New(reflect.TypeOf(protoPrototype).Elem()).Interface().(pb.Message)
 		if msgType.isOxiaStreamRequest() {
 			om := &Message[OxiaStreamMessage]{}
 			if err := json.Unmarshal([]byte(line), om); err != nil {


### PR DESCRIPTION
## Summary

- `parseRequest()` deserialized messages into singleton struct pointers stored in `jsonMsgMapping`/`protoMsgMapping`
- Since message handlers run as goroutines (`dispatcher.go:136`), the next incoming message would overwrite the singleton while the previous goroutine was still reading from it
- This caused the Maelstrom lin-kv linearizability test to fail: a CAS(from=1, to=0) succeeded because its goroutine read `From=1` from a singleton that had been overwritten by a later message, when the actual register value was 3
- Use `reflect.New()` to create a fresh instance from each prototype on every parse, so each goroutine gets its own isolated copy

## Test plan

- [ ] Maelstrom lin-kv test passes in CI