### PR TITLE
fix: reduce flakiness in TestLeaderBalancedNodeAdded

### DIFF
--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -232,7 +232,7 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 		},
 		Servers: []model.Server{s1ad, s2ad, s3ad},
 		LoadBalancer: &model.LoadBalancer{
-			QuarantineTime: 5 * time.Second,
+			QuarantineTime: 1 * time.Second,
 		},
 	}
 
@@ -291,5 +291,5 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 			}
 		}
 		return true
-	}, 1*time.Minute, 1*time.Second)
+	}, 2*time.Minute, 100*time.Millisecond)
 }


### PR DESCRIPTION
Reduced QuarantineTime from 5s to 1s (matching the similar TestLeaderBalancedNodeCrashAndBack test) and increased the final assertion timeout to 2 minutes with a 100ms poll interval, giving the multi-round ensemble+leader rebalancing enough time to complete.