### PR TITLE
fix: add context cancellation check in write stream processing loop

### DIFF
--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -131,6 +131,11 @@ func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) 
 
 func procesWriteStream(streamCtx context.Context, finished chan<- error, stream proto.OxiaClient_WriteStreamServer, lc lead.LeaderController) {
 	for {
+		if streamCtx.Err() != nil {
+			channel.PushNoBlock(finished, streamCtx.Err())
+			return
+		}
+
 		req, err := stream.Recv()
 		if err != nil {
 			if errors.Is(err, io.EOF) {

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -129,10 +129,9 @@ func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) 
 	return wr, err
 }
 
-func procesWriteStream(streamCtx context.Context, finished chan<- error, stream proto.OxiaClient_WriteStreamServer, lc lead.LeaderController) {
+func processWriteStream(streamCtx context.Context, finished chan<- error, stream proto.OxiaClient_WriteStreamServer, lc lead.LeaderController) {
 	for {
 		if streamCtx.Err() != nil {
-			channel.PushNoBlock(finished, streamCtx.Err())
 			return
 		}
 
@@ -200,7 +199,7 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 			"shard":     fmt.Sprintf("%d", lc.ShardID()),
 		},
 		func() {
-			procesWriteStream(streamCtx, finished, stream, lc)
+			processWriteStream(streamCtx, finished, stream, lc)
 		},
 	)
 


### PR DESCRIPTION
## Summary
- Add an early context cancellation check at the top of the `procesWriteStream` loop, before `stream.Recv()` (Issue #12)
- This ensures the loop exits promptly when the context is cancelled (e.g., after a send error on the response stream), rather than continuing to process requests that can no longer be responded to

## Test plan
- [ ] Verify `go build ./oxiad/dataserver/...` passes
- [ ] Verify `golangci-lint run ./oxiad/dataserver/...` passes (no new issues)
- [ ] Verify existing write stream tests still pass
- [ ] Verify that when the stream context is cancelled, the loop exits immediately instead of blocking on `stream.Recv()`