### PR TITLE
Reduce default memtable size to 4MB and make it configurable

### DIFF
--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -73,8 +73,7 @@ func init() {
 	Cmd.Flags().StringVar(&storageDatabase.Dir, "data-dir", "./data/db", "Directory where to store data")
 	Cmd.Flags().Int64Var(&storageDatabase.ReadCacheSizeMB, "db-cache-size-mb", kvstore.DefaultFactoryOptions.CacheSizeMB,
 		"Max size of the shared DB cache")
-	Cmd.Flags().Int64Var(&storageDatabase.MemTableSizeMB, "db-memtable-size-mb", kvstore.DefaultFactoryOptions.MemTableSizeMB,
-		"Size of each memtable in megabytes")
+
 
 	publicAuth := &dataServerOptions.Server.Public.Auth
 	Cmd.Flags().StringVar(&publicAuth.Provider, "auth-provider-name", "", "Authentication provider name. supported: oidc")

--- a/cmd/server/cmd.go
+++ b/cmd/server/cmd.go
@@ -73,6 +73,8 @@ func init() {
 	Cmd.Flags().StringVar(&storageDatabase.Dir, "data-dir", "./data/db", "Directory where to store data")
 	Cmd.Flags().Int64Var(&storageDatabase.ReadCacheSizeMB, "db-cache-size-mb", kvstore.DefaultFactoryOptions.CacheSizeMB,
 		"Max size of the shared DB cache")
+	Cmd.Flags().Int64Var(&storageDatabase.MemTableSizeMB, "db-memtable-size-mb", kvstore.DefaultFactoryOptions.MemTableSizeMB,
+		"Size of each memtable in megabytes")
 
 	publicAuth := &dataServerOptions.Server.Public.Auth
 	Cmd.Flags().StringVar(&publicAuth.Provider, "auth-provider-name", "", "Authentication provider name. supported: oidc")

--- a/cmd/standalone/cmd.go
+++ b/cmd/standalone/cmd.go
@@ -68,8 +68,7 @@ func init() {
 	Cmd.Flags().StringVar(&storageOptions.Database.Dir, "data-dir", "./data/db", "Directory where to store data")
 	Cmd.Flags().Int64Var(&storageOptions.Database.ReadCacheSizeMB, "db-cache-size-mb", kvstore.DefaultFactoryOptions.CacheSizeMB,
 		"Max size of the shared DB cache")
-	Cmd.Flags().Int64Var(&storageOptions.Database.MemTableSizeMB, "db-memtable-size-mb", kvstore.DefaultFactoryOptions.MemTableSizeMB,
-		"Size of each memtable in megabytes")
+
 
 	// Convert time.Duration to option.Duration after flag parsing
 	Cmd.PreRun = func(*cobra.Command, []string) {

--- a/cmd/standalone/cmd.go
+++ b/cmd/standalone/cmd.go
@@ -68,6 +68,8 @@ func init() {
 	Cmd.Flags().StringVar(&storageOptions.Database.Dir, "data-dir", "./data/db", "Directory where to store data")
 	Cmd.Flags().Int64Var(&storageOptions.Database.ReadCacheSizeMB, "db-cache-size-mb", kvstore.DefaultFactoryOptions.CacheSizeMB,
 		"Max size of the shared DB cache")
+	Cmd.Flags().Int64Var(&storageOptions.Database.MemTableSizeMB, "db-memtable-size-mb", kvstore.DefaultFactoryOptions.MemTableSizeMB,
+		"Size of each memtable in megabytes")
 
 	// Convert time.Duration to option.Duration after flag parsing
 	Cmd.PreRun = func(*cobra.Command, []string) {

--- a/oxiad/dataserver/database/kvstore/kv.go
+++ b/oxiad/dataserver/database/kvstore/kv.go
@@ -136,19 +136,21 @@ type KV interface {
 	Delete() error
 }
 type FactoryOptions struct {
-	DataDir     string
-	CacheSizeMB int64
-	UseWAL      bool
-	SyncData    bool
-	KvTrap      *KvTrap
+	DataDir        string
+	CacheSizeMB    int64
+	MemTableSizeMB int64
+	UseWAL         bool
+	SyncData       bool
+	KvTrap         *KvTrap
 }
 
 var DefaultFactoryOptions = &FactoryOptions{
-	DataDir:     "data",
-	CacheSizeMB: 100,
-	UseWAL:      true,
-	SyncData:    true,
-	KvTrap:      nil,
+	DataDir:        "data",
+	CacheSizeMB:    100,
+	MemTableSizeMB: 4,
+	UseWAL:         true,
+	SyncData:       true,
+	KvTrap:         nil,
 }
 
 func (fo *FactoryOptions) EnsureDefaults() {
@@ -158,6 +160,10 @@ func (fo *FactoryOptions) EnsureDefaults() {
 
 	if fo.CacheSizeMB == 0 {
 		fo.CacheSizeMB = DefaultFactoryOptions.CacheSizeMB
+	}
+
+	if fo.MemTableSizeMB == 0 {
+		fo.MemTableSizeMB = DefaultFactoryOptions.MemTableSizeMB
 	}
 }
 

--- a/oxiad/dataserver/database/kvstore/kv_pebble.go
+++ b/oxiad/dataserver/database/kvstore/kv_pebble.go
@@ -240,7 +240,7 @@ func newKVPebble(factory *PebbleFactory, namespace string, shardId int64, keySor
 	)
 	pbOptions := &pebble.Options{
 		Cache:        factory.cache,
-		MemTableSize: 32 * 1024 * 1024,
+		MemTableSize: uint64(factory.options.MemTableSizeMB) * 1024 * 1024,
 		Levels:       levelOptions,
 		FS:           vfs.Default,
 		DisableWAL:   !factory.options.UseWAL,

--- a/oxiad/dataserver/option/option.go
+++ b/oxiad/dataserver/option/option.go
@@ -127,6 +127,7 @@ func (*WALOptions) Validate() error {
 type DatabaseOptions struct {
 	Dir             string `yaml:"dir" json:"dir" jsonschema:"description=Directory path for storing database files,example=./data/db"`
 	ReadCacheSizeMB int64  `yaml:"readCacheSizeMB,omitempty" json:"readCacheSizeMB,omitempty" jsonschema:"description=Size of read cache in megabytes for performance optimization,default=100,minimum=1"`
+	MemTableSizeMB  int64  `yaml:"memTableSizeMB,omitempty" json:"memTableSizeMB,omitempty" jsonschema:"description=Size of each memtable in megabytes,default=4,minimum=1"`
 }
 
 func (do *DatabaseOptions) WithDefault() {
@@ -135,6 +136,9 @@ func (do *DatabaseOptions) WithDefault() {
 	}
 	if do.ReadCacheSizeMB == 0 {
 		do.ReadCacheSizeMB = 100
+	}
+	if do.MemTableSizeMB == 0 {
+		do.MemTableSizeMB = 4
 	}
 }
 func (*DatabaseOptions) Validate() error {

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -76,10 +76,11 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 
 	storage := &options.Storage
 	kvFactory, err := kvstore.NewPebbleKVFactory(&kvstore.FactoryOptions{
-		DataDir:     storage.Database.Dir,
-		CacheSizeMB: storage.Database.ReadCacheSizeMB,
-		UseWAL:      false, // WAL is kept outside the KV store
-		SyncData:    false, // WAL is kept outside the KV store
+		DataDir:        storage.Database.Dir,
+		CacheSizeMB:    storage.Database.ReadCacheSizeMB,
+		MemTableSizeMB: storage.Database.MemTableSizeMB,
+		UseWAL:         false, // WAL is kept outside the KV store
+		SyncData:       false, // WAL is kept outside the KV store
 	})
 	if err != nil {
 		return nil, err

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -86,10 +86,11 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 
 	storageOptions := config.DataServerOptions.Storage
 	kvOptions := kvstore.FactoryOptions{
-		DataDir:     storageOptions.Database.Dir,
-		UseWAL:      false, // WAL is kept outside the KV store
-		SyncData:    false, // WAL is kept outside the KV store
-		CacheSizeMB: storageOptions.Database.ReadCacheSizeMB,
+		DataDir:        storageOptions.Database.Dir,
+		UseWAL:         false, // WAL is kept outside the KV store
+		SyncData:       false, // WAL is kept outside the KV store
+		CacheSizeMB:    storageOptions.Database.ReadCacheSizeMB,
+		MemTableSizeMB: storageOptions.Database.MemTableSizeMB,
 	}
 	s.walFactory = wal.NewWalFactory(&wal.FactoryOptions{
 		BaseWalDir:  storageOptions.WAL.Dir,


### PR DESCRIPTION
### Motivation

The Pebble memtable size was hardcoded to 32MB, which is 8x higher than Pebble's own default of 4MB. This increases memory usage unnecessarily, especially when running many shards. Making it configurable allows operators to tune it for their workloads.

### Modification

- Reduced default memtable size from 32MB to 4MB (Pebble's default)
- Added `MemTableSizeMB` to `FactoryOptions` with a default of 4MB
- Added `memTableSizeMB` field to `DatabaseOptions` for YAML configuration
- Added `--db-memtable-size-mb` CLI flag to both `server` and `standalone` commands
- Wired the configurable value through to Pebble options in `server.go` and `standalone.go`