### PR TITLE
fix: make leader balancer tests event-driven instead of time-based

### DIFF
--- a/oxiad/coordinator/balancer/scheduler_test.go
+++ b/oxiad/coordinator/balancer/scheduler_test.go
@@ -59,6 +59,10 @@ func (m *mockStatusResource) IsReady(_ *model.ClusterConfig) bool {
 	return true
 }
 
+func (m *mockStatusResource) ChangeNotify() <-chan struct{} {
+	return make(chan struct{})
+}
+
 // mockClusterConfigResource implements resource.ClusterConfigResource for testing.
 type mockClusterConfigResource struct {
 	nodes     *linkedhashset.Set[string]

--- a/oxiad/coordinator/resource/status_resource.go
+++ b/oxiad/coordinator/resource/status_resource.go
@@ -15,6 +15,7 @@
 package resource
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"sync"
@@ -40,6 +41,23 @@ type StatusResource interface {
 	DeleteShardMetadata(namespace string, shard int64)
 
 	IsReady(clusterConfig *model.ClusterConfig) bool
+
+	// ChangeNotify returns a channel that is closed when the next status
+	// change occurs. Callers should capture this channel BEFORE checking
+	// the condition they are waiting for, to avoid missing a change:
+	//
+	//	for {
+	//	    ch := statusResource.ChangeNotify()
+	//	    if condition(statusResource.Load()) {
+	//	        return
+	//	    }
+	//	    select {
+	//	    case <-ch:
+	//	    case <-ctx.Done():
+	//	        return ctx.Err()
+	//	    }
+	//	}
+	ChangeNotify() <-chan struct{}
 }
 
 var _ StatusResource = &status{}
@@ -51,6 +69,7 @@ type status struct {
 	lock             sync.RWMutex
 	current          *model.ClusterStatus
 	currentVersionID metadata.Version
+	changeCh         chan struct{}
 }
 
 // handleStoreError handles errors from metadata.Store().
@@ -63,6 +82,39 @@ func (*status) handleStoreError(err error) error {
 		return backoff.Permanent(err)
 	}
 	return err
+}
+
+// notifyChange wakes all goroutines waiting on ChangeNotify.
+// Must be called while holding s.lock for writing.
+func (s *status) notifyChange() {
+	close(s.changeCh)
+	s.changeCh = make(chan struct{})
+}
+
+func (s *status) ChangeNotify() <-chan struct{} {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.changeCh
+}
+
+// WaitForCondition blocks until condition returns true for the current
+// status, using event-driven notifications instead of time-based polling.
+// It triggers triggerFn (if non-nil) each iteration to drive progress.
+func WaitForCondition(ctx context.Context, sr StatusResource, triggerFn func(), condition func(*model.ClusterStatus) bool) error {
+	for {
+		ch := sr.ChangeNotify()
+		if condition(sr.Load()) {
+			return nil
+		}
+		if triggerFn != nil {
+			triggerFn()
+		}
+		select {
+		case <-ch:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 }
 
 func (s *status) loadWithInitSlow() {
@@ -128,6 +180,9 @@ func (s *status) Swap(newStatus *model.ClusterStatus, version metadata.Version) 
 			slog.Duration("retry-after", duration),
 		)
 	})
+	if err == nil {
+		s.notifyChange()
+	}
 	return err == nil
 }
 
@@ -149,6 +204,7 @@ func (s *status) Update(newStatus *model.ClusterStatus) {
 			slog.Duration("retry-after", duration),
 		)
 	})
+	s.notifyChange()
 }
 
 func (s *status) UpdateShardMetadata(namespace string, shard int64, shardMetadata model.ShardMetadata) {
@@ -176,6 +232,7 @@ func (s *status) UpdateShardMetadata(namespace string, shard int64, shardMetadat
 			slog.Duration("retry-after", duration),
 		)
 	})
+	s.notifyChange()
 }
 
 func (s *status) DeleteShardMetadata(namespace string, shard int64) {
@@ -206,6 +263,7 @@ func (s *status) DeleteShardMetadata(namespace string, shard int64) {
 			slog.Duration("retry-after", duration),
 		)
 	})
+	s.notifyChange()
 }
 
 func (s *status) IsReady(clusterConfig *model.ClusterConfig) bool {
@@ -235,6 +293,7 @@ func NewStatusResource(meta metadata.Provider) StatusResource {
 		metadata:         meta,
 		currentVersionID: metadata.NotExists,
 		current:          nil,
+		changeCh:         make(chan struct{}),
 	}
 	s.Load()
 	return &s

--- a/tests/balancer/leader_balancer_test.go
+++ b/tests/balancer/leader_balancer_test.go
@@ -19,13 +19,51 @@ import (
 	"time"
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
+	"github.com/oxia-db/oxia/oxiad/coordinator/resource"
 	"github.com/oxia-db/oxia/oxiad/coordinator/util"
 
 	"github.com/oxia-db/oxia/tests/mock"
 )
+
+func waitForSteadyState(t *testing.T, statusResource resource.StatusResource, expectedNamespaces int) {
+	t.Helper()
+	ctx := t.Context()
+	err := resource.WaitForCondition(ctx, statusResource, nil, func(status *model.ClusterStatus) bool {
+		if len(status.Namespaces) != expectedNamespaces {
+			return false
+		}
+		for _, ns := range status.Namespaces {
+			for _, shard := range ns.Shards {
+				if shard.Status != model.ShardStatusSteadyState {
+					return false
+				}
+			}
+		}
+		return true
+	})
+	require.NoError(t, err, "timed out waiting for shards to reach steady state")
+}
+
+func waitForLeadersBalanced(t *testing.T, statusResource resource.StatusResource, balancer interface{ Trigger() }, candidates *linkedhashset.Set[string], expectedPerNode int) {
+	t.Helper()
+	ctx := t.Context()
+	err := resource.WaitForCondition(ctx, statusResource, balancer.Trigger, func(status *model.ClusterStatus) bool {
+		shardLeaders, electedShards, nodeShards := util.NodeShardLeaders(candidates, status)
+		if shardLeaders != electedShards {
+			return false
+		}
+		for _, shards := range nodeShards {
+			if shards.Size() != expectedPerNode {
+				return false
+			}
+		}
+		return true
+	})
+	require.NoError(t, err, "timed out waiting for leaders to be balanced (%d per node)", expectedPerNode)
+}
 
 func TestLeaderBalanced(t *testing.T) {
 	s1, s1ad := mock.NewServer(t, "sv-1")
@@ -55,6 +93,9 @@ func TestLeaderBalanced(t *testing.T) {
 			},
 		},
 		Servers: []model.Server{s1ad, s2ad, s3ad},
+		LoadBalancer: &model.LoadBalancer{
+			QuarantineTime: 1 * time.Millisecond,
+		},
 	}
 
 	ch := make(chan any, 1)
@@ -62,37 +103,10 @@ func TestLeaderBalanced(t *testing.T) {
 	defer coordinator.Close()
 
 	statusResource := coordinator.StatusResource()
-
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		if len(status.Namespaces) != 3 {
-			return false
-		}
-		for _, ns := range status.Namespaces {
-			for _, shard := range ns.Shards {
-				if shard.Status != model.ShardStatusSteadyState {
-					return false
-				}
-			}
-		}
-		return true
-	}, 10*time.Second, 50*time.Millisecond)
+	waitForSteadyState(t, statusResource, 3)
 
 	balancer := coordinator.LoadBalancer()
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		shardLeaders, electedShards, nodeShards := util.NodeShardLeaders(candidates, status)
-		if shardLeaders != electedShards {
-			return false
-		}
-		balancer.Trigger()
-		for _, shards := range nodeShards {
-			if shards.Size() != 4 {
-				return false
-			}
-		}
-		return true
-	}, 10*time.Second, 50*time.Millisecond)
+	waitForLeadersBalanced(t, statusResource, balancer, candidates, 4)
 }
 
 func TestLeaderBalancedNodeCrashAndBack(t *testing.T) {
@@ -123,7 +137,7 @@ func TestLeaderBalancedNodeCrashAndBack(t *testing.T) {
 		},
 		Servers: []model.Server{s1ad, s2ad, s3ad},
 		LoadBalancer: &model.LoadBalancer{
-			QuarantineTime: 1 * time.Second,
+			QuarantineTime: 1 * time.Millisecond,
 		},
 	}
 
@@ -132,68 +146,29 @@ func TestLeaderBalancedNodeCrashAndBack(t *testing.T) {
 	defer coordinator.Close()
 
 	statusResource := coordinator.StatusResource()
-
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		if len(status.Namespaces) != 3 {
-			return false
-		}
-		for _, ns := range status.Namespaces {
-			for _, shard := range ns.Shards {
-				if shard.Status != model.ShardStatusSteadyState {
-					return false
-				}
-			}
-		}
-		return true
-	}, 10*time.Second, 50*time.Millisecond)
+	waitForSteadyState(t, statusResource, 3)
 
 	balancer := coordinator.LoadBalancer()
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		shardLeaders, electedShards, nodeShards := util.NodeShardLeaders(candidates, status)
-		if shardLeaders != electedShards {
-			return false
-		}
-		balancer.Trigger()
-		for _, shards := range nodeShards {
-			if shards.Size() != 4 {
-				return false
-			}
-		}
-		return true
-	}, 10*time.Second, 50*time.Millisecond)
+	waitForLeadersBalanced(t, statusResource, balancer, candidates, 4)
 
 	// close s3
-	assert.NoError(t, s3.Close())
+	require.NoError(t, s3.Close())
 
 	// wait for leader moved
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
+	ctx := t.Context()
+	err := resource.WaitForCondition(ctx, statusResource, nil, func(status *model.ClusterStatus) bool {
 		_, _, nodeShards := util.NodeShardLeaders(candidates, status)
 		shards := nodeShards[s3ad.GetIdentifier()]
 		return shards.Size() == 0
-	}, 10*time.Second, 50*time.Millisecond)
+	})
+	require.NoError(t, err, "timed out waiting for leaders to move off crashed node")
 
 	// start s3
 	s3, s3ad = mock.NewServerWithAddress(t, "sv-3", s3ad.Public, s3ad.Internal)
 	defer s3.Close()
 
 	// wait for leader balanced
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		shardLeaders, electedShards, nodeShards := util.NodeShardLeaders(candidates, status)
-		if shardLeaders != electedShards {
-			return false
-		}
-		balancer.Trigger()
-		for _, shards := range nodeShards {
-			if shards.Size() != 4 {
-				return false
-			}
-		}
-		return true
-	}, 30*time.Second, 50*time.Millisecond)
+	waitForLeadersBalanced(t, statusResource, balancer, candidates, 4)
 }
 
 func TestLeaderBalancedNodeAdded(t *testing.T) {
@@ -232,7 +207,7 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 		},
 		Servers: []model.Server{s1ad, s2ad, s3ad},
 		LoadBalancer: &model.LoadBalancer{
-			QuarantineTime: 1 * time.Second,
+			QuarantineTime: 1 * time.Millisecond,
 		},
 	}
 
@@ -241,55 +216,15 @@ func TestLeaderBalancedNodeAdded(t *testing.T) {
 	defer coordinator.Close()
 
 	statusResource := coordinator.StatusResource()
-
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		if len(status.Namespaces) != 3 {
-			return false
-		}
-		for _, ns := range status.Namespaces {
-			for _, shard := range ns.Shards {
-				if shard.Status != model.ShardStatusSteadyState {
-					return false
-				}
-			}
-		}
-		return true
-	}, 10*time.Second, 50*time.Millisecond)
+	waitForSteadyState(t, statusResource, 3)
 
 	balancer := coordinator.LoadBalancer()
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		shardLeaders, electedShards, nodeShards := util.NodeShardLeaders(candidates, status)
-		if shardLeaders != electedShards {
-			return false
-		}
-		balancer.Trigger()
-		for _, shards := range nodeShards {
-			if shards.Size() != 4 {
-				return false
-			}
-		}
-		return true
-	}, 10*time.Second, 50*time.Millisecond)
+	waitForLeadersBalanced(t, statusResource, balancer, candidates, 4)
 
 	cc.Servers = append(cc.Servers, s4ad, s5ad, s6ad)
 	ch <- nil
 	candidates = linkedhashset.New(s1ad.GetIdentifier(), s2ad.GetIdentifier(), s3ad.GetIdentifier(), s4ad.GetIdentifier(), s5ad.GetIdentifier(), s6ad.GetIdentifier())
 
 	// wait for leader balanced
-	assert.Eventually(t, func() bool {
-		status := statusResource.Load()
-		shardLeaders, electedShards, nodeShards := util.NodeShardLeaders(candidates, status)
-		if shardLeaders != electedShards {
-			return false
-		}
-		balancer.Trigger()
-		for _, shards := range nodeShards {
-			if shards.Size() != 2 {
-				return false
-			}
-		}
-		return true
-	}, 2*time.Minute, 100*time.Millisecond)
+	waitForLeadersBalanced(t, statusResource, balancer, candidates, 2)
 }


### PR DESCRIPTION
## Summary
- Add `StatusResource.ChangeNotify()` that returns a channel closed on the next status change, enabling event-driven waiting instead of time-based polling
- Add `WaitForCondition()` helper that blocks until a condition is met by reacting to actual status changes
- Replace all `assert.Eventually` calls in leader balancer tests with event-driven waiting
- Set `QuarantineTime` to 1ms in all tests (previously 5min default or 1s) to eliminate wall-clock quarantine delays
- Extract waitForSteadyState/waitForLeadersBalanced test helpers

## Test plan
- [x] All 3 leader balancer tests pass with `-race` flag
- [x] All tests pass consistently across 3 consecutive runs (9/9)
- [x] Full balancer test suite passes