### PR TITLE
security: redact bearer tokens in debug log messages

### DIFF
--- a/oxiad/common/rpc/auth/interceptor.go
+++ b/oxiad/common/rpc/auth/interceptor.go
@@ -98,8 +98,18 @@ func validateTokenWithContext(ctx context.Context, provider AuthenticationProvid
 	if userName, err = provider.Authenticate(ctx, token); err != nil {
 		slog.Debug("Failed to authenticate token",
 			slog.String("peer", peerMeta.Addr.String()),
-			slog.String("token", token))
+			slog.String("token", redactToken(token)))
 		return "", err
 	}
 	return userName, nil
+}
+
+// redactToken returns a redacted version of a token for safe logging.
+// Only the last 8 characters are preserved; the rest is replaced with "***".
+func redactToken(token string) string {
+	const suffixLen = 8
+	if len(token) <= suffixLen {
+		return "***"
+	}
+	return "***" + token[len(token)-suffixLen:]
 }

--- a/oxiad/common/rpc/auth/interceptor.go
+++ b/oxiad/common/rpc/auth/interceptor.go
@@ -105,11 +105,14 @@ func validateTokenWithContext(ctx context.Context, provider AuthenticationProvid
 }
 
 // redactToken returns a redacted version of a token for safe logging.
-// Only the last 8 characters are preserved; the rest is replaced with "***".
+// For tokens longer than 8 characters, at most the last 8 characters are
+// preserved and the rest is replaced with "[REDACTED]". Tokens of 8 characters
+// or fewer are fully redacted to "[REDACTED]".
 func redactToken(token string) string {
 	const suffixLen = 8
+	const prefix = "[REDACTED]"
 	if len(token) <= suffixLen {
-		return "***"
+		return prefix
 	}
-	return "***" + token[len(token)-suffixLen:]
+	return prefix + token[len(token)-suffixLen:]
 }

--- a/oxiad/common/rpc/auth/interceptor_test.go
+++ b/oxiad/common/rpc/auth/interceptor_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedactToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		token    string
+		expected string
+	}{
+		{"empty", "", "***"},
+		{"short", "abc", "***"},
+		{"exactly8", "12345678", "***"},
+		{"9chars", "123456789", "***23456789"},
+		{"long token", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature", "***ignature"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := redactToken(tt.token)
+			assert.Equal(t, tt.expected, result)
+			// Ensure the original token is never fully present in the result
+			if len(tt.token) > 8 {
+				assert.NotContains(t, result, tt.token)
+			}
+		})
+	}
+}

--- a/oxiad/common/rpc/auth/interceptor_test.go
+++ b/oxiad/common/rpc/auth/interceptor_test.go
@@ -26,20 +26,19 @@ func TestRedactToken(t *testing.T) {
 		token    string
 		expected string
 	}{
-		{"empty", "", "***"},
-		{"short", "abc", "***"},
-		{"exactly8", "12345678", "***"},
-		{"9chars", "123456789", "***23456789"},
-		{"long token", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature", "***ignature"},
+		{"empty", "", "[REDACTED]"},
+		{"short", "abc", "[REDACTED]"},
+		{"exactly8", "12345678", "[REDACTED]"},
+		{"9chars", "123456789", "[REDACTED]23456789"},
+		{"starts with redaction prefix", "[REDACTED]123456789", "[REDACTED]23456789"},
+		{"long token", "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.payload.signature", "[REDACTED]ignature"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := redactToken(tt.token)
 			assert.Equal(t, tt.expected, result)
-			// Ensure the original token is never fully present in the result
-			if len(tt.token) > 8 {
-				assert.NotContains(t, result, tt.token)
-			}
+			// Ensure the redacted output never equals the original token
+			assert.NotEqual(t, tt.token, result, "redacted output must differ from original token")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Replace plaintext token logging in the auth interceptor with a redacted form (`***` + last 8 chars)
- Add `redactToken()` helper function
- Add `TestRedactToken` with coverage for empty, short, and long tokens

Previously, the full JWT token was logged at DEBUG level when authentication failed, exposing credentials in application logs.

**GHSA:** [GHSA-pm7q-rjjx-979p](https://github.com/oxia-db/oxia/security/advisories/GHSA-pm7q-rjjx-979p)

## Test plan
- [ ] `go test -v -run TestRedactToken ./oxiad/common/rpc/auth/...`
- [ ] Existing auth tests pass
- [ ] Verify token is not visible in debug log output