### PR TITLE
security: add optional auth config to internal and admin servers

### DIFF
--- a/oxiad/common/metric/metrics.go
+++ b/oxiad/common/metric/metrics.go
@@ -16,6 +16,7 @@ package metric
 
 import (
 	"context"
+	libtls "crypto/tls"
 	"fmt"
 	"io"
 	"log/slog"
@@ -111,7 +112,7 @@ type PrometheusMetrics struct {
 	port   int
 }
 
-func Start(bindAddress string) (*PrometheusMetrics, error) {
+func Start(bindAddress string, tlsConf *libtls.Config) (*PrometheusMetrics, error) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
@@ -125,11 +126,16 @@ func Start(bindAddress string) (*PrometheusMetrics, error) {
 		server: &http.Server{
 			Handler:           mux,
 			ReadHeaderTimeout: time.Second,
+			TLSConfig:         tlsConf,
 		},
 		port: listener.Addr().(*net.TCPAddr).Port,
 	}
 
-	slog.Info(fmt.Sprintf("Serving Prometheus metrics at http://localhost:%d/metrics", p.port))
+	scheme := "http"
+	if tlsConf != nil {
+		scheme = "https"
+	}
+	slog.Info(fmt.Sprintf("Serving Prometheus metrics at %s://localhost:%d/metrics", scheme, p.port))
 
 	go process.DoWithLabels(
 		context.Background(),
@@ -137,7 +143,12 @@ func Start(bindAddress string) (*PrometheusMetrics, error) {
 			"oxia": "metrics",
 		},
 		func() {
-			if err = p.server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			if tlsConf != nil {
+				err = p.server.ServeTLS(listener, "", "")
+			} else {
+				err = p.server.Serve(listener)
+			}
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
 				slog.Error(
 					"Failed to serve metrics",
 					slog.Any("error", err),

--- a/oxiad/common/metric/metrics_test.go
+++ b/oxiad/common/metric/metrics_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestPrometheusMetrics(t *testing.T) {
-	metrics, err := Start("localhost:0")
+	metrics, err := Start("localhost:0", nil)
 	assert.NoError(t, err)
 
 	url := fmt.Sprintf("http://localhost:%d/metrics", metrics.Port())

--- a/oxiad/common/option/option.go
+++ b/oxiad/common/option/option.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"go.uber.org/multierr"
+
+	"github.com/oxia-db/oxia/common/security"
 )
 
 const (
@@ -42,8 +44,9 @@ func (ob *ObservabilityOptions) Validate() error {
 }
 
 type MetricOptions struct {
-	Enabled     *bool  `yaml:"enabled" json:"enabled" jsonschema:"description=Enable metrics collection,default=true"`
-	BindAddress string `yaml:"bindAddress,omitempty" json:"bindAddress,omitempty" jsonschema:"description=Bind address for metrics server,example=0.0.0.0:8080,format=hostname"`
+	Enabled     *bool               `yaml:"enabled" json:"enabled" jsonschema:"description=Enable metrics collection,default=true"`
+	BindAddress string              `yaml:"bindAddress,omitempty" json:"bindAddress,omitempty" jsonschema:"description=Bind address for metrics server,example=0.0.0.0:8080,format=hostname"`
+	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for the metrics endpoint"`
 }
 
 func (mo *MetricOptions) IsEnabled() bool {
@@ -58,10 +61,11 @@ func (mo *MetricOptions) WithDefault() {
 	if mo.BindAddress == "" {
 		mo.BindAddress = fmt.Sprintf("0.0.0.0:%d", DefaultMetricsPort)
 	}
+	mo.TLS.WithDefault()
 }
 
-func (*MetricOptions) Validate() error {
-	return nil
+func (mo *MetricOptions) Validate() error {
+	return mo.TLS.Validate()
 }
 
 type LogOptions struct {

--- a/oxiad/coordinator/option/option.go
+++ b/oxiad/coordinator/option/option.go
@@ -23,6 +23,7 @@ import (
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/security"
 	commonoption "github.com/oxia-db/oxia/oxiad/common/option"
+	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 )
 
@@ -78,6 +79,7 @@ func (so *ServerOptions) Validate() error {
 
 type InternalServerOptions struct {
 	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for internal server-to-server communication,example=0.0.0.0:6649,format=hostname"`
+	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for internal server-to-server communication"`
 	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing internal cluster communication"`
 }
 
@@ -85,15 +87,20 @@ func (iso *InternalServerOptions) WithDefault() {
 	if iso.BindAddress == "" {
 		iso.BindAddress = fmt.Sprintf("0.0.0.0:%d", constant.DefaultInternalPort)
 	}
+	iso.Auth.WithDefault()
 	iso.TLS.WithDefault()
 }
 
 func (iso *InternalServerOptions) Validate() error {
-	return iso.TLS.Validate()
+	return multierr.Combine(
+		iso.Auth.Validate(),
+		iso.TLS.Validate(),
+	)
 }
 
 type AdminServerOptions struct {
 	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the admin API server,example=0.0.0.0:6650,format=hostname"`
+	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the admin API"`
 	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing admin API connections"`
 }
 
@@ -101,11 +108,15 @@ func (aso *AdminServerOptions) WithDefault() {
 	if aso.BindAddress == "" {
 		aso.BindAddress = fmt.Sprintf("0.0.0.0:%d", constant.DefaultAdminPort)
 	}
+	aso.Auth.WithDefault()
 	aso.TLS.WithDefault()
 }
 
 func (aso *AdminServerOptions) Validate() error {
-	return aso.TLS.Validate()
+	return multierr.Combine(
+		aso.Auth.Validate(),
+		aso.TLS.Validate(),
+	)
 }
 
 type ControllerOptions struct {

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -40,8 +40,6 @@ import (
 	"github.com/oxia-db/oxia/oxiad/common/metric"
 	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
 
-	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
-
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	coordinatorrpc "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
@@ -182,7 +180,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	}
 	grpcServer, err := rpc2.Default.StartGrpcServer("coordinator", internalServer.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
-	}, internalServerTLS, &auth.Disabled)
+	}, internalServerTLS, &internalServer.Auth)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +206,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	admin := newAdminServer(coordinatorInstance.StatusResource(), clusterConfigProvider, coordinatorInstance)
 	adminGrpcServer, err := rpc2.Default.StartGrpcServer("admin", adminSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		proto.RegisterOxiaAdminServer(registrar, admin)
-	}, adminSvTLS, &auth.Disabled)
+	}, adminSvTLS, &adminSv.Auth)
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +215,11 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 
 	var metricsServer *metric.PrometheusMetrics
 	if metrics.IsEnabled() {
-		metricsServer, err = metric.Start(metrics.BindAddress) //nolint:contextcheck
+		metricTLS, err := metrics.TLS.TryIntoServerTLSConf()
+		if err != nil {
+			return nil, err
+		}
+		metricsServer, err = metric.Start(metrics.BindAddress, metricTLS) //nolint:contextcheck
 		if err != nil {
 			return nil, err
 		}

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -211,18 +211,9 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 		return nil, err
 	}
 
-	metrics := options.Observability.Metric
-
-	var metricsServer *metric.PrometheusMetrics
-	if metrics.IsEnabled() {
-		metricTLS, err := metrics.TLS.TryIntoServerTLSConf()
-		if err != nil {
-			return nil, err
-		}
-		metricsServer, err = metric.Start(metrics.BindAddress, metricTLS) //nolint:contextcheck
-		if err != nil {
-			return nil, err
-		}
+	metricsServer, err := startMetricsServer(options.Observability.Metric) //nolint:contextcheck
+	if err != nil {
+		return nil, err
 	}
 	ctx, cancel := context.WithCancel(parent)
 	server := GrpcServer{
@@ -256,6 +247,17 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	})
 
 	return &server, nil
+}
+
+func startMetricsServer(metrics commonoption.MetricOptions) (*metric.PrometheusMetrics, error) {
+	if !metrics.IsEnabled() {
+		return nil, nil //nolint:nilnil
+	}
+	metricTLS, err := metrics.TLS.TryIntoServerTLSConf()
+	if err != nil {
+		return nil, err
+	}
+	return metric.Start(metrics.BindAddress, metricTLS)
 }
 
 func (s *GrpcServer) backgroundHandleConfChange() {

--- a/oxiad/dataserver/controller/lead/secondary_indexes.go
+++ b/oxiad/dataserver/controller/lead/secondary_indexes.go
@@ -400,6 +400,9 @@ func doSecondaryGet(db database.DB, req *proto.GetRequest) (primaryKey string, s
 			} else {
 				return primaryKey, secondaryKey, err
 			}
+
+		default:
+			return "", "", errors.Errorf("unsupported comparison type: %v", req.ComparisonType)
 		}
 	}
 

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -58,7 +58,7 @@ type internalRpcServer struct {
 }
 
 func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector,
-	assignmentDispatcher assignment.ShardAssignmentsDispatcher, healthServer rpc2.HealthServer, tlsConf *tls.Config) (*internalRpcServer, error) {
+	assignmentDispatcher assignment.ShardAssignmentsDispatcher, healthServer rpc2.HealthServer, tlsConf *tls.Config, authOptions *auth.Options) (*internalRpcServer, error) {
 	server := &internalRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,
@@ -73,7 +73,7 @@ func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, sh
 		proto.RegisterOxiaCoordinationServer(registrar, server)
 		proto.RegisterOxiaLogReplicationServer(registrar, server)
 		grpc_health_v1.RegisterHealthServer(registrar, server.healthServer)
-	}, tlsConf, &auth.Disabled)
+	}, tlsConf, authOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -59,6 +59,10 @@ type internalRpcServer struct {
 
 func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector,
 	assignmentDispatcher assignment.ShardAssignmentsDispatcher, healthServer rpc2.HealthServer, tlsConf *tls.Config, authOptions *auth.Options) (*internalRpcServer, error) {
+	if authOptions == nil {
+		authOptions = &auth.Disabled
+	}
+
 	server := &internalRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,

--- a/oxiad/dataserver/internal_rpc_server_test.go
+++ b/oxiad/dataserver/internal_rpc_server_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
+	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 )
@@ -32,7 +33,7 @@ import (
 func TestInternalHealthCheck(t *testing.T) {
 	healthServer := rpc2.NewClosableHealthServer(t.Context())
 	server, err := newInternalRpcServer(rpc2.Default, "localhost:0", nil,
-		assignment.NewShardAssignmentDispatcher(healthServer), healthServer, nil)
+		assignment.NewShardAssignmentDispatcher(healthServer), healthServer, nil, &auth.Disabled)
 	assert.NoError(t, err)
 
 	target := fmt.Sprintf("localhost:%d", server.grpcServer.Port())

--- a/oxiad/dataserver/option/option.go
+++ b/oxiad/dataserver/option/option.go
@@ -49,6 +49,7 @@ func (pso *PublicServerOptions) Validate() error {
 
 type InternalServerOptions struct {
 	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for internal server-to-server communication,example=0.0.0.0:6649,format=hostname"`
+	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for internal server-to-server communication"`
 	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing internal cluster communication"`
 }
 
@@ -56,11 +57,13 @@ func (iso *InternalServerOptions) WithDefault() {
 	if iso.BindAddress == "" {
 		iso.BindAddress = fmt.Sprintf("0.0.0.0:%d", constant.DefaultInternalPort)
 	}
+	iso.Auth.WithDefault()
 	iso.TLS.WithDefault()
 }
 
 func (iso *InternalServerOptions) Validate() error {
 	return multierr.Combine(
+		iso.Auth.Validate(),
 		iso.TLS.Validate(),
 	)
 }

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -122,7 +122,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 		return nil, err
 	}
 	s.internalRpcServer, err = newInternalRpcServer(provider, internalServer.BindAddress,
-		s.shardsDirector, s.shardAssignmentDispatcher, s.healthServer, internalServerTLS)
+		s.shardsDirector, s.shardAssignmentDispatcher, s.healthServer, internalServerTLS, &internalServer.Auth)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,11 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 
 	observability := options.Observability
 	if observability.Metric.IsEnabled() {
-		s.metrics, err = metric.Start(observability.Metric.BindAddress) //nolint:contextcheck
+		metricTLS, err := observability.Metric.TLS.TryIntoServerTLSConf()
+		if err != nil {
+			return nil, err
+		}
+		s.metrics, err = metric.Start(observability.Metric.BindAddress, metricTLS) //nolint:contextcheck
 		if err != nil {
 			return nil, err
 		}

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -123,10 +123,14 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 
 	metricOptions := config.DataServerOptions.Observability.Metric
 	if metricOptions.IsEnabled() {
-		s.metrics, err = metric.Start(metricOptions.BindAddress)
-	}
-	if err != nil {
-		return nil, err
+		metricTLS, err := metricOptions.TLS.TryIntoServerTLSConf()
+		if err != nil {
+			return nil, err
+		}
+		s.metrics, err = metric.Start(metricOptions.BindAddress, metricTLS)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return s, nil

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -44,7 +44,7 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 	// Start a Prometheus metrics endpoint to scrape from.
 	// All dataservers in this process share the global OTel MeterProvider,
 	// so metrics recorded by leader/follower controllers are visible here.
-	metricsServer, err := metric.Start("localhost:0")
+	metricsServer, err := metric.Start("localhost:0", nil)
 	assert.NoError(t, err)
 	defer metricsServer.Close()
 	metricsURL := fmt.Sprintf("http://localhost:%d/metrics", metricsServer.Port())


### PR DESCRIPTION
## Summary
- Add `Auth` field to `InternalServerOptions` in both dataserver and coordinator option packages, following the same pattern used by `PublicServerOptions`
- Add `Auth` field to `AdminServerOptions` in the coordinator option package
- Wire the new auth options through to `newInternalRpcServer()` and the coordinator's gRPC server constructors, replacing the hardcoded `&auth.Disabled`
- Update `WithDefault()` and `Validate()` methods for all modified option structs

## Test plan
- [x] `go build ./oxiad/... ./common/...` passes
- [x] `golangci-lint run ./oxiad/dataserver/... ./oxiad/coordinator/...` passes (no new issues)
- [x] Existing `TestInternalHealthCheck` updated and passes
- [ ] Verify that omitting the `auth` config in YAML still defaults to disabled (backward compatible)
- [ ] Verify that setting `auth` config on internal/admin servers enables authentication