### PR TITLE
fix: delete idx file before txn to prevent dangling idx on crash

### DIFF
--- a/oxiad/dataserver/wal/readonly_segment.go
+++ b/oxiad/dataserver/wal/readonly_segment.go
@@ -155,8 +155,8 @@ func (ms *readOnlySegment) Close() error {
 func (ms *readOnlySegment) Delete() error {
 	return multierr.Combine(
 		ms.Close(),
-		os.Remove(ms.c.txnPath),
 		os.Remove(ms.c.idxPath),
+		os.Remove(ms.c.txnPath),
 	)
 }
 

--- a/oxiad/dataserver/wal/readwrite_segment.go
+++ b/oxiad/dataserver/wal/readwrite_segment.go
@@ -200,8 +200,8 @@ func (ms *readWriteSegment) Close() error {
 func (ms *readWriteSegment) Delete() error {
 	return multierr.Combine(
 		ms.Close(),
-		os.Remove(ms.c.txnPath),
 		os.Remove(ms.c.idxPath),
+		os.Remove(ms.c.txnPath),
 	)
 }
 


### PR DESCRIPTION
## Summary
- Swap deletion order in `readOnlySegment.Delete()` and `readWriteSegment.Delete()` to remove the `.idx` file before the `.txn` file
- `listAllSegments()` discovers segments by scanning for `.txn` files, so `.txn` must be the last file deleted — if a crash occurs after `.idx` is removed but before `.txn`, the segment will be rediscovered on restart and cleaned up on the next trim pass
- The previous order (`.txn` first, `.idx` second) could leave a permanently dangling `.idx` file that would never be cleaned up

Closes #618

## Test plan
- [x] Existing WAL tests pass
- [ ] Verify no dangling idx files after crash during segment trimming