### PR TITLE
fix: update GitHub Actions to Node.js 22+ compatible versions

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -40,7 +40,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -50,20 +50,20 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: oxia/oxia
           tags: |
             type=ref,event=branch
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: ${{ inputs.platform }}

--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -37,17 +37,17 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.work'
           cache: 'true'
           cache-dependency-path: "go.work.sum"
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -84,7 +84,7 @@ jobs:
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
       actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -92,7 +92,7 @@ jobs:
             image=moby/buildkit:latest
             network=host
       - name: Build docker
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false
@@ -115,7 +115,7 @@ jobs:
         with:
           sarif_file: 'trivy-results.sarif'
 
-      - uses: helm/kind-action@v1.5.0
+      - uses: helm/kind-action@v1.14.0
         with:
           cluster_name: kind
           kubectl_version: v1.25.5
@@ -156,17 +156,17 @@ jobs:
       contents: read
       actions: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.work'
           cache: 'true'
           cache-dependency-path: "go.work.sum"
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,14 +40,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.work'
           cache: true
           cache-dependency-path: "go.work.sum"
 
       - name: Install protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.work'
           cache: 'true'
@@ -124,7 +124,7 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -134,7 +134,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: oxia/oxia
           tags: |
@@ -143,13 +143,13 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -189,7 +189,7 @@ jobs:
           done
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') }}

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -33,7 +33,7 @@ jobs:
             image=moby/buildkit:latest
             network=host
       - name: Build docker
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false


### PR DESCRIPTION
## Summary
- Update all GitHub Actions to latest major versions to fix Node.js 20 deprecation warnings
- Node.js 20 actions will stop working after June 2, 2026
- `chaos-mesh/chaos-mesh-action` remains on `@master` (no newer stable release available)

Updated across all 4 workflow files:
| Action | Old | New |
|---|---|---|
| `actions/checkout` | v3 | v4 |
| `actions/setup-go` | v3/v4 | v5 |
| `actions/setup-java` | v3 | v4 |
| `arduino/setup-protoc` | v1 | v3 |
| `docker/setup-qemu-action` | v2 | v3 |
| `docker/metadata-action` | v4 | v5 |
| `docker/login-action` | v2 | v3 |
| `docker/build-push-action` | v3 | v6 |
| `helm/kind-action` | v1.5.0 | v1.14.0 |
| `softprops/action-gh-release` | v1 | v2 |

## Test plan
- [ ] CI passes on this PR (validates the updated actions work correctly)