### PR TITLE
fix: race in split controller between completion event and metadata cleanup

### DIFF
--- a/oxiad/coordinator/controller/split_controller.go
+++ b/oxiad/coordinator/controller/split_controller.go
@@ -592,20 +592,19 @@ func (sc *SplitController) runCutover() error {
 		})
 	}
 
+	// Clear split metadata and mark parent for deletion in a single update,
+	// before notifying the coordinator. This avoids a race where the
+	// coordinator (or tests) observes the completion event but finds stale
+	// split metadata on the parent.
 	sc.updateParentMeta(func(meta *model.ShardMetadata) {
 		meta.Status = model.ShardStatusDeleting
+		meta.Split = nil
 	})
 
 	// Step 5: Notify the coordinator. This triggers the parent shard
 	// controller's DeleteShard (which retries indefinitely with backoff)
 	// and recomputes shard assignments so clients discover the children.
 	sc.eventListener.SplitComplete(sc.parentShardId, sc.leftChildId, sc.rightChildId)
-
-	// Clear split metadata from parent — the split controller's job is done.
-	// The parent shard controller handles the actual deletion.
-	sc.updateParentMeta(func(meta *model.ShardMetadata) {
-		meta.Split = nil
-	})
 
 	return nil
 }


### PR DESCRIPTION
### Motivation

`TestSplitController_FullLifecycle` fails intermittently because the test observes stale split metadata on the parent shard after receiving the `SplitComplete` event. The root cause is that `runCutover()` notifies via `SplitComplete` *before* clearing the parent's split metadata in a separate update, creating a window where observers see the completion but the metadata hasn't been cleaned up yet.

### Modification

- Combine the parent status update (`ShardStatusDeleting`) and split metadata cleanup (`Split = nil`) into a single atomic `updateParentMeta` call, executed **before** the `SplitComplete` notification
- This ensures that by the time any observer receives the completion event, the parent's split metadata is already cleared