### PR TITLE
fix: resolve data race between followerCursor.Close() and stream.Send()

### DIFF
--- a/oxiad/dataserver/controller/lead/follower_cursor.go
+++ b/oxiad/dataserver/controller/lead/follower_cursor.go
@@ -192,14 +192,6 @@ func (fc *followerCursor) shouldSendSnapshot() bool {
 func (fc *followerCursor) Close() error {
 	fc.closed.Store(true)
 	fc.cancel()
-
-	fc.Lock()
-	defer fc.Unlock()
-
-	if fc.stream != nil {
-		return fc.stream.CloseSend()
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Close() was calling stream.CloseSend() concurrently with streamEntriesLoop() calling stream.Send() on the same gRPC stream. The cancel() call already terminates the stream by cancelling the context, so the explicit CloseSend() is unnecessary and racy.