### PR TITLE
fix: narrow release artifact download pattern

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           path: artifacts
-          pattern: "oxia-*"
+          pattern: "oxia-*-*"
 
       - name: Prepare release assets
         run: |


### PR DESCRIPTION
## Summary
Narrow the release artifact download pattern so the GitHub release job only downloads the five binary artifacts.

## Why
The prior fix changed the pattern to `oxia-*`, but that still matched Docker build record artifacts like `oxia-db~oxia~20WWW4.dockerbuild` because they also begin with `oxia-`.

The `create-release` job then tried to download that `.dockerbuild` artifact and failed again.

Failed run: https://github.com/oxia-db/oxia/actions/runs/24333038936

This updates the pattern to `oxia-*-*`, which matches the binary artifacts:
- `oxia-linux-amd64`
- `oxia-linux-arm64`
- `oxia-darwin-amd64`
- `oxia-darwin-arm64`
- `oxia-windows-amd64`

and does not match the Docker build record artifact name.