### PR TITLE
fix: add missing term to dataserver controller log messages

### DIFF
--- a/oxiad/dataserver/controller/follow/follower_controller.go
+++ b/oxiad/dataserver/controller/follow/follower_controller.go
@@ -330,7 +330,7 @@ func (fc *followerController) NewTerm(req *proto.NewTermRequest) (*proto.NewTerm
 	newTerm := req.GetTerm()
 	newTermOptions := req.GetOptions()
 	if newTerm < fc.term.Load() { // Allowing idempotency during negotiations
-		fc.log.Warn("Failed to fence with invalid term", slog.Int64("new-term", newTerm))
+		fc.log.Warn("Failed to fence with invalid term", slog.Int64("current-term", fc.term.Load()), slog.Int64("new-term", newTerm))
 		return nil, dserror.ErrInvalidTerm
 	}
 	fc.rwMutex.Lock()

--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -527,6 +527,7 @@ func (lc *leaderController) RemoveObserver(req *proto.RemoveObserverRequest) (*p
 
 	lc.log.Info("Removed observer follower",
 		slog.String("observer-key", observerKey),
+		slog.Int64("term", lc.term.Load()),
 	)
 
 	return &proto.RemoveObserverResponse{}, nil
@@ -586,6 +587,7 @@ func (lc *leaderController) addObserver(observerKey string, follower string, fol
 			slog.Any("error", err),
 			slog.String("follower", follower),
 			slog.Any("follower-head-entry", followerHeadEntryId),
+			slog.Int64("term", lc.term.Load()),
 		)
 		return err
 	}
@@ -601,6 +603,7 @@ func (lc *leaderController) addObserver(observerKey string, follower string, fol
 			"Failed to create observer follower cursor",
 			slog.Any("error", err),
 			slog.String("follower", follower),
+			slog.Int64("term", lc.term.Load()),
 		)
 		return err
 	}
@@ -610,6 +613,7 @@ func (lc *leaderController) addObserver(observerKey string, follower string, fol
 		slog.String("follower", follower),
 		slog.Any("follower-head-entry", followerHeadEntryId),
 		slog.Int64("head-offset", lc.wal.LastOffset()),
+		slog.Int64("term", lc.term.Load()),
 	)
 	lc.observers[observerKey] = cursor
 	lc.followerAckOffsetGauges[observerKey] = metric.NewGauge("oxia_server_observer_ack_offset", "", "count",

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -400,6 +400,7 @@ func (s *internalRpcServer) SendSnapshot(srv proto.OxiaLogReplication_SendSnapsh
 		"Received SendSnapshot request",
 		slog.Int64("shard", shardId),
 		slog.String("namespace", namespace),
+		slog.Int64("term", term),
 		slog.String("peer", rpc.GetPeer(srv.Context())),
 	)
 
@@ -410,6 +411,7 @@ func (s *internalRpcServer) SendSnapshot(srv proto.OxiaLogReplication_SendSnapsh
 			slog.Any("error", err),
 			slog.String("namespace", namespace),
 			slog.Int64("shard", shardId),
+			slog.Int64("term", term),
 			slog.String("peer", rpc.GetPeer(srv.Context())),
 		)
 		return err


### PR DESCRIPTION
## Summary
- Add `current-term` field to follower controller's invalid-term fence warning for easier debugging of term mismatches
- Add `term` field to leader controller's observer follower log messages (add, remove, truncate error, cursor creation error) for consistency with regular follower logging

## Test plan
- [x] `go build ./oxiad/...` compiles successfully
- [x] `go test -race -count=1 ./oxiad/dataserver/controller/...` all tests pass