### PR TITLE
fix: ignore docker build record artifacts in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: artifacts
-          pattern: "!*.dockerbuild"
+          pattern: "oxia-*"
 
       - name: Prepare release assets
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,6 +174,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: artifacts
+          pattern: "!*.dockerbuild"
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
## Summary
Exclude Docker build record artifacts from the release asset download step.

## Why
The release workflow for tag `v0.16.2` failed in `Create Release` because `actions/download-artifact` tried to fetch the `*.dockerbuild` artifact emitted by `docker/build-push-action` alongside the binary artifacts.

Run: https://github.com/oxia-db/oxia/actions/runs/24329857979/job/71039891933
Artifacts API: https://api.github.com/repos/oxia-db/oxia/actions/runs/24329857979/artifacts

This change filters those build record artifacts out so `create-release` only downloads the uploaded binary artifacts it actually packages.