### PR TITLE
fix: prevent load balancer from swapping shards in RF=1 namespaces

### DIFF
--- a/oxiad/coordinator/balancer/scheduler.go
+++ b/oxiad/coordinator/balancer/scheduler.go
@@ -226,6 +226,13 @@ func (r *nodeBasedBalancer) swapShard(
 	if nsc, exist = r.configResource.NamespaceConfig(candidateShard.Namespace); !exist {
 		return false, nil
 	}
+
+	// With RF=1, an ensemble swap cannot safely transfer data (there's no
+	// follower to replicate from). Skip rebalancing for such namespaces.
+	if nsc.ReplicationFactor <= 1 {
+		return false, nil
+	}
+
 	policies := nsc.Policies
 	sContext := &single.Context{
 		Candidates:         candidates,

--- a/oxiad/coordinator/balancer/scheduler_test.go
+++ b/oxiad/coordinator/balancer/scheduler_test.go
@@ -134,6 +134,69 @@ func newTestBalancer(
 	}
 }
 
+// selectRecordingSelector records whether Select was ever called.
+type selectRecordingSelector struct {
+	called bool
+}
+
+func (s *selectRecordingSelector) Select(_ *single.Context) (string, error) {
+	s.called = true
+	return "", selector.ErrUnsatisfiedAntiAffinity
+}
+
+func TestSwapShardSkipsRF1Namespace(t *testing.T) {
+	// Two nodes with an imbalanced distribution: sv-1 owns all 3 shards,
+	// sv-2 owns none. With RF=3 the balancer would try to swap, but with
+	// RF=1 it must skip entirely.
+	sv1 := model.Server{Internal: "sv-1"}
+	sv2 := model.Server{Internal: "sv-2"}
+
+	status := &model.ClusterStatus{
+		Namespaces: map[string]model.NamespaceStatus{
+			"rf1ns": {
+				ReplicationFactor: 1,
+				Shards: map[int64]model.ShardMetadata{
+					0: {Status: model.ShardStatusSteadyState, Ensemble: []model.Server{sv1}},
+					1: {Status: model.ShardStatusSteadyState, Ensemble: []model.Server{sv1}},
+					2: {Status: model.ShardStatusSteadyState, Ensemble: []model.Server{sv1}},
+				},
+			},
+		},
+	}
+
+	nodes := linkedhashset.New("sv-1", "sv-2")
+	sel := &selectRecordingSelector{}
+	configRes := &mockClusterConfigResource{
+		nodes:    nodes,
+		metadata: map[string]model.ServerMetadata{},
+		nsConfigs: map[string]*model.NamespaceConfig{
+			"rf1ns": {Name: "rf1ns", ReplicationFactor: 1},
+		},
+		nodeMap: map[string]*model.Server{
+			"sv-1": &sv1,
+			"sv-2": &sv2,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	b := newTestBalancer(ctx, cancel, &mockStatusResource{status: status}, configRes, sel)
+
+	b.rebalanceEnsemble()
+
+	// The selector must never have been called because swapShard should
+	// return early for RF=1 namespaces.
+	if sel.called {
+		t.Fatal("selector was called for RF=1 namespace; expected swapShard to skip it")
+	}
+
+	// No swap actions should have been emitted.
+	if len(b.actionCh) != 0 {
+		t.Fatalf("expected 0 actions, got %d", len(b.actionCh))
+	}
+}
+
 func TestBalanceHighestNodeDoesNotHangOnSelectorError(t *testing.T) {
 	sv1 := model.Server{Internal: "sv-1"}
 	sv2 := model.Server{Internal: "sv-2"}


### PR DESCRIPTION
## Summary

- When a namespace has `ReplicationFactor=1`, the load balancer's ensemble swap causes **permanent data loss**: the new (empty) server becomes the leader without any data transfer, and the old server's data is then deleted.
- This PR adds an early return in `swapShard()` that skips ensemble swaps entirely for namespaces with `ReplicationFactor <= 1`.
- Adds a unit test verifying that the selector is never invoked and no swap actions are emitted for RF=1 namespaces.

## Test plan

- [x] New unit test `TestSwapShardSkipsRF1Namespace` validates the guard
- [x] All existing balancer tests pass with `-race`: `go test -race ./oxiad/coordinator/balancer/...`