### PR TITLE
security: validate namespace names to prevent path traversal

### DIFF
--- a/common/validation/namespace.go
+++ b/common/validation/namespace.go
@@ -1,0 +1,40 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var validNamespacePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$`)
+
+func ValidateNamespace(namespace string) error {
+	if namespace == "" {
+		return errors.New("namespace must not be empty")
+	}
+	if strings.Contains(namespace, "..") {
+		return errors.Errorf("namespace %q contains invalid path traversal sequence", namespace)
+	}
+	if strings.ContainsAny(namespace, `/\`) {
+		return errors.Errorf("namespace %q contains invalid path separator", namespace)
+	}
+	if !validNamespacePattern.MatchString(namespace) {
+		return errors.Errorf("namespace %q contains invalid characters", namespace)
+	}
+	return nil
+}

--- a/common/validation/namespace_test.go
+++ b/common/validation/namespace_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package wal
+package validation
 
 import (
 	"testing"
@@ -64,28 +64,34 @@ func TestValidateNamespace(t *testing.T) {
 			errMsg:    "must not be empty",
 		},
 		{
-			name:      "path traversal with dot-dot",
+			name:      "path traversal with dot-dot prefix",
 			namespace: "../evil",
 			wantErr:   true,
-			errMsg:    "path traversal characters",
+			errMsg:    "path traversal sequence",
 		},
 		{
 			name:      "path traversal with dot-dot only",
 			namespace: "..",
 			wantErr:   true,
-			errMsg:    "path traversal characters",
+			errMsg:    "path traversal sequence",
+		},
+		{
+			name:      "path traversal with embedded dot-dot",
+			namespace: "a..b",
+			wantErr:   true,
+			errMsg:    "path traversal sequence",
 		},
 		{
 			name:      "forward slash",
 			namespace: "ns/evil",
 			wantErr:   true,
-			errMsg:    "path traversal characters",
+			errMsg:    "path separator",
 		},
 		{
 			name:      "backslash",
 			namespace: "ns\\evil",
 			wantErr:   true,
-			errMsg:    "path traversal characters",
+			errMsg:    "path separator",
 		},
 		{
 			name:      "starts with dot",
@@ -109,7 +115,7 @@ func TestValidateNamespace(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateNamespace(tt.namespace)
+			err := ValidateNamespace(tt.namespace)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, tt.errMsg)

--- a/oxiad/coordinator/model/cluster_config.go
+++ b/oxiad/coordinator/model/cluster_config.go
@@ -15,6 +15,7 @@
 package model
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -23,6 +24,8 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/policy"
 )
+
+var validNamespaceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$`)
 
 type ClusterConfig struct {
 	Namespaces []NamespaceConfig `json:"namespaces" yaml:"namespaces"`
@@ -85,6 +88,10 @@ func (cc *ClusterConfig) Validate() error {
 	for _, ns := range cc.Namespaces {
 		if ns.Name == "" {
 			return errors.New("cluster config: namespace name must not be empty")
+		}
+
+		if !validNamespaceNamePattern.MatchString(ns.Name) {
+			return errors.Errorf("cluster config: namespace name %q contains invalid characters", ns.Name)
 		}
 
 		if ns.ReplicationFactor < 1 {

--- a/oxiad/coordinator/model/cluster_config.go
+++ b/oxiad/coordinator/model/cluster_config.go
@@ -15,17 +15,15 @@
 package model
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/oxia-db/oxia/common/entity"
 	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/common/validation"
 	"github.com/oxia-db/oxia/oxiad/coordinator/policy"
 )
-
-var validNamespaceNamePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$`)
 
 type ClusterConfig struct {
 	Namespaces []NamespaceConfig `json:"namespaces" yaml:"namespaces"`
@@ -86,12 +84,8 @@ func (cc *ClusterConfig) Validate() error {
 	}
 
 	for _, ns := range cc.Namespaces {
-		if ns.Name == "" {
-			return errors.New("cluster config: namespace name must not be empty")
-		}
-
-		if !validNamespaceNamePattern.MatchString(ns.Name) {
-			return errors.Errorf("cluster config: namespace name %q contains invalid characters", ns.Name)
+		if err := validation.ValidateNamespace(ns.Name); err != nil {
+			return errors.Wrap(err, "cluster config")
 		}
 
 		if ns.ReplicationFactor < 1 {

--- a/oxiad/coordinator/model/cluster_config_test.go
+++ b/oxiad/coordinator/model/cluster_config_test.go
@@ -92,7 +92,7 @@ func TestValidate_NoNamespaces(t *testing.T) {
 func TestValidate_EmptyNamespaceName(t *testing.T) {
 	cc := validConfig()
 	cc.Namespaces[0].Name = ""
-	assert.ErrorContains(t, cc.Validate(), "namespace name must not be empty")
+	assert.ErrorContains(t, cc.Validate(), "namespace must not be empty")
 }
 
 func TestValidate_ReplicationFactorZero(t *testing.T) {
@@ -139,25 +139,25 @@ func TestClusterConfig_Validate_NamespaceNames(t *testing.T) {
 			name:    "path traversal dot-dot-slash",
 			nsName:  "../evil",
 			wantErr: true,
-			errMsg:  "contains invalid characters",
+			errMsg:  "path traversal sequence",
 		},
 		{
 			name:    "forward slash",
 			nsName:  "ns/evil",
 			wantErr: true,
-			errMsg:  "contains invalid characters",
+			errMsg:  "path separator",
 		},
 		{
 			name:    "backslash",
 			nsName:  "ns\\evil",
 			wantErr: true,
-			errMsg:  "contains invalid characters",
+			errMsg:  "path separator",
 		},
 		{
 			name:    "dot-dot only",
 			nsName:  "..",
 			wantErr: true,
-			errMsg:  "contains invalid characters",
+			errMsg:  "path traversal sequence",
 		},
 		{
 			name:    "starts with dot",

--- a/oxiad/coordinator/model/cluster_config_test.go
+++ b/oxiad/coordinator/model/cluster_config_test.go
@@ -112,3 +112,77 @@ func TestValidate_ReplicationFactorExceedsServers(t *testing.T) {
 	cc.Namespaces[0].ReplicationFactor = 5
 	assert.ErrorContains(t, cc.Validate(), "replicationFactor=5 but only 3 servers are configured")
 }
+
+func TestClusterConfig_Validate_NamespaceNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		nsName  string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid name",
+			nsName:  "default",
+			wantErr: false,
+		},
+		{
+			name:    "valid name with dots",
+			nsName:  "my.namespace",
+			wantErr: false,
+		},
+		{
+			name:    "valid name with hyphens and underscores",
+			nsName:  "my-ns_01",
+			wantErr: false,
+		},
+		{
+			name:    "path traversal dot-dot-slash",
+			nsName:  "../evil",
+			wantErr: true,
+			errMsg:  "contains invalid characters",
+		},
+		{
+			name:    "forward slash",
+			nsName:  "ns/evil",
+			wantErr: true,
+			errMsg:  "contains invalid characters",
+		},
+		{
+			name:    "backslash",
+			nsName:  "ns\\evil",
+			wantErr: true,
+			errMsg:  "contains invalid characters",
+		},
+		{
+			name:    "dot-dot only",
+			nsName:  "..",
+			wantErr: true,
+			errMsg:  "contains invalid characters",
+		},
+		{
+			name:    "starts with dot",
+			nsName:  ".hidden",
+			wantErr: true,
+			errMsg:  "contains invalid characters",
+		},
+		{
+			name:    "contains spaces",
+			nsName:  "my namespace",
+			wantErr: true,
+			errMsg:  "contains invalid characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cc := validConfig()
+			cc.Namespaces[0].Name = tt.nsName
+			err := cc.Validate()
+			if tt.wantErr {
+				assert.ErrorContains(t, err, tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -99,8 +101,27 @@ func walPath(logDir string, namespace string, shard int64) string {
 	return filepath.Join(logDir, namespace, fmt.Sprint("shard-", shard))
 }
 
+var validNamespacePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$`)
+
+func validateNamespace(namespace string) error {
+	if namespace == "" {
+		return errors.New("namespace name must not be empty")
+	}
+	if strings.Contains(namespace, "/") || strings.Contains(namespace, "\\") || strings.Contains(namespace, "..") {
+		return errors.Errorf("namespace name %q contains path traversal characters", namespace)
+	}
+	if !validNamespacePattern.MatchString(namespace) {
+		return errors.Errorf("namespace name %q contains invalid characters", namespace)
+	}
+	return nil
+}
+
 func newWal(namespace string, shard int64, options *FactoryOptions, commitOffsetProvider CommitOffsetProvider,
 	clock time2.Clock, trimmerCheckInterval time.Duration) (Wal, error) {
+	if err := validateNamespace(namespace); err != nil {
+		return nil, err
+	}
+
 	if options.SegmentSize == 0 {
 		options.SegmentSize = DefaultFactoryOptions.SegmentSize
 	}

--- a/oxiad/dataserver/wal/wal_impl.go
+++ b/oxiad/dataserver/wal/wal_impl.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -37,6 +35,7 @@ import (
 	"github.com/oxia-db/oxia/common/object"
 	"github.com/oxia-db/oxia/common/process"
 	time2 "github.com/oxia-db/oxia/common/time"
+	"github.com/oxia-db/oxia/common/validation"
 
 	"github.com/oxia-db/oxia/common/metric"
 	"github.com/oxia-db/oxia/common/proto"
@@ -101,24 +100,9 @@ func walPath(logDir string, namespace string, shard int64) string {
 	return filepath.Join(logDir, namespace, fmt.Sprint("shard-", shard))
 }
 
-var validNamespacePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$`)
-
-func validateNamespace(namespace string) error {
-	if namespace == "" {
-		return errors.New("namespace name must not be empty")
-	}
-	if strings.Contains(namespace, "/") || strings.Contains(namespace, "\\") || strings.Contains(namespace, "..") {
-		return errors.Errorf("namespace name %q contains path traversal characters", namespace)
-	}
-	if !validNamespacePattern.MatchString(namespace) {
-		return errors.Errorf("namespace name %q contains invalid characters", namespace)
-	}
-	return nil
-}
-
 func newWal(namespace string, shard int64, options *FactoryOptions, commitOffsetProvider CommitOffsetProvider,
 	clock time2.Clock, trimmerCheckInterval time.Duration) (Wal, error) {
-	if err := validateNamespace(namespace); err != nil {
+	if err := validation.ValidateNamespace(namespace); err != nil {
 		return nil, err
 	}
 

--- a/oxiad/dataserver/wal/wal_namespace_test.go
+++ b/oxiad/dataserver/wal/wal_namespace_test.go
@@ -1,0 +1,121 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateNamespace(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "valid simple name",
+			namespace: "default",
+			wantErr:   false,
+		},
+		{
+			name:      "valid name with hyphens",
+			namespace: "my-namespace",
+			wantErr:   false,
+		},
+		{
+			name:      "valid name with underscores",
+			namespace: "my_namespace",
+			wantErr:   false,
+		},
+		{
+			name:      "valid name with dots",
+			namespace: "my.ns",
+			wantErr:   false,
+		},
+		{
+			name:      "valid name with numbers",
+			namespace: "ns123",
+			wantErr:   false,
+		},
+		{
+			name:      "valid single character",
+			namespace: "a",
+			wantErr:   false,
+		},
+		{
+			name:      "empty namespace",
+			namespace: "",
+			wantErr:   true,
+			errMsg:    "must not be empty",
+		},
+		{
+			name:      "path traversal with dot-dot",
+			namespace: "../evil",
+			wantErr:   true,
+			errMsg:    "path traversal characters",
+		},
+		{
+			name:      "path traversal with dot-dot only",
+			namespace: "..",
+			wantErr:   true,
+			errMsg:    "path traversal characters",
+		},
+		{
+			name:      "forward slash",
+			namespace: "ns/evil",
+			wantErr:   true,
+			errMsg:    "path traversal characters",
+		},
+		{
+			name:      "backslash",
+			namespace: "ns\\evil",
+			wantErr:   true,
+			errMsg:    "path traversal characters",
+		},
+		{
+			name:      "starts with dot",
+			namespace: ".hidden",
+			wantErr:   true,
+			errMsg:    "invalid characters",
+		},
+		{
+			name:      "starts with hyphen",
+			namespace: "-invalid",
+			wantErr:   true,
+			errMsg:    "invalid characters",
+		},
+		{
+			name:      "contains spaces",
+			namespace: "my namespace",
+			wantErr:   true,
+			errMsg:    "invalid characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNamespace(tt.namespace)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `validateNamespace()` in the WAL layer (`wal_impl.go`) that rejects namespace names containing path traversal characters (`/`, `\`, `..`) or not matching `^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`
- Add the same regex validation in `ClusterConfig.Validate()` (`cluster_config.go`) to catch invalid names at configuration time
- Prevents an attacker from using crafted namespace names like `../evil` to escape the WAL data directory

## Test plan
- [x] `TestValidateNamespace` in `oxiad/dataserver/wal/wal_namespace_test.go` covers valid names, empty, path traversal (`../evil`), slashes, backslashes, dots only (`..`), valid dots (`my.ns`)
- [x] `TestClusterConfig_Validate_NamespaceNames` in `oxiad/coordinator/model/cluster_config_test.go` covers invalid namespace names in cluster config validation
- [x] `golangci-lint run` passes with 0 issues
- [x] All new and existing tests pass