### PR TITLE
perf: use vtproto UnmarshalVT for NotificationBatch in trimmer

### DIFF
--- a/oxiad/dataserver/database/notifications_trimmer.go
+++ b/oxiad/dataserver/database/notifications_trimmer.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	pb "google.golang.org/protobuf/proto"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
 
@@ -248,7 +247,7 @@ func (t *notificationsTrimmer) readFrom(offset int64) (int64, time.Time, error) 
 	}
 
 	nb := &proto.NotificationBatch{}
-	if err := pb.Unmarshal(value, nb); err != nil {
+	if err := nb.UnmarshalVT(value); err != nil {
 		return constant.I64NegativeOne, time.Time{}, errors.Wrap(err, "failed to deserialize notification batch")
 	}
 	return actualOffset, time.UnixMilli(int64(nb.Timestamp)), nil


### PR DESCRIPTION
### Motivation

The codebase uses vtproto (generated `UnmarshalVT` methods) throughout for decoding protobuf messages, because they are lower-allocation and faster than the reflective `google.golang.org/protobuf/proto.Unmarshal`. A Copilot review on #1018 pointed out that `notificationsTrimmer.readFrom` still used `pb.Unmarshal`, and `readFrom` is on the trimmer's binary-search hot path, so the win is worth taking.

### Modification

- `oxiad/dataserver/database/notifications_trimmer.go`: `readFrom` now calls `nb.UnmarshalVT(value)` instead of `pb.Unmarshal(value, nb)`. Dropped the now-unused `pb "google.golang.org/protobuf/proto"` import.