### PR TITLE
fix: start gRPC health server before leader election

### DIFF
--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -159,19 +159,6 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 		return nil, errors.New(`must be one of "memory", "configmap" or "file"`)
 	}
 
-	controller := &options.Controller
-	controllerTLS, err := controller.TLS.TryIntoClientTLSConf()
-	if err != nil {
-		return nil, err
-	}
-	clientPool := rpc.NewClientPool(controllerTLS, nil)
-	rpcClient := coordinatorrpc.NewRpcProvider(clientPool)
-
-	coordinatorInstance, err := NewCoordinator(metadataProvider, clusterConfigProvider, clusterConfigChangeNotifications, rpcClient) //nolint:contextcheck
-	if err != nil {
-		return nil, err
-	}
-
 	healthServer := health.NewServer()
 
 	internalServer := options.Server.Internal
@@ -182,6 +169,19 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	grpcServer, err := rpc2.Default.StartGrpcServer("coordinator", internalServer.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
 	}, internalServerTLS, &auth.Disabled)
+	if err != nil {
+		return nil, err
+	}
+
+	controller := &options.Controller
+	controllerTLS, err := controller.TLS.TryIntoClientTLSConf()
+	if err != nil {
+		return nil, err
+	}
+	clientPool := rpc.NewClientPool(controllerTLS, nil)
+	rpcClient := coordinatorrpc.NewRpcProvider(clientPool)
+
+	coordinatorInstance, err := NewCoordinator(metadataProvider, clusterConfigProvider, clusterConfigChangeNotifications, rpcClient) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fix coordinator sidecar health checks in Kubernetes StatefulSet mode where non-leader coordinators get killed by liveness probes.

## Problem

In sidecar mode (3-pod StatefulSet), only the leader coordinator wins the Lease election. Non-leader coordinators block at `WaitToBecomeLeader()` inside `NewCoordinator()`. The gRPC server was started **after** `NewCoordinator()`, so the health endpoint was never reachable on non-leader pods. Kubernetes liveness probes fail and kill them in a crash loop.

## Fix

Move `health.NewServer()` and `StartGrpcServer()` before `NewCoordinator()`. This is a pure reorder — no new logic added.

`health.NewServer()` in grpc-go automatically sets the default service (`""`) to `SERVING`, so no explicit `SetServingStatus` calls are needed. This matches the existing behavior of the standalone coordinator deployment, which has been running in production (109 days, 1 restart) without any manual health status calls.

## Test plan

- [x] Deploy 3-pod coordinator StatefulSet on kind cluster — all pods 2/2 Running, 0 restarts
- [x] Chaos test: 5 random pod kills + leader kill — all pods recovered correctly
- [ ] CI passes