### PR TITLE
security: validate authority address to prevent SSRF in standalone mode

### DIFF
--- a/oxiad/dataserver/assignment/assignment_dispatcher.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher.go
@@ -18,9 +18,12 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"net"
+	"strings"
 	"sync"
 
 	"github.com/emirpasic/gods/v2/trees/redblacktree"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
@@ -183,12 +186,40 @@ func (s *shardAssignmentDispatcher) assignmentsInterceptorFunc(clientStream Clie
 	}, nil
 }
 
+func validateAuthorityAddress(addr string) error {
+	if strings.Contains(addr, "://") {
+		return errors.Errorf("authority address %q must not contain a scheme", addr)
+	}
+	if strings.Contains(addr, "/") {
+		return errors.Errorf("authority address %q must not contain a path", addr)
+	}
+	if strings.Contains(addr, "?") {
+		return errors.Errorf("authority address %q must not contain a query string", addr)
+	}
+	if strings.Contains(addr, "#") {
+		return errors.Errorf("authority address %q must not contain a fragment", addr)
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return errors.Errorf("authority address %q is not a valid host:port pair: %v", addr, err)
+	}
+	if host == "" {
+		return errors.Errorf("authority address %q has an empty host", addr)
+	}
+
+	return nil
+}
+
 func authority(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
-		authority := md[":authority"]
-		if len(authority) > 0 {
-			return authority[0], nil
+		addr := md[":authority"]
+		if len(addr) > 0 {
+			if err := validateAuthorityAddress(addr[0]); err != nil {
+				return "", status.Errorf(codes.InvalidArgument, "oxia: invalid authority address: %v", err)
+			}
+			return addr[0], nil
 		}
 	}
 	return "", status.Errorf(codes.Internal, "oxia: authority not identified")

--- a/oxiad/dataserver/assignment/authority_test.go
+++ b/oxiad/dataserver/assignment/authority_test.go
@@ -1,0 +1,100 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package assignment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAuthorityAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		addr    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid host:port",
+			addr:    "localhost:6649",
+			wantErr: false,
+		},
+		{
+			name:    "valid hostname:port",
+			addr:    "server1.example.com:6649",
+			wantErr: false,
+		},
+		{
+			name:    "valid IP:port",
+			addr:    "192.168.1.1:6649",
+			wantErr: false,
+		},
+		{
+			name:    "scheme injection http",
+			addr:    "http://evil:6649",
+			wantErr: true,
+			errMsg:  "must not contain a scheme",
+		},
+		{
+			name:    "scheme injection https",
+			addr:    "https://evil:6649",
+			wantErr: true,
+			errMsg:  "must not contain a scheme",
+		},
+		{
+			name:    "path injection",
+			addr:    "host:6649/path",
+			wantErr: true,
+			errMsg:  "must not contain a path",
+		},
+		{
+			name:    "query injection",
+			addr:    "host:6649?param=value",
+			wantErr: true,
+			errMsg:  "must not contain a query string",
+		},
+		{
+			name:    "fragment injection",
+			addr:    "host:6649#fragment",
+			wantErr: true,
+			errMsg:  "must not contain a fragment",
+		},
+		{
+			name:    "empty host",
+			addr:    ":6649",
+			wantErr: true,
+			errMsg:  "has an empty host",
+		},
+		{
+			name:    "missing port",
+			addr:    "host",
+			wantErr: true,
+			errMsg:  "not a valid host:port pair",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAuthorityAddress(tt.addr)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `validateAuthorityAddress()` in the assignment dispatcher that rejects gRPC `:authority` metadata containing scheme (`://`), path (`/`), query (`?`), or fragment (`#`) characters
- Validates the address is a well-formed `host:port` pair using `net.SplitHostPort()` and rejects empty hosts
- Prevents an attacker from injecting arbitrary URLs through the `:authority` header when running in standalone mode

## Test plan
- [x] `TestValidateAuthorityAddress` in `oxiad/dataserver/assignment/authority_test.go` covers: valid `host:port`, scheme injection (`http://evil:6649`), path injection (`host:6649/path`), query injection, fragment injection, empty host, missing port
- [x] `golangci-lint run` passes with 0 issues
- [x] All new and existing tests pass