### PR TITLE
fix: pin Alpine to 3.22.3 to resolve OpenSSL CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     make
 
-FROM alpine:3.22
+FROM alpine:3.22.3
 
 RUN apk add --no-cache bash bash-completion jq
 RUN apk upgrade --no-cache


### PR DESCRIPTION
## Summary
- Pin Docker runtime base image from `alpine:3.22` to `alpine:3.22.3`
- Alpine 3.22.3 includes OpenSSL 3.6.2 which fixes all 7 open Trivy code-scanning alerts (14 total, each duplicated across two scan targets):
  - **HIGH**: CVE-2026-28390 — DoS via NULL pointer dereference in CMS EnvelopedData
  - **MEDIUM**: CVE-2026-31790 — info disclosure from uninitialized memory via invalid RSA key
  - **LOW**: CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-31789
- Pinning the patch version also ensures GHA Docker build cache invalidation picks up the patched base image

## Test plan
- [ ] Docker image builds successfully
- [ ] Trivy scan shows no open OpenSSL CVEs after merge