### PR TITLE
fix: bump aquasecurity/trivy-action from 0.34.0 to 0.35.0

### DIFF
--- a/.github/workflows/pr_build_and_test.yaml
+++ b/.github/workflows/pr_build_and_test.yaml
@@ -102,7 +102,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'oxia:latest'
           format: 'template'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -44,7 +44,7 @@ jobs:
 
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: 'oxia:latest'
           format: 'template'


### PR DESCRIPTION
### Motivation

Version `0.34.0` of `aquasecurity/trivy-action` has been removed from GitHub, causing CI failures on every PR.

### Modification

- Bump `aquasecurity/trivy-action` from `0.34.0` to `0.35.0` in `pr_build_and_test.yaml` and `trivy.yml`