### PR TITLE
security: fix race condition in session heartbeat handling

### DIFF
--- a/oxiad/dataserver/controller/lead/session.go
+++ b/oxiad/dataserver/controller/lead/session.go
@@ -110,7 +110,11 @@ func (s *session) heartbeat() {
 	s.Lock()
 	defer s.Unlock()
 	if s.heartbeatCh != nil {
-		s.heartbeatCh <- true
+		select {
+		case s.heartbeatCh <- true:
+		default:
+			// A heartbeat is already pending in the buffer; skip.
+		}
 	}
 }
 

--- a/oxiad/dataserver/controller/lead/session_manager.go
+++ b/oxiad/dataserver/controller/lead/session_manager.go
@@ -195,8 +195,8 @@ func (sm *sessionManager) getSession(sessionId int64) (*session, error) {
 
 func (sm *sessionManager) KeepAlive(sessionId int64) error {
 	sm.RLock()
+	defer sm.RUnlock()
 	s, err := sm.getSession(sessionId)
-	sm.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/oxiad/dataserver/controller/lead/session_test.go
+++ b/oxiad/dataserver/controller/lead/session_test.go
@@ -1,0 +1,108 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lead
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSession_Heartbeat_NonBlocking(t *testing.T) {
+	s := &session{
+		heartbeatCh: make(chan bool, 1),
+		log:         slog.Default(),
+	}
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+
+	// Fill the heartbeat channel buffer
+	s.heartbeatCh <- true
+
+	// Second heartbeat should not block (non-blocking select)
+	done := make(chan struct{})
+	go func() {
+		s.heartbeat()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: heartbeat returned without blocking
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat() blocked when channel buffer was full")
+	}
+}
+
+func TestSession_Heartbeat_AfterClose(t *testing.T) {
+	ch := make(chan bool, 1)
+	s := &session{
+		heartbeatCh: ch,
+		log:         slog.Default(),
+	}
+	s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+	s.latch.Add(1)
+
+	// Drain heartbeats using local reference (mirrors waitForHeartbeats pattern)
+	go func() {
+		defer s.latch.Done()
+		for range ch {
+		}
+	}()
+
+	s.close()
+	s.latch.Wait()
+
+	// Calling heartbeat after close should not panic
+	assert.NotPanics(t, func() {
+		s.heartbeat()
+	})
+}
+
+func TestSession_Heartbeat_ConcurrentCloseAndHeartbeat(t *testing.T) {
+	// Run many iterations to increase chance of hitting the race
+	for i := 0; i < 100; i++ {
+		ch := make(chan bool, 1)
+		s := &session{
+			heartbeatCh: ch,
+			log:         slog.Default(),
+		}
+		s.ctx, s.ctxCancel = context.WithCancel(context.Background())
+		s.latch.Add(1)
+
+		// Drain using local reference (mirrors waitForHeartbeats pattern)
+		go func() {
+			defer s.latch.Done()
+			for range ch {
+			}
+		}()
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.close()
+		}()
+		go func() {
+			defer wg.Done()
+			s.heartbeat()
+		}()
+		wg.Wait()
+		s.latch.Wait()
+	}
+}

--- a/oxiad/dataserver/controller/lead/session_test.go
+++ b/oxiad/dataserver/controller/lead/session_test.go
@@ -24,6 +24,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func drainChannel(ch <-chan bool) {
+	for range ch { //nolint:revive
+	}
+}
+
 func TestSession_Heartbeat_NonBlocking(t *testing.T) {
 	s := &session{
 		heartbeatCh: make(chan bool, 1),
@@ -61,8 +66,7 @@ func TestSession_Heartbeat_AfterClose(t *testing.T) {
 	// Drain heartbeats using local reference (mirrors waitForHeartbeats pattern)
 	go func() {
 		defer s.latch.Done()
-		for range ch {
-		}
+		drainChannel(ch)
 	}()
 
 	s.close()
@@ -88,20 +92,16 @@ func TestSession_Heartbeat_ConcurrentCloseAndHeartbeat(t *testing.T) {
 		// Drain using local reference (mirrors waitForHeartbeats pattern)
 		go func() {
 			defer s.latch.Done()
-			for range ch {
-			}
+			drainChannel(ch)
 		}()
 
 		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			s.close()
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		wg.Go(func() {
 			s.heartbeat()
-		}()
+		})
 		wg.Wait()
 		s.latch.Wait()
 	}


### PR DESCRIPTION
## Summary
- Change `heartbeat()` to use non-blocking `select` instead of blocking channel send
- Fix TOCTOU in `KeepAlive()` by holding `RLock` through the entire operation via `defer`
- Add tests: `TestSession_Heartbeat_NonBlocking`, `TestSession_Heartbeat_AfterClose`, `TestSession_Heartbeat_ConcurrentCloseAndHeartbeat`

Previously, rapid KeepAlive requests during session expiry could cause a server panic (`send on closed channel`) or deadlock (blocked send holding the mutex).

**GHSA:** [GHSA-5gqc-qhrj-9xw8](https://github.com/oxia-db/oxia/security/advisories/GHSA-5gqc-qhrj-9xw8)

## Test plan
- [ ] `go test -v -race -run TestSession_Heartbeat ./oxiad/dataserver/controller/lead/...`
- [ ] All 3 new tests pass with `-race` flag
- [ ] Existing session manager tests continue to pass
- [ ] No race conditions detected