### PR TITLE
Fix candidate-release: remove broken secrets line

### DIFF
--- a/.github/workflows/candidate-release.yml
+++ b/.github/workflows/candidate-release.yml
@@ -141,7 +141,6 @@ jobs:
       candidate_image: "oxia/oxia:${{ needs.prepare.outputs.rc_tag }}"
       stable_image: "oxia/oxia:${{ needs.prepare.outputs.stable_tag }}"
     secrets: inherit
-      regret_studio: ${{ secrets.REGRET_STUDIO_URL }}
 
   # ── Step 4: Manual approval + promote to official release ──
   promote:


### PR DESCRIPTION
Fix invalid YAML: `secrets: inherit` can't be combined with individual secret entries. Removed the stale `regret_studio` line. Validated with actionlint.