### PR TITLE
fix: validate cluster config to reject invalid replicationFactor

### DIFF
--- a/oxiad/coordinator/model/cluster_config.go
+++ b/oxiad/coordinator/model/cluster_config.go
@@ -73,6 +73,40 @@ func (*KeySorting) Type() string {
 	return "KeySorting"
 }
 
+func (cc *ClusterConfig) Validate() error {
+	if len(cc.Servers) == 0 {
+		return errors.New("cluster config: at least one server must be configured")
+	}
+
+	if len(cc.Namespaces) == 0 {
+		return errors.New("cluster config: at least one namespace must be configured")
+	}
+
+	for _, ns := range cc.Namespaces {
+		if ns.Name == "" {
+			return errors.New("cluster config: namespace name must not be empty")
+		}
+
+		if ns.ReplicationFactor < 1 {
+			return errors.Errorf("cluster config: namespace %q has invalid replicationFactor=%d, must be >= 1",
+				ns.Name, ns.ReplicationFactor)
+		}
+
+		if ns.InitialShardCount < 1 {
+			return errors.Errorf("cluster config: namespace %q has invalid initialShardCount=%d, must be >= 1",
+				ns.Name, ns.InitialShardCount)
+		}
+
+		if ns.ReplicationFactor > uint32(len(cc.Servers)) {
+			return errors.Errorf(
+				"cluster config: namespace %q has replicationFactor=%d but only %d servers are configured",
+				ns.Name, ns.ReplicationFactor, len(cc.Servers))
+		}
+	}
+
+	return nil
+}
+
 // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 func (ks *KeySorting) ToProto() proto.KeySortingType {

--- a/oxiad/coordinator/model/cluster_config_test.go
+++ b/oxiad/coordinator/model/cluster_config_test.go
@@ -56,3 +56,59 @@ func TestClusterConfig(t *testing.T) {
 	assert.Equal(t, cc1, cc2)
 	assert.NotSame(t, &cc1, &cc2)
 }
+
+func validConfig() ClusterConfig {
+	return ClusterConfig{
+		Namespaces: []NamespaceConfig{{
+			Name:              "ns1",
+			InitialShardCount: 1,
+			ReplicationFactor: 3,
+		}},
+		Servers: []Server{
+			{Public: "s1:6648", Internal: "s1:6649"},
+			{Public: "s2:6648", Internal: "s2:6649"},
+			{Public: "s3:6648", Internal: "s3:6649"},
+		},
+	}
+}
+
+func TestValidate_ValidConfig(t *testing.T) {
+	cc := validConfig()
+	assert.NoError(t, cc.Validate())
+}
+
+func TestValidate_NoServers(t *testing.T) {
+	cc := validConfig()
+	cc.Servers = nil
+	assert.ErrorContains(t, cc.Validate(), "at least one server must be configured")
+}
+
+func TestValidate_NoNamespaces(t *testing.T) {
+	cc := validConfig()
+	cc.Namespaces = nil
+	assert.ErrorContains(t, cc.Validate(), "at least one namespace must be configured")
+}
+
+func TestValidate_EmptyNamespaceName(t *testing.T) {
+	cc := validConfig()
+	cc.Namespaces[0].Name = ""
+	assert.ErrorContains(t, cc.Validate(), "namespace name must not be empty")
+}
+
+func TestValidate_ReplicationFactorZero(t *testing.T) {
+	cc := validConfig()
+	cc.Namespaces[0].ReplicationFactor = 0
+	assert.ErrorContains(t, cc.Validate(), "invalid replicationFactor=0, must be >= 1")
+}
+
+func TestValidate_InitialShardCountZero(t *testing.T) {
+	cc := validConfig()
+	cc.Namespaces[0].InitialShardCount = 0
+	assert.ErrorContains(t, cc.Validate(), "invalid initialShardCount=0, must be >= 1")
+}
+
+func TestValidate_ReplicationFactorExceedsServers(t *testing.T) {
+	cc := validConfig()
+	cc.Namespaces[0].ReplicationFactor = 5
+	assert.ErrorContains(t, cc.Validate(), "replicationFactor=5 but only 3 servers are configured")
+}

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -120,6 +120,10 @@ func loadClusterConfig(cluster *option.ClusterOptions, v *viper.Viper) (model.Cl
 		return cc, errors.Wrap(err, "failed to load cluster config")
 	}
 
+	if err := cc.Validate(); err != nil {
+		return cc, err
+	}
+
 	return cc, nil
 }
 


### PR DESCRIPTION
## Summary
- Added `ClusterConfig.Validate()` method that checks for invalid configurations at load time
- Rejects `replicationFactor < 1`, `initialShardCount < 1`, empty namespace names, no servers, no namespaces, and `replicationFactor` exceeding the number of configured servers
- Called from `loadClusterConfig()` which is used both at startup and as the `clusterConfigProvider` for dynamic config reloads, so dynamically added namespaces are also validated

## Test plan
- [x] Added unit tests for all validation cases (valid config, zero replication factor, zero shard count, empty name, no servers, no namespaces, replication factor exceeds servers)
- [ ] Start coordinator with `replicationFactor: 0` and verify it exits with a clear error message
- [ ] Dynamically update config to add a namespace with `replicationFactor: 0` and verify it is rejected