### PR TITLE
fix: publish namespace status during initial placement

### DIFF
--- a/oxiad/coordinator/util/cluster_updates.go
+++ b/oxiad/coordinator/util/cluster_updates.go
@@ -50,6 +50,10 @@ func ApplyClusterChanges(config *model.ClusterConfig, status *model.ClusterStatu
 			Shards:            map[int64]model.ShardMetadata{},
 			ReplicationFactor: nc.ReplicationFactor,
 		}
+		// Publish the namespace into status *before* placing shards so that
+		// each per-shard ensembleSupplier call sees the placements made earlier
+		// in this same init cycle.
+		status.Namespaces[nc.Name] = nss
 
 		for _, shard := range sharding.GenerateShards(status.ShardIdGenerator, nc.InitialShardCount) {
 			var esm []model.Server
@@ -68,12 +72,10 @@ func ApplyClusterChanges(config *model.ClusterConfig, status *model.ClusterStatu
 				},
 			}
 
-			nss.Shards[shard.Id] = shardMetadata
+			status.Namespaces[nc.Name].Shards[shard.Id] = shardMetadata
 			status.ServerIdx = (status.ServerIdx + nc.ReplicationFactor) % uint32(len(config.Servers))
 			shardsToAdd[shard.Id] = nc.Name
 		}
-		status.Namespaces[nc.Name] = nss
-
 		status.ShardIdGenerator += int64(nc.InitialShardCount)
 	}
 

--- a/oxiad/coordinator/util/cluster_updates_test.go
+++ b/oxiad/coordinator/util/cluster_updates_test.go
@@ -25,6 +25,79 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 )
 
+// loadAwareEnsembleSupplier picks the `nc.ReplicationFactor` servers that
+// currently hold the fewest ensemble slots across all already-placed shards in
+// `cs`. It is used to verify that ApplyClusterChanges publishes intermediate
+// shard placements into status during the init loop, so that successive
+// per-shard ensemble selections within the same init cycle observe each
+// other's choices. Without that publication every call sees an empty cluster
+// and returns the same servers, producing wildly uneven initial placement.
+func loadAwareEnsembleSupplier(servers []model.Server) func(*model.NamespaceConfig, *model.ClusterStatus) ([]model.Server, error) {
+	return func(nc *model.NamespaceConfig, cs *model.ClusterStatus) ([]model.Server, error) {
+		load := make(map[string]int, len(servers))
+		for _, s := range servers {
+			load[s.Internal] = 0
+		}
+		for _, ns := range cs.Namespaces {
+			for _, sh := range ns.Shards {
+				for _, m := range sh.Ensemble {
+					load[m.Internal]++
+				}
+			}
+		}
+		ranked := make([]model.Server, len(servers))
+		copy(ranked, servers)
+		sort.SliceStable(ranked, func(i, j int) bool {
+			return load[ranked[i].Internal] < load[ranked[j].Internal]
+		})
+		return ranked[:nc.ReplicationFactor], nil
+	}
+}
+
+// TestClientUpdates_InitialPlacementSeesPriorShards verifies that the
+// per-shard ensembleSupplier called by ApplyClusterChanges during a new
+// namespace's bootstrap can observe shards that were placed earlier in the
+// same call. Regression for an upstream bug where the new NamespaceStatus was
+// only assigned into status.Namespaces *after* the GenerateShards loop, so
+// every shard was selected against an empty cluster snapshot, leading to
+// pseudo-random initial placement that immediately tripped the count-based
+// load-balancer once the cluster came up.
+func TestClientUpdates_InitialPlacementSeesPriorShards(t *testing.T) {
+	servers := []model.Server{s1, s2, s3, s4}
+	const shardCount = 16
+	const rf = 3
+
+	status := model.NewClusterStatus()
+	_, _ = ApplyClusterChanges(&model.ClusterConfig{
+		Namespaces: []model.NamespaceConfig{{
+			Name:              "ns-1",
+			InitialShardCount: shardCount,
+			ReplicationFactor: rf,
+		}},
+		Servers: servers,
+	}, status, loadAwareEnsembleSupplier(servers))
+
+	slots := map[string]int{}
+	for _, s := range servers {
+		slots[s.Internal] = 0
+	}
+	for _, sh := range status.Namespaces["ns-1"].Shards {
+		assert.Len(t, sh.Ensemble, rf)
+		for _, m := range sh.Ensemble {
+			slots[m.Internal]++
+		}
+	}
+
+	// shardCount * rf == 48 ensemble slots distributed across 4 servers ⇒
+	// exactly 12 slots per server when each ensembleSupplier call sees prior
+	// placements.
+	expected := shardCount * rf / len(servers)
+	for _, s := range servers {
+		assert.Equal(t, expected, slots[s.Internal],
+			"server %s should hold exactly %d ensemble slots", s.Internal, expected)
+	}
+}
+
 var (
 	s1 = model.Server{Public: "s1:6648", Internal: "s1:6649"}
 	s2 = model.Server{Public: "s2:6648", Internal: "s2:6649"}


### PR DESCRIPTION
During a load test of Oxia, I ran into some rebalance storms. The proper workaround for me was to warm up easier -  create the shards, then wait before starting to blast the system with operations.

I was confused why rebalances were happening when I'm simply creating a few shards from scratch. This led me to this bug, where the `ensembleSupplier` would not get an ever-updating clusterStatus (which it expects to pass to `GroupingShardsNodeByStatus` in the one prod code path). By passing an empty clusterStatus as it did, the initial load balancing placement could never work.