### PR TITLE
fix: remove self-referencing replace directive in common/go.mod

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -38,5 +38,3 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 )
-
-replace github.com/oxia-db/oxia/common => ../common


### PR DESCRIPTION
### Motivation

The `common/go.mod` had a self-referencing `replace` directive (`replace github.com/oxia-db/oxia/common => ../common`) which is a no-op — a module replacing itself with itself. This was likely added by accident.

### Modification

- Remove the self-referencing `replace` directive from `common/go.mod`