### PR TITLE
fix: suppress noisy follower-not-caught-up log during election

### DIFF
--- a/oxiad/coordinator/controller/shard_controller_election.go
+++ b/oxiad/coordinator/controller/shard_controller_election.go
@@ -46,6 +46,7 @@ import (
 
 var (
 	ErrNotReadyForChangeEnsemble = errors.New("shard is not ready for change ensemble, please retry later")
+	ErrFollowerNotCaughtUp       = errors.New("follower not caught up yet")
 )
 
 type ShardElection struct {
@@ -294,21 +295,17 @@ func (e *ShardElection) ensureFollowerCaught(ensemble []model.Server, leader *mo
 						)
 						return nil
 					}
-					e.Info(
-						"Follower is *not* caught-up yet with the leader",
-						slog.Any("server", server),
-						slog.Int64("leader-head-offset", leaderEntry.Offset),
-						slog.Int64("follower-head-offset", followerHeadOffset),
-					)
-					return errors.New("follower not caught up yet")
+					return ErrFollowerNotCaughtUp
 				}, oxiatime.NewBackOff(e.Context), func(err error, duration time.Duration) {
-					if status.Code(err) == constant.CodeNodeIsNotMember {
+					switch {
+					case errors.Is(err, ErrFollowerNotCaughtUp):
+					case status.Code(err) == constant.CodeNodeIsNotMember:
 						e.Info("Follower has not been added by leader yet",
 							slog.Any("server", server),
 							slog.Int64("shard", e.shard),
 							slog.Duration("retry-after", duration),
 						)
-					} else {
+					default:
 						e.Warn("Failed to get the follower status",
 							slog.Any("server", server),
 							slog.Any("error", err),

--- a/oxiad/coordinator/controller/shard_controller_election.go
+++ b/oxiad/coordinator/controller/shard_controller_election.go
@@ -295,6 +295,12 @@ func (e *ShardElection) ensureFollowerCaught(ensemble []model.Server, leader *mo
 						)
 						return nil
 					}
+					e.Info(
+						"Follower is *not* caught-up yet with the leader",
+						slog.Any("server", server),
+						slog.Int64("leader-head-offset", leaderEntry.Offset),
+						slog.Int64("follower-head-offset", followerHeadOffset),
+					)
 					return ErrFollowerNotCaughtUp
 				}, oxiatime.NewBackOff(e.Context), func(err error, duration time.Duration) {
 					switch {


### PR DESCRIPTION
### Motivation

The `Follower is *not* caught-up yet with the leader` info log fires on every retry iteration while waiting for followers to catch up after an election. This is expected transient behavior and produces excessive log noise.

### Modification

- Add `ErrFollowerNotCaughtUp` sentinel error to replace inline `errors.New`
- Remove the verbose info log on each retry and return the sentinel error instead
- Skip logging in the `RetryNotify` callback when the error is `ErrFollowerNotCaughtUp`
- Refactor the notify callback to use a `switch` statement for clarity