### PR TITLE
release: oxia v0.16.1

### DIFF
--- a/oxia/go.mod
+++ b/oxia/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/emirpasic/gods/v2 v2.0.0-alpha
 	github.com/google/uuid v1.6.0
-	github.com/oxia-db/oxia/common v0.0.0-00010101000000-000000000000
+	github.com/oxia-db/oxia/common v0.16.1
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.40.0
@@ -45,5 +45,3 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/oxia-db/oxia/common => ../common

--- a/oxia/go.sum
+++ b/oxia/go.sum
@@ -37,6 +37,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/oxia-db/oxia/common v0.16.1 h1:VNyee3jZpckVQe/yL/v9gQGEMuwUX3yEZdaNcRXqq3Q=
+github.com/oxia-db/oxia/common v0.16.1/go.mod h1:xb8ZDFtMwZVDMecajiIrNBzxvl/6G43nXKYXbfF6kIk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=


### PR DESCRIPTION
### Motivation

The `oxia/go.mod` used a `replace` directive to point `common` to `../common`, which is ignored by external consumers and causes them to fail resolving the dependency. Now that `common/v0.16.1` is tagged and published, we can reference it directly.

### Modification

- Replace `github.com/oxia-db/oxia/common v0.0.0-00010101000000-000000000000` with `v0.16.1`
- Remove the `replace github.com/oxia-db/oxia/common => ../common` directive