### PR TITLE
fix: notifications trimmer aborting binary search on offset gaps

### DIFF
--- a/oxiad/dataserver/controller/statemachine/notifications_gap_test.go
+++ b/oxiad/dataserver/controller/statemachine/notifications_gap_test.go
@@ -1,0 +1,102 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statemachine
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+	stdtime "time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	oxiatime "github.com/oxia-db/oxia/common/time"
+	"github.com/oxia-db/oxia/oxiad/dataserver/database"
+	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+)
+
+func TestNotificationsTrimmer_GapFromControlRequests(t *testing.T) {
+	clock := &oxiatime.MockedClock{}
+
+	factory, err := kvstore.NewPebbleKVFactory(kvstore.NewFactoryOptionsForTest(t))
+	assert.NoError(t, err)
+	defer factory.Close()
+
+	db, err := database.NewDB(
+		constant.DefaultNamespace, 1, factory,
+		proto.KeySortingType_NATURAL,
+		10*stdtime.Millisecond, clock,
+	)
+	assert.NoError(t, err)
+	defer db.Close()
+
+	controlOffsets := map[int64]bool{5: true, 12: true, 18: true}
+	for offset := int64(0); offset < 25; offset++ {
+		var proposal Proposal
+		if controlOffsets[offset] {
+			proposal = NewControlProposal(offset, &proto.ControlRequest{
+				Value: &proto.ControlRequest_RecordChecksum{
+					RecordChecksum: &proto.RecordChecksumRequest{},
+				},
+			})
+		} else {
+			proposal = NewWriteProposal(offset, &proto.WriteRequest{
+				Puts: []*proto.PutRequest{{
+					Key:   fmt.Sprintf("key-%d", offset),
+					Value: []byte("v"),
+				}},
+			})
+		}
+
+		entryValue := &proto.LogEntryValue{}
+		proposal.ToLogEntry(entryValue)
+		value, err := entryValue.MarshalVT()
+		assert.NoError(t, err)
+
+		entry := &proto.LogEntry{
+			Term:      1,
+			Offset:    offset,
+			Value:     value,
+			Timestamp: uint64(offset),
+		}
+		_, err = ApplyLogEntry(db, entry, database.NoOpCallback)
+		assert.NoError(t, err)
+	}
+
+	clock.Set(30)
+	assert.Eventually(t, func() bool {
+		nb, err := db.ReadNextNotifications(context.Background(), 0)
+		if err != nil {
+			return false
+		}
+		got := make([]int64, 0, len(nb))
+		for _, b := range nb {
+			got = append(got, b.Offset)
+		}
+		return reflect.DeepEqual(got, []int64{21, 22, 23, 24})
+	}, 10*stdtime.Second, 500*stdtime.Millisecond)
+
+	clock.Set(100)
+	assert.Eventually(t, func() bool {
+		nb, err := db.ReadNextNotifications(context.Background(), 0)
+		if err != nil {
+			return false
+		}
+		return len(nb) == 0
+	}, 10*stdtime.Second, 500*stdtime.Millisecond)
+}

--- a/oxiad/dataserver/database/notifications_trimmer.go
+++ b/oxiad/dataserver/database/notifications_trimmer.go
@@ -210,6 +210,10 @@ func (t *notificationsTrimmer) binarySearch(firstOffset, lastOffset int64, cutof
 		midProbe := firstOffset + (lastOffset-firstOffset+1)/2
 
 		actualMid, tsMid, err := t.readFrom(midProbe)
+		// No notification exists in [midProbe, lastOffset]: either the ceiling
+		// lookup found no entry at all (e.g. concurrent FilterDBForSplit deleted
+		// the rest of the namespace), or it landed on an offset above our
+		// current upper bound. In both cases we shrink the window and retry.
 		if errors.Is(err, kvstore.ErrKeyNotFound) || (err == nil && actualMid > lastOffset) {
 			lastOffset = midProbe - 1
 			continue

--- a/oxiad/dataserver/database/notifications_trimmer.go
+++ b/oxiad/dataserver/database/notifications_trimmer.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -26,6 +27,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
 
 	"github.com/oxia-db/oxia/common/concurrent"
+	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/process"
 	time2 "github.com/oxia-db/oxia/common/time"
 
@@ -115,14 +117,21 @@ func (t *notificationsTrimmer) trimNotifications() error {
 		slog.Duration("retention-time", t.notificationsRetentionTime),
 	)
 
-	if last == -1 {
+	if last == constant.I64NegativeOne {
 		return nil
 	}
 
 	cutoffTime := t.clock.Now().Add(-t.notificationsRetentionTime)
 
-	// Check if first entry has expired
-	tsFirst, err := t.readAt(first)
+	_, tsFirst, err := t.readFrom(first)
+	if errors.Is(err, kvstore.ErrKeyNotFound) {
+		t.log.Warn(
+			"First notification entry disappeared after range scan",
+			slog.Int64("first-offset", first),
+			slog.Int64("last-offset", last),
+		)
+		return nil
+	}
 	if err != nil {
 		return err
 	}
@@ -134,7 +143,6 @@ func (t *notificationsTrimmer) trimNotifications() error {
 	)
 
 	if cutoffTime.Before(tsFirst) {
-		// First entry has not expired. We don't need to check more
 		return nil
 	}
 
@@ -168,12 +176,12 @@ func (t *notificationsTrimmer) trimNotifications() error {
 func (t *notificationsTrimmer) getFirstLast() (first, last int64, err error) {
 	it1, err := t.kv.KeyRangeScan(firstNotificationKey, lastNotificationKey, kvstore.ShowInternalKeys)
 	if err != nil {
-		return -1, -1, err
+		return constant.I64NegativeOne, constant.I64NegativeOne, err
 	}
 	defer it1.Close()
 	if !it1.Valid() {
 		// There are no entries in DB
-		return -1, -1, nil
+		return constant.I64NegativeOne, constant.I64NegativeOne, nil
 	}
 
 	if first, err = parseNotificationKey(it1.Key()); err != nil {
@@ -182,12 +190,12 @@ func (t *notificationsTrimmer) getFirstLast() (first, last int64, err error) {
 
 	it2, err := t.kv.KeyRangeScanReverse(firstNotificationKey, lastNotificationKey, kvstore.ShowInternalKeys)
 	if err != nil {
-		return -1, -1, err
+		return constant.I64NegativeOne, constant.I64NegativeOne, err
 	}
 	defer it2.Close()
 	if !it2.Valid() {
 		// There are no entries in DB
-		return -1, -1, nil
+		return constant.I64NegativeOne, constant.I64NegativeOne, nil
 	}
 
 	if last, err = parseNotificationKey(it2.Key()); err != nil {
@@ -197,43 +205,48 @@ func (t *notificationsTrimmer) getFirstLast() (first, last int64, err error) {
 	return first, last, nil
 }
 
-// Perform binary search to find the highest entry that falls within the cutoff time.
 func (t *notificationsTrimmer) binarySearch(firstOffset, lastOffset int64, cutoffTime time.Time) (int64, error) {
 	for firstOffset < lastOffset {
-		med := (firstOffset + lastOffset) / 2
-		// Take the ceiling
-		if (firstOffset+lastOffset)%2 > 0 {
-			med++
+		midProbe := firstOffset + (lastOffset-firstOffset+1)/2
+
+		actualMid, tsMid, err := t.readFrom(midProbe)
+		if errors.Is(err, kvstore.ErrKeyNotFound) || (err == nil && actualMid > lastOffset) {
+			lastOffset = midProbe - 1
+			continue
 		}
-		tsMed, err := t.readAt(med)
 		if err != nil {
-			return -1, err
+			return constant.I64NegativeOne, err
 		}
 
-		if cutoffTime.Before(tsMed) {
-			// The entry at position `med` has not expired yet
-			lastOffset = med - 1
+		if cutoffTime.Before(tsMid) {
+			lastOffset = midProbe - 1
 		} else {
-			// The entry has expired
-			firstOffset = med
+			firstOffset = actualMid
 		}
 	}
 
 	return firstOffset, nil
 }
 
-func (t *notificationsTrimmer) readAt(offset int64) (time.Time, error) {
-	_, res, closer, err := t.kv.Get(notificationKey(offset), kvstore.ComparisonEqual, kvstore.ShowInternalKeys)
+func (t *notificationsTrimmer) readFrom(offset int64) (int64, time.Time, error) {
+	returnedKey, value, closer, err := t.kv.Get(notificationKey(offset), kvstore.ComparisonCeiling, kvstore.ShowInternalKeys)
 	if err != nil {
-		return time.Time{}, err
+		return constant.I64NegativeOne, time.Time{}, err
 	}
-
 	defer closer.Close()
 
-	nb := &proto.NotificationBatch{}
-	if err := pb.Unmarshal(res, nb); err != nil {
-		return time.Time{}, errors.Wrap(err, "failed to Deserialize notification batch")
+	if !strings.HasPrefix(returnedKey, notificationsPrefix+"/") {
+		return constant.I64NegativeOne, time.Time{}, kvstore.ErrKeyNotFound
 	}
 
-	return time.UnixMilli(int64(nb.Timestamp)), nil
+	actualOffset, err := parseNotificationKey(returnedKey)
+	if err != nil {
+		return constant.I64NegativeOne, time.Time{}, err
+	}
+
+	nb := &proto.NotificationBatch{}
+	if err := pb.Unmarshal(value, nb); err != nil {
+		return constant.I64NegativeOne, time.Time{}, errors.Wrap(err, "failed to deserialize notification batch")
+	}
+	return actualOffset, time.UnixMilli(int64(nb.Timestamp)), nil
 }

--- a/oxiad/dataserver/database/notifications_trimmer.go
+++ b/oxiad/dataserver/database/notifications_trimmer.go
@@ -211,8 +211,7 @@ func (t *notificationsTrimmer) binarySearch(firstOffset, lastOffset int64, cutof
 
 		actualMid, tsMid, err := t.readFrom(midProbe)
 		// No notification exists in [midProbe, lastOffset]: either the ceiling
-		// lookup found no entry at all (e.g. concurrent FilterDBForSplit deleted
-		// the rest of the namespace), or it landed on an offset above our
+		// lookup found no entry at all or it landed on an offset above our
 		// current upper bound. In both cases we shrink the window and retry.
 		if errors.Is(err, kvstore.ErrKeyNotFound) || (err == nil && actualMid > lastOffset) {
 			lastOffset = midProbe - 1


### PR DESCRIPTION
### Motivation

The notifications trimmer was repeatedly failing with `failed to perform binary search: oxia: key not found` on every shard of namespaces that have `FEATURE_DB_CHECKSUM` enabled (seen in production on `bookkeeper` and `broker`). Every checksum scheduler tick introduces a hole in the notification offset sequence that `binarySearch` cannot handle, so expired notifications are never trimmed.

Root cause: `state_machine.ApplyLogEntry` does not call `db.ProcessWrite` for `LogEntryValue_ControlRequest` entries (`FeatureEnable`, `RecordChecksum`). Those entries still consume WAL offsets, so no notification key is written at those offsets. `binarySearch` probed midpoints with `ComparisonEqual` and aborted as soon as a probe landed in a gap.

### Modification

- Add `notificationsTrimmer.readFrom(offset)` — a ceiling lookup that returns the first notification entry at or after the given offset, transparently skipping over gaps in the sparse notification offset sequence.
- Update `binarySearch` to probe via `readFrom`; when the ceiling-resolved offset lands above the current upper bound (i.e. no notification exists in `[midProbe, lastOffset]`), it shrinks the window via `lastOffset = midProbe - 1` and continues. Termination is preserved because every branch strictly narrows `[firstOffset, lastOffset]`.
- Rewrite the first-entry expiry check in `trimNotifications` to use `readFrom`, with a `WARN` log if it returns `ErrKeyNotFound` (only possible via a concurrent delete after `getFirstLast`).
- Add `TestNotificationsTrimmer_GapFromControlRequests` in the `statemachine` package. The test drives the real WAL path via `ApplyLogEntry` with a mix of `WriteProposal` and `ControlProposal` (`RecordChecksum`) entries to produce production-shaped gaps, then asserts the trimmer (a) trims a partial range when some entries are still within retention, and (b) trims every remaining notification once the clock advances past the full retention window. Verified to reproduce the exact production error on the unpatched code.