### PR TITLE
ci: clean up RC tags and releases on official release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -200,3 +200,51 @@ jobs:
           draft: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Clean up RC tags and releases when an official release is published
+  cleanup-rc-tags:
+    name: Cleanup RC Tags
+    runs-on: ubuntu-latest
+    needs: create-release
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, 'rc') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'alpha')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Delete RC tags and releases
+        run: |
+          # Extract base version from tag (e.g., v0.16.2 -> v0.16.2)
+          BASE_VERSION="${GITHUB_REF_NAME}"
+          echo "Official release: ${BASE_VERSION}"
+
+          # Find all RC tags matching this version
+          RC_TAGS=$(git tag --list "${BASE_VERSION}-rc*")
+
+          if [ -z "$RC_TAGS" ]; then
+            echo "No RC tags found for ${BASE_VERSION}"
+            exit 0
+          fi
+
+          echo "Found RC tags to clean up:"
+          echo "$RC_TAGS"
+
+          for TAG in $RC_TAGS; do
+            echo "Processing ${TAG}..."
+
+            # Delete the GitHub release if it exists
+            if gh release view "$TAG" > /dev/null 2>&1; then
+              echo "  Deleting GitHub release: ${TAG}"
+              gh release delete "$TAG" --yes --cleanup-tag
+            else
+              echo "  No GitHub release found for ${TAG}, deleting tag only"
+              # Delete remote tag
+              git push origin --delete "refs/tags/${TAG}" || true
+            fi
+          done
+
+          echo "RC tag cleanup complete"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation

When an official release is published (e.g., `v0.16.2`), the corresponding RC tags (`v0.16.2-rc0`, `v0.16.2-rc1`, ...) and their GitHub releases are left behind, cluttering the tags and releases page.

### Modification

- Add a `cleanup-rc-tags` job to the release workflow that runs after `create-release`
- The job only triggers for official releases (tags without `rc`, `beta`, or `alpha`)
- It finds all RC tags matching the released version and deletes both the GitHub release and the git tag for each
- Uses `gh release delete --cleanup-tag` when a release exists, or `git push --delete` for orphaned tags