### PR TITLE
feat: add fatal error propagation from StatusResource to Coordinator

### DIFF
--- a/oxiad/coordinator/balancer/scheduler_test.go
+++ b/oxiad/coordinator/balancer/scheduler_test.go
@@ -59,6 +59,10 @@ func (m *mockStatusResource) IsReady(_ *model.ClusterConfig) bool {
 	return true
 }
 
+func (m *mockStatusResource) FatalErr() <-chan error {
+	return make(chan error)
+}
+
 // mockClusterConfigResource implements resource.ClusterConfigResource for testing.
 type mockClusterConfigResource struct {
 	nodes     *linkedhashset.Set[string]

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	pb "google.golang.org/protobuf/proto"
 
@@ -55,6 +54,9 @@ type Coordinator interface {
 
 	StatusResource() resource.StatusResource
 	ConfigResource() resource.ClusterConfigResource
+
+	Done() <-chan struct{}
+	Err() error
 }
 
 var _ Coordinator = &coordinator{}
@@ -89,6 +91,28 @@ type coordinator struct {
 	assignments        *proto.ShardAssignments
 
 	rpc rpc.Provider
+
+	done    chan struct{}
+	fatal   error
+	fatalMu sync.Mutex
+}
+
+func (c *coordinator) Done() <-chan struct{} {
+	return c.done
+}
+
+func (c *coordinator) Err() error {
+	c.fatalMu.Lock()
+	defer c.fatalMu.Unlock()
+	return c.fatal
+}
+
+func (c *coordinator) setFatal(err error) {
+	c.fatalMu.Lock()
+	c.fatal = err
+	c.fatalMu.Unlock()
+	close(c.done)
+	c.cancel()
 }
 
 func (c *coordinator) LeaderElected(int64, model.Server, []model.Server) {
@@ -330,7 +354,7 @@ func (c *coordinator) WaitForNextUpdate(ctx context.Context, currentValue *proto
 }
 
 func (c *coordinator) startBackgroundActionWorker() {
-	defer c.Done()
+	defer c.WaitGroup.Done()
 	for {
 		select {
 		case ac := <-c.loadBalancer.Action():
@@ -443,15 +467,9 @@ func NewCoordinator(ctx context.Context, meta metadata.Provider,
 		nodeControllers:       make(map[string]controller.DataServerController),
 		drainingNodes:         make(map[string]controller.DataServerController),
 		rpc:                   rpcProvider,
+		done:                  make(chan struct{}),
 	}
 	c.ccrWg.Add(1)
-
-	// Ensure we are to become the leader coordinator
-	c.Info("Waiting to become leader")
-	if err := meta.WaitToBecomeLeader(ctx); err != nil {
-		return nil, errors.Wrap(err, "failed to wait in becoming leader")
-	}
-	c.Info("This coordinator is now leader")
 
 	c.ctx, c.cancel = context.WithCancel(ctx)
 	c.assignmentsChanged = concurrent.NewConditionContext(c)
@@ -491,6 +509,12 @@ func NewCoordinator(ctx context.Context, meta metadata.Provider,
 		clusterStatus, _, _ = util.ApplyClusterChanges(clusterConfig, model.NewClusterStatus(), c.selectNewEnsemble)
 
 		c.statusResource.Update(clusterStatus)
+
+		select {
+		case <-c.done:
+			return nil, c.Err()
+		default:
+		}
 	} else {
 		c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
 
@@ -501,6 +525,12 @@ func NewCoordinator(ctx context.Context, meta metadata.Provider,
 
 		if len(shardsToAdd) > 0 || len(shardsToDelete) > 0 {
 			c.statusResource.Update(clusterStatus)
+
+			select {
+			case <-c.done:
+				return nil, c.Err()
+			default:
+			}
 		}
 	}
 
@@ -518,6 +548,20 @@ func NewCoordinator(ctx context.Context, meta metadata.Provider,
 				c, c.rpc, controller.DefaultPeriodicTasksInterval)
 		}
 	}
+
+	// Watch for fatal errors from the status resource
+	c.Add(1)
+	go process.DoWithLabels(c.ctx, map[string]string{
+		"component": "coordinator-fatal-watcher",
+	}, func() {
+		defer c.WaitGroup.Done()
+		select {
+		case err := <-c.statusResource.FatalErr():
+			c.Error("Fatal error detected, shutting down coordinator", slog.Any("error", err))
+			c.setFatal(err)
+		case <-c.ctx.Done():
+		}
+	})
 
 	c.Add(1)
 	go process.DoWithLabels(c.ctx, map[string]string{

--- a/oxiad/coordinator/resource/status_resource.go
+++ b/oxiad/coordinator/resource/status_resource.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -39,6 +40,8 @@ type StatusResource interface {
 	DeleteShardMetadata(namespace string, shard int64)
 
 	IsReady(clusterConfig *model.ClusterConfig) bool
+
+	FatalErr() <-chan error
 }
 
 var _ StatusResource = &status{}
@@ -50,6 +53,19 @@ type status struct {
 	lock             sync.RWMutex
 	current          *model.ClusterStatus
 	currentVersionID metadata.Version
+
+	fatalErr  chan error
+	fatalOnce sync.Once
+}
+
+func (s *status) signalFatal(err error) {
+	s.fatalOnce.Do(func() {
+		s.fatalErr <- err
+	})
+}
+
+func (s *status) FatalErr() <-chan error {
+	return s.fatalErr
 }
 
 func (s *status) loadWithInitSlow() {
@@ -94,16 +110,29 @@ func (s *status) LoadWithVersion() (*model.ClusterStatus, metadata.Version) {
 	return s.current, s.currentVersionID
 }
 
+func (s *status) wrapBadVersion(err error) error {
+	if errors.Is(err, metadata.ErrMetadataBadVersion) {
+		return backoff.Permanent(err)
+	}
+	return err
+}
+
+func (s *status) checkFatal(err error) {
+	if err != nil && errors.Is(err, metadata.ErrMetadataBadVersion) {
+		s.signalFatal(err)
+	}
+}
+
 func (s *status) Swap(newStatus *model.ClusterStatus, version metadata.Version) bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	if s.currentVersionID != version {
 		return false
 	}
-	_ = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(newStatus, s.currentVersionID)
 		if err != nil {
-			return err
+			return s.wrapBadVersion(err)
 		}
 		s.current = newStatus
 		s.currentVersionID = versionID
@@ -115,16 +144,17 @@ func (s *status) Swap(newStatus *model.ClusterStatus, version metadata.Version) 
 			slog.Duration("retry-after", duration),
 		)
 	})
+	s.checkFatal(err)
 	return true
 }
 
 func (s *status) Update(newStatus *model.ClusterStatus) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	_ = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(newStatus, s.currentVersionID)
 		if err != nil {
-			return err
+			return s.wrapBadVersion(err)
 		}
 		s.current = newStatus
 		s.currentVersionID = versionID
@@ -136,6 +166,7 @@ func (s *status) Update(newStatus *model.ClusterStatus) {
 			slog.Duration("retry-after", duration),
 		)
 	})
+	s.checkFatal(err)
 }
 
 func (s *status) UpdateShardMetadata(namespace string, shard int64, shardMetadata model.ShardMetadata) {
@@ -148,10 +179,10 @@ func (s *status) UpdateShardMetadata(namespace string, shard int64, shardMetadat
 		return
 	}
 	ns.Shards[shard] = shardMetadata.Clone()
-	_ = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(clonedStatus, s.currentVersionID)
 		if err != nil {
-			return err
+			return s.wrapBadVersion(err)
 		}
 		s.current = clonedStatus
 		s.currentVersionID = versionID
@@ -163,6 +194,7 @@ func (s *status) UpdateShardMetadata(namespace string, shard int64, shardMetadat
 			slog.Duration("retry-after", duration),
 		)
 	})
+	s.checkFatal(err)
 }
 
 func (s *status) DeleteShardMetadata(namespace string, shard int64) {
@@ -178,10 +210,10 @@ func (s *status) DeleteShardMetadata(namespace string, shard int64) {
 	if len(ns.Shards) == 0 {
 		delete(clonedStatus.Namespaces, namespace)
 	}
-	_ = backoff.RetryNotify(func() error {
+	err := backoff.RetryNotify(func() error {
 		versionID, err := s.metadata.Store(clonedStatus, s.currentVersionID)
 		if err != nil {
-			return err
+			return s.wrapBadVersion(err)
 		}
 		s.current = clonedStatus
 		s.currentVersionID = versionID
@@ -193,6 +225,7 @@ func (s *status) DeleteShardMetadata(namespace string, shard int64) {
 			slog.Duration("retry-after", duration),
 		)
 	})
+	s.checkFatal(err)
 }
 
 func (s *status) IsReady(clusterConfig *model.ClusterConfig) bool {
@@ -222,6 +255,7 @@ func NewStatusResource(meta metadata.Provider) StatusResource {
 		metadata:         meta,
 		currentVersionID: metadata.NotExists,
 		current:          nil,
+		fatalErr:         make(chan error, 1),
 	}
 	s.Load()
 	return &s


### PR DESCRIPTION
## Summary
- `StatusResource` detects `ErrMetadataBadVersion` from metadata `Store` calls, wraps as `backoff.Permanent` to stop infinite retries, and signals via `FatalErr()` channel
- `Coordinator` gains `Done()`/`Err()` interface methods for lifecycle signaling
- Fatal-watcher goroutine monitors `StatusResource.FatalErr()` and on error: closes `Done` channel, cancels coordinator context
- `WaitToBecomeLeader` removed from `NewCoordinator` — leadership managed by caller

**Note:** Uses `c.WaitGroup.Done()` explicitly to avoid shadowing with the new `Done() <-chan struct{}` method.

**Depends on:** #921

## Test plan
- [x] `go build ./...` compiles across all modules
- [x] `go test ./coordinator/...` all unit tests pass
- [x] `go test ./tests/coordinator/...` all 11 e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)