### PR TITLE
fix: coordinator not reacting to ConfigMap cluster config changes

### DIFF
--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -33,6 +33,14 @@ import (
 )
 
 type cmConfigProvider struct {
+	onConfigChange func()
+}
+
+// OnConfigChange sets the event handler that is called when a config map changes.
+// This mirrors viper's OnConfigChange API for file-based configs, filling in
+// the gap where viper's WatchRemoteConfigOnChannel does not trigger callbacks.
+func (c *cmConfigProvider) OnConfigChange(fn func()) {
+	c.onConfigChange = fn
 }
 
 const filePath = "config.yaml"
@@ -68,7 +76,7 @@ func (c *cmConfigProvider) Watch(rp viper.RemoteProvider) (io.Reader, error) {
 	return c.Get(rp)
 }
 
-func (*cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.RemoteResponse, chan bool) {
+func (c *cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.RemoteResponse, chan bool) {
 	kubernetes := metadata.NewK8SClientset(metadata.NewK8SClientConfig())
 	namespace, configmap, _ := getNamespaceAndCmName(rp)
 
@@ -95,6 +103,7 @@ func (*cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.Re
 					slog.String("k8s-config-map", configmap),
 					slog.Any("object", res),
 				)
+				continue
 			}
 			if cm.Name != configmap {
 				continue
@@ -111,6 +120,9 @@ func (*cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.Re
 				ch <- &viper.RemoteResponse{
 					Value: []byte(cm.Data[filePath]),
 					Error: nil,
+				}
+				if c.onConfigChange != nil {
+					c.onConfigChange()
 				}
 			default:
 				ch <- &viper.RemoteResponse{

--- a/oxiad/coordinator/resource/cluster_config_resource.go
+++ b/oxiad/coordinator/resource/cluster_config_resource.go
@@ -214,7 +214,7 @@ func (ccf *clusterConfig) waitForUpdates() {
 
 			if reflect.DeepEqual(oldClusterConfig, currentClusterConfig) {
 				ccf.Info("No cluster config changes detected")
-				return
+				continue
 			}
 			ccf.clusterConfigEventListener.ConfigChanged(currentClusterConfig)
 		}

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -65,24 +65,32 @@ type GrpcServer struct {
 	metrics      *metric.PrometheusMetrics
 }
 
-func setConfigPath(cluster *option.ClusterOptions, v *viper.Viper) error {
-	v.SetConfigType("yaml")
+func watchClusterConfigProvider(cluster *option.ClusterOptions, v *viper.Viper, clusterConfigChangeNotifications chan any) error {
 	configPath := cluster.ConfigPath
+	v.SetConfigType("yaml")
+	onChange := func() { clusterConfigChangeNotifications <- nil }
 
-	if strings.HasPrefix(configPath, "configmap:") {
+	switch {
+	// remote configmap
+	case strings.HasPrefix(configPath, "configmap:"):
 		err := v.AddRemoteProvider("configmap", "endpoint", configPath)
 		if err != nil {
 			slog.Error("Failed to add remote provider", slog.Any("error", err))
 			return err
 		}
+		if watcher, ok := viper.RemoteConfig.(interface{ OnConfigChange(func()) }); ok {
+			watcher.OnConfigChange(onChange)
+		}
 		return v.WatchRemoteConfigOnChannel()
-	}
-	if configPath == "" {
+	// local file
+	case configPath == "":
 		v.AddConfigPath("/oxia/conf")
 		v.AddConfigPath(".")
+	default:
+		v.SetConfigFile(configPath)
 	}
 
-	v.SetConfigFile(configPath)
+	v.OnConfigChange(func(_ fsnotify.Event) { onChange() })
 	v.WatchConfig()
 	return nil
 }
@@ -124,19 +132,16 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	v := viper.New()
 
 	clusterConfigChangeNotifications := make(chan any)
-	v.OnConfigChange(func(_ fsnotify.Event) {
-		clusterConfigChangeNotifications <- nil
-	})
 
 	clusterConfigProvider := func() (model.ClusterConfig, error) {
 		return loadClusterConfig(&options.Cluster, v)
 	}
 
-	if err := setConfigPath(&options.Cluster, v); err != nil {
+	if err := watchClusterConfigProvider(&options.Cluster, v, clusterConfigChangeNotifications); err != nil {
 		return nil, err
 	}
 
-	if _, err := loadClusterConfig(&options.Cluster, v); err != nil {
+	if _, err := clusterConfigProvider(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
### Motivation

The coordinator fails to detect ConfigMap cluster config changes at runtime. When deploying with `configmap:` config path, K8S watch events are received but the coordinator never processes them — config changes (e.g., adding namespaces) require a pod restart to take effect.

### Modification

- Add `OnConfigChange` method to `cmConfigProvider` (mirrors viper's `OnConfigChange` API), since viper's `WatchRemoteConfigOnChannel` never triggers `OnConfigChange` callbacks
- Fix `waitForUpdates` goroutine in `cluster_config_resource.go` that exits permanently after the first no-change event (`return` → `continue`)
- Refactor `setConfigPath` → `watchClusterConfigProvider` to own all notification setup for both file and configmap paths in a unified pattern
- Replace redundant `loadClusterConfig()` call with `clusterConfigProvider()`
- Fix potential nil panic in `WatchChannel` when type assertion fails (missing `continue`)