### PR TITLE
fix: reconnect K8S ConfigMap watch on expiration

### DIFF
--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	k8s "k8s.io/client-go/kubernetes"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 
@@ -90,69 +91,11 @@ func (c *cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.
 	}, func() {
 		bo := oxiatime.NewBackOffWithInitialInterval(context.Background(), 1*time.Second)
 		_ = backoff.RetryNotify(func() error {
-			w, err := kubernetes.CoreV1().ConfigMaps(namespace).Watch(
-				context.Background(),
-				metav1.SingleObject(metav1.ObjectMeta{Name: configmap, Namespace: namespace}),
-			)
+			err := c.watchConfigMap(kubernetes, namespace, configmap, ch)
 			if err != nil {
-				return errors.Wrap(err, "failed to setup watch on config map")
+				return err
 			}
-			defer w.Stop()
-
 			bo.Reset()
-
-			// Read the current state after establishing the watch to avoid
-			// missing updates that occurred between disconnect and re-watch.
-			currentCm, err := kubernetes.CoreV1().ConfigMaps(namespace).Get(context.Background(), configmap, metav1.GetOptions{})
-			if err != nil {
-				return errors.Wrap(err, "failed to get current config map after watch setup")
-			}
-			ch <- &viper.RemoteResponse{
-				Value: []byte(currentCm.Data[filePath]),
-				Error: nil,
-			}
-			if c.onConfigChange != nil {
-				c.onConfigChange()
-			}
-
-			for res := range w.ResultChan() {
-				if res.Type == watch.Error {
-					return errors.Errorf("watch error: %v", res.Object)
-				}
-
-				cm, ok := res.Object.(*corev1.ConfigMap)
-				if !ok {
-					slog.Warn("Got wrong type of object notification",
-						slog.String("k8s-namespace", namespace),
-						slog.String("k8s-config-map", configmap),
-						slog.Any("object", res),
-					)
-					continue
-				}
-
-				slog.Info("Got watch event from K8S",
-					slog.String("k8s-namespace", namespace),
-					slog.String("k8s-config-map", configmap),
-					slog.Any("event-type", res.Type),
-				)
-
-				switch res.Type {
-				case watch.Added, watch.Modified:
-					ch <- &viper.RemoteResponse{
-						Value: []byte(cm.Data[filePath]),
-						Error: nil,
-					}
-					if c.onConfigChange != nil {
-						c.onConfigChange()
-					}
-				default:
-					ch <- &viper.RemoteResponse{
-						Value: nil,
-						Error: errors.Errorf("unexpected event on config map: %v", res.Type),
-					}
-				}
-			}
-
 			return errors.New("K8S config map watch closed")
 		}, bo, func(err error, duration time.Duration) {
 			slog.Warn("K8S config map watch failed, reconnecting",
@@ -165,6 +108,69 @@ func (c *cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.
 	})
 
 	return ch, nil
+}
+
+func (c *cmConfigProvider) watchConfigMap(kubernetes k8s.Interface, namespace, configmap string, ch chan<- *viper.RemoteResponse) error {
+	w, err := kubernetes.CoreV1().ConfigMaps(namespace).Watch(
+		context.Background(),
+		metav1.SingleObject(metav1.ObjectMeta{Name: configmap, Namespace: namespace}),
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to setup watch on config map")
+	}
+	defer w.Stop()
+
+	// Read the current state after establishing the watch to avoid
+	// missing updates that occurred between disconnect and re-watch.
+	currentCm, err := kubernetes.CoreV1().ConfigMaps(namespace).Get(context.Background(), configmap, metav1.GetOptions{})
+	if err != nil {
+		return errors.Wrap(err, "failed to get current config map after watch setup")
+	}
+	c.notifyChange(ch, currentCm.Data[filePath])
+
+	for res := range w.ResultChan() {
+		if res.Type == watch.Error {
+			return errors.Errorf("watch error: %v", res.Object)
+		}
+
+		cm, ok := res.Object.(*corev1.ConfigMap)
+		if !ok {
+			slog.Warn("Got wrong type of object notification",
+				slog.String("k8s-namespace", namespace),
+				slog.String("k8s-config-map", configmap),
+				slog.Any("object", res),
+			)
+			continue
+		}
+
+		slog.Info("Got watch event from K8S",
+			slog.String("k8s-namespace", namespace),
+			slog.String("k8s-config-map", configmap),
+			slog.Any("event-type", res.Type),
+		)
+
+		switch res.Type {
+		case watch.Added, watch.Modified:
+			c.notifyChange(ch, cm.Data[filePath])
+		default:
+			ch <- &viper.RemoteResponse{
+				Value: nil,
+				Error: errors.Errorf("unexpected event on config map: %v", res.Type),
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *cmConfigProvider) notifyChange(ch chan<- *viper.RemoteResponse, data string) {
+	ch <- &viper.RemoteResponse{
+		Value: []byte(data),
+		Error: nil,
+	}
+	if c.onConfigChange != nil {
+		c.onConfigChange()
+	}
 }
 
 func init() {

--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -20,7 +20,9 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +32,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 
 	"github.com/oxia-db/oxia/common/process"
+	oxiatime "github.com/oxia-db/oxia/common/time"
 )
 
 type cmConfigProvider struct {
@@ -81,56 +84,65 @@ func (c *cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.
 	namespace, configmap, _ := getNamespaceAndCmName(rp)
 
 	ch := make(chan *viper.RemoteResponse)
-	w, err := kubernetes.CoreV1().ConfigMaps(namespace).Watch(context.Background(), metav1.ListOptions{})
-	if err != nil {
-		slog.Error("Failed to setup watch on config map",
-			slog.String("k8s-namespace", namespace),
-			slog.String("k8s-config-map", configmap),
-			slog.Any("error", err))
-		ch <- &viper.RemoteResponse{Error: err}
-		close(ch)
-		return ch, nil
-	}
 
 	go process.DoWithLabels(context.Background(), map[string]string{
 		"component": "k8s-configmap-watch",
 	}, func() {
-		for res := range w.ResultChan() {
-			cm, ok := res.Object.(*corev1.ConfigMap)
-			if !ok {
-				slog.Warn("Got wrong type of object notification",
+		bo := oxiatime.NewBackOffWithInitialInterval(context.Background(), 1*time.Second)
+		_ = backoff.RetryNotify(func() error {
+			w, err := kubernetes.CoreV1().ConfigMaps(namespace).Watch(context.Background(), metav1.ListOptions{})
+			if err != nil {
+				return errors.Wrap(err, "failed to setup watch on config map")
+			}
+
+			bo.Reset()
+
+			for res := range w.ResultChan() {
+				cm, ok := res.Object.(*corev1.ConfigMap)
+				if !ok {
+					slog.Warn("Got wrong type of object notification",
+						slog.String("k8s-namespace", namespace),
+						slog.String("k8s-config-map", configmap),
+						slog.Any("object", res),
+					)
+					continue
+				}
+				if cm.Name != configmap {
+					continue
+				}
+
+				slog.Info("Got watch event from K8S",
 					slog.String("k8s-namespace", namespace),
 					slog.String("k8s-config-map", configmap),
-					slog.Any("object", res),
+					slog.Any("event-type", res.Type),
 				)
-				continue
-			}
-			if cm.Name != configmap {
-				continue
+
+				switch res.Type {
+				case watch.Added, watch.Modified:
+					ch <- &viper.RemoteResponse{
+						Value: []byte(cm.Data[filePath]),
+						Error: nil,
+					}
+					if c.onConfigChange != nil {
+						c.onConfigChange()
+					}
+				default:
+					ch <- &viper.RemoteResponse{
+						Value: nil,
+						Error: errors.Errorf("unexpected event on config map: %v", res.Type),
+					}
+				}
 			}
 
-			slog.Info("Got watch event from K8S",
+			return errors.New("K8S config map watch closed")
+		}, bo, func(err error, duration time.Duration) {
+			slog.Warn("K8S config map watch failed, reconnecting",
 				slog.String("k8s-namespace", namespace),
 				slog.String("k8s-config-map", configmap),
-				slog.Any("event-type", res.Type),
+				slog.Any("error", err),
+				slog.Duration("retry-after", duration),
 			)
-
-			switch res.Type {
-			case watch.Added, watch.Modified:
-				ch <- &viper.RemoteResponse{
-					Value: []byte(cm.Data[filePath]),
-					Error: nil,
-				}
-				if c.onConfigChange != nil {
-					c.onConfigChange()
-				}
-			default:
-				ch <- &viper.RemoteResponse{
-					Value: nil,
-					Error: errors.Errorf("unexpected event on config map: %v", res.Type),
-				}
-			}
-		}
+		})
 	})
 
 	return ch, nil

--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -120,20 +120,6 @@ func (c *cmConfigProvider) watchConfigMap(kubernetes k8s.Interface, namespace, c
 	}
 	defer w.Stop()
 
-	// Read the current state after establishing the watch to avoid
-	// missing updates that occurred between disconnect and re-watch.
-	getCtx, getCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer getCancel()
-	currentCm, err := kubernetes.CoreV1().ConfigMaps(namespace).Get(getCtx, configmap, metav1.GetOptions{})
-	if err != nil {
-		return errors.Wrap(err, "failed to get current config map after watch setup")
-	}
-	data, ok := currentCm.Data[filePath]
-	if !ok {
-		return errors.Errorf("key %q not found in config map %s/%s", filePath, namespace, configmap)
-	}
-	c.notifyChange(ch, data)
-
 	for res := range w.ResultChan() {
 		if res.Type == watch.Error {
 			return errors.Errorf("watch error: %v", res.Object)

--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -143,7 +143,13 @@ func (c *cmConfigProvider) watchConfigMap(kubernetes k8s.Interface, namespace, c
 
 		switch res.Type {
 		case watch.Added, watch.Modified:
-			c.notifyChange(ch, cm.Data[filePath])
+			ch <- &viper.RemoteResponse{
+				Value: []byte(cm.Data[filePath]),
+				Error: nil,
+			}
+			if c.onConfigChange != nil {
+				c.onConfigChange()
+			}
 		default:
 			ch <- &viper.RemoteResponse{
 				Value: nil,
@@ -153,16 +159,6 @@ func (c *cmConfigProvider) watchConfigMap(kubernetes k8s.Interface, namespace, c
 	}
 
 	return nil
-}
-
-func (c *cmConfigProvider) notifyChange(ch chan<- *viper.RemoteResponse, data string) {
-	ch <- &viper.RemoteResponse{
-		Value: []byte(data),
-		Error: nil,
-	}
-	if c.onConfigChange != nil {
-		c.onConfigChange()
-	}
 }
 
 func init() {

--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -143,9 +143,7 @@ func (c *cmConfigProvider) watchConfigMap(kubernetes k8s.Interface, namespace, c
 
 		switch res.Type {
 		case watch.Added, watch.Modified:
-			if configData, exists := cm.Data[filePath]; exists {
-				c.notifyChange(ch, configData)
-			}
+			c.notifyChange(ch, cm.Data[filePath])
 		default:
 			ch <- &viper.RemoteResponse{
 				Value: nil,

--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -122,11 +122,17 @@ func (c *cmConfigProvider) watchConfigMap(kubernetes k8s.Interface, namespace, c
 
 	// Read the current state after establishing the watch to avoid
 	// missing updates that occurred between disconnect and re-watch.
-	currentCm, err := kubernetes.CoreV1().ConfigMaps(namespace).Get(context.Background(), configmap, metav1.GetOptions{})
+	getCtx, getCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer getCancel()
+	currentCm, err := kubernetes.CoreV1().ConfigMaps(namespace).Get(getCtx, configmap, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "failed to get current config map after watch setup")
 	}
-	c.notifyChange(ch, currentCm.Data[filePath])
+	data, ok := currentCm.Data[filePath]
+	if !ok {
+		return errors.Errorf("key %q not found in config map %s/%s", filePath, namespace, configmap)
+	}
+	c.notifyChange(ch, data)
 
 	for res := range w.ResultChan() {
 		if res.Type == watch.Error {
@@ -151,7 +157,9 @@ func (c *cmConfigProvider) watchConfigMap(kubernetes k8s.Interface, namespace, c
 
 		switch res.Type {
 		case watch.Added, watch.Modified:
-			c.notifyChange(ch, cm.Data[filePath])
+			if configData, exists := cm.Data[filePath]; exists {
+				c.notifyChange(ch, configData)
+			}
 		default:
 			ch <- &viper.RemoteResponse{
 				Value: nil,

--- a/cmd/coordinator/viper_configmap.go
+++ b/cmd/coordinator/viper_configmap.go
@@ -90,14 +90,36 @@ func (c *cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.
 	}, func() {
 		bo := oxiatime.NewBackOffWithInitialInterval(context.Background(), 1*time.Second)
 		_ = backoff.RetryNotify(func() error {
-			w, err := kubernetes.CoreV1().ConfigMaps(namespace).Watch(context.Background(), metav1.ListOptions{})
+			w, err := kubernetes.CoreV1().ConfigMaps(namespace).Watch(
+				context.Background(),
+				metav1.SingleObject(metav1.ObjectMeta{Name: configmap, Namespace: namespace}),
+			)
 			if err != nil {
 				return errors.Wrap(err, "failed to setup watch on config map")
 			}
+			defer w.Stop()
 
 			bo.Reset()
 
+			// Read the current state after establishing the watch to avoid
+			// missing updates that occurred between disconnect and re-watch.
+			currentCm, err := kubernetes.CoreV1().ConfigMaps(namespace).Get(context.Background(), configmap, metav1.GetOptions{})
+			if err != nil {
+				return errors.Wrap(err, "failed to get current config map after watch setup")
+			}
+			ch <- &viper.RemoteResponse{
+				Value: []byte(currentCm.Data[filePath]),
+				Error: nil,
+			}
+			if c.onConfigChange != nil {
+				c.onConfigChange()
+			}
+
 			for res := range w.ResultChan() {
+				if res.Type == watch.Error {
+					return errors.Errorf("watch error: %v", res.Object)
+				}
+
 				cm, ok := res.Object.(*corev1.ConfigMap)
 				if !ok {
 					slog.Warn("Got wrong type of object notification",
@@ -105,9 +127,6 @@ func (c *cmConfigProvider) WatchChannel(rp viper.RemoteProvider) (<-chan *viper.
 						slog.String("k8s-config-map", configmap),
 						slog.Any("object", res),
 					)
-					continue
-				}
-				if cm.Name != configmap {
 					continue
 				}
 


### PR DESCRIPTION
### Motivation

The K8S API server closes watches after a server-side timeout. When this happened, the `k8s-configmap-watch` goroutine silently exited with no log and no reconnection, permanently stopping ConfigMap change detection until a pod restart.

### Modification

- Wrap the K8S watch loop with `backoff.RetryNotify` for automatic reconnection with exponential backoff
- Reset backoff after each successful watch connection
- Log a warning with error details and retry duration on every reconnect attempt
- Move watch creation inside the goroutine so it can be re-established on each retry