### PR TITLE
Add get-data-server admin command

### DIFF
--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/cmd/admin/getdataserver"
 	"github.com/oxia-db/oxia/cmd/admin/listdataservers"
 	"github.com/oxia-db/oxia/cmd/admin/listnodes"
 	"github.com/oxia-db/oxia/cmd/admin/splitshard"
@@ -41,6 +42,7 @@ func init() {
 	defaultAdminClientAddress := fmt.Sprintf("localhost:%d", oxiacommon.DefaultAdminPort)
 	Cmd.PersistentFlags().StringVar(&commons.AdminConfig.AdminAddress, "admin-address", defaultAdminClientAddress, "Admin client address")
 
+	Cmd.AddCommand(getdataserver.Cmd)
 	Cmd.AddCommand(listdataservers.Cmd)
 	Cmd.AddCommand(listnamespaces.Cmd)
 	Cmd.AddCommand(listnodes.Cmd)

--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -55,6 +55,14 @@ func (m *MockAdminClient) ListDataServers() ([]*proto.DataServer, error) {
 	return nil, errors.New("no data servers available")
 }
 
+func (m *MockAdminClient) GetDataServer(dataServer string) (*proto.DataServer, error) {
+	args := m.MethodCalled("GetDataServer", dataServer)
+	if v, ok := args.Get(0).(*proto.DataServer); ok {
+		return v, args.Error(1)
+	}
+	return nil, errors.New("data server not found")
+}
+
 func (m *MockAdminClient) ListNodes() *oxia.ListNodesResult {
 	args := m.MethodCalled("ListNodes")
 	if v, ok := args.Get(0).(*oxia.ListNodesResult); ok {

--- a/cmd/admin/getdataserver/cmd.go
+++ b/cmd/admin/getdataserver/cmd.go
@@ -1,0 +1,49 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getdataserver
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	cc "github.com/oxia-db/oxia/cmd/client/common"
+	"github.com/oxia-db/oxia/oxia"
+)
+
+var Cmd = &cobra.Command{
+	Use:          "get-data-server [data-server]",
+	Short:        "Get a data server",
+	Long:         `Get a data server`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         exec,
+	SilenceUsage: true,
+}
+
+func exec(cmd *cobra.Command, args []string) error {
+	client, err := commons.AdminConfig.NewAdminClient()
+	if err != nil {
+		return err
+	}
+	defer func(client oxia.AdminClient) {
+		_ = client.Close()
+	}(client)
+
+	dataServer, err := client.GetDataServer(args[0])
+	if err != nil {
+		return err
+	}
+	cc.WriteOutput(cmd.OutOrStdout(), dataServer)
+	return nil
+}

--- a/cmd/admin/getdataserver/cmd_test.go
+++ b/cmd/admin/getdataserver/cmd_test.go
@@ -42,9 +42,11 @@ func Test_cmd_getDataServer(t *testing.T) {
 
 	commons.MockedAdminClient.On("Close").Return(nil)
 	commons.MockedAdminClient.On("GetDataServer", serverName).Return(&proto.DataServer{
-		Name:            &serverName,
-		PublicAddress:   "public1",
-		InternalAddress: "internal1",
+		Name:              &serverName,
+		PublicAddress:     "public1",
+		InternalAddress:   "internal1",
+		Metadata:          map[string]string{"rack": "r1"},
+		SupportedFeatures: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM},
 	}, nil)
 
 	out, err := runCmd(Cmd, serverName)
@@ -56,4 +58,6 @@ func Test_cmd_getDataServer(t *testing.T) {
 	assert.Equal(t, serverName, *dataServer.Name)
 	assert.Equal(t, "public1", dataServer.PublicAddress)
 	assert.Equal(t, "internal1", dataServer.InternalAddress)
+	assert.Equal(t, map[string]string{"rack": "r1"}, dataServer.Metadata)
+	assert.Equal(t, []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}, dataServer.SupportedFeatures)
 }

--- a/cmd/admin/getdataserver/cmd_test.go
+++ b/cmd/admin/getdataserver/cmd_test.go
@@ -1,0 +1,59 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package getdataserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func runCmd(cmd *cobra.Command, args ...string) (string, error) {
+	actual := new(bytes.Buffer)
+	cmd.SetOut(actual)
+	cmd.SetErr(actual)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return strings.TrimSpace(actual.String()), err
+}
+
+func Test_cmd_getDataServer(t *testing.T) {
+	serverName := "server-1"
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.On("GetDataServer", serverName).Return(&proto.DataServer{
+		Name:            &serverName,
+		PublicAddress:   "public1",
+		InternalAddress: "internal1",
+	}, nil)
+
+	out, err := runCmd(Cmd, serverName)
+
+	assert.NoError(t, err)
+	var dataServer proto.DataServer
+	assert.NoError(t, json.Unmarshal([]byte(out), &dataServer))
+	assert.NotNil(t, dataServer.Name)
+	assert.Equal(t, serverName, *dataServer.Name)
+	assert.Equal(t, "public1", dataServer.PublicAddress)
+	assert.Equal(t, "internal1", dataServer.InternalAddress)
+}

--- a/common/constant/grpc_errors.go
+++ b/common/constant/grpc_errors.go
@@ -53,12 +53,13 @@ var (
 	ErrNodeIsNotMember         = status.Error(CodeNodeIsNotMember, "oxia: node is not a member")
 )
 
-func NewNodeIsNotLeaderWithHint(shard int64, leader string) error {
+func NewNodeIsNotLeaderWithHint(shard int64, leader string, clusterID string) error {
 	st := status.New(CodeNodeIsNotLeader, fmt.Sprintf("node is not leader for shard %d", shard))
 	if leader != "" {
 		redirect := &proto.LeaderHint{
 			Shard:         shard,
 			LeaderAddress: leader,
+			ClusterId:     clusterID,
 		}
 		stWithDetails, err := st.WithDetails(redirect)
 		if err != nil {

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -75,12 +75,14 @@ func (*ListDataServersRequest) Descriptor() ([]byte, []int) {
 }
 
 type DataServer struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Name            *string                `protobuf:"bytes,1,opt,name=name,proto3,oneof" json:"name,omitempty"`
-	PublicAddress   string                 `protobuf:"bytes,2,opt,name=public_address,json=publicAddress,proto3" json:"public_address,omitempty"`
-	InternalAddress string                 `protobuf:"bytes,3,opt,name=internal_address,json=internalAddress,proto3" json:"internal_address,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Name              *string                `protobuf:"bytes,1,opt,name=name,proto3,oneof" json:"name,omitempty"`
+	PublicAddress     string                 `protobuf:"bytes,2,opt,name=public_address,json=publicAddress,proto3" json:"public_address,omitempty"`
+	InternalAddress   string                 `protobuf:"bytes,3,opt,name=internal_address,json=internalAddress,proto3" json:"internal_address,omitempty"`
+	Metadata          map[string]string      `protobuf:"bytes,4,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	SupportedFeatures []Feature              `protobuf:"varint,5,rep,packed,name=supported_features,json=supportedFeatures,proto3,enum=replication.Feature" json:"supported_features,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *DataServer) Reset() {
@@ -132,6 +134,20 @@ func (x *DataServer) GetInternalAddress() string {
 		return x.InternalAddress
 	}
 	return ""
+}
+
+func (x *DataServer) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *DataServer) GetSupportedFeatures() []Feature {
+	if x != nil {
+		return x.SupportedFeatures
+	}
+	return nil
 }
 
 type ListDataServersResponse struct {
@@ -567,13 +583,18 @@ var File_admin_proto protoreflect.FileDescriptor
 
 const file_admin_proto_rawDesc = "" +
 	"\n" +
-	"\vadmin.proto\x12\x10io.oxia.proto.v1\"\x18\n" +
-	"\x16ListDataServersRequest\"\x80\x01\n" +
+	"\vadmin.proto\x12\x10io.oxia.proto.v1\x1a\x11replication.proto\"\x18\n" +
+	"\x16ListDataServersRequest\"\xca\x02\n" +
 	"\n" +
 	"DataServer\x12\x17\n" +
 	"\x04name\x18\x01 \x01(\tH\x00R\x04name\x88\x01\x01\x12%\n" +
 	"\x0epublic_address\x18\x02 \x01(\tR\rpublicAddress\x12)\n" +
-	"\x10internal_address\x18\x03 \x01(\tR\x0finternalAddressB\a\n" +
+	"\x10internal_address\x18\x03 \x01(\tR\x0finternalAddress\x12F\n" +
+	"\bmetadata\x18\x04 \x03(\v2*.io.oxia.proto.v1.DataServer.MetadataEntryR\bmetadata\x12C\n" +
+	"\x12supported_features\x18\x05 \x03(\x0e2\x14.replication.FeatureR\x11supportedFeatures\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\a\n" +
 	"\x05_name\"Z\n" +
 	"\x17ListDataServersResponse\x12?\n" +
 	"\fdata_servers\x18\x01 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\vdataServers\"7\n" +
@@ -626,7 +647,7 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_admin_proto_goTypes = []any{
 	(*ListDataServersRequest)(nil),  // 0: io.oxia.proto.v1.ListDataServersRequest
 	(*DataServer)(nil),              // 1: io.oxia.proto.v1.DataServer
@@ -639,27 +660,31 @@ var file_admin_proto_goTypes = []any{
 	(*ListNodesResponse)(nil),       // 8: io.oxia.proto.v1.ListNodesResponse
 	(*SplitShardRequest)(nil),       // 9: io.oxia.proto.v1.SplitShardRequest
 	(*SplitShardResponse)(nil),      // 10: io.oxia.proto.v1.SplitShardResponse
-	nil,                             // 11: io.oxia.proto.v1.Node.MetadataEntry
+	nil,                             // 11: io.oxia.proto.v1.DataServer.MetadataEntry
+	nil,                             // 12: io.oxia.proto.v1.Node.MetadataEntry
+	(Feature)(0),                    // 13: replication.Feature
 }
 var file_admin_proto_depIdxs = []int32{
-	1,  // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	11, // 1: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
-	7,  // 2: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
-	0,  // 3: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	3,  // 4: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
-	4,  // 5: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	6,  // 6: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
-	9,  // 7: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	2,  // 8: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	1,  // 9: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.DataServer
-	5,  // 10: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	8,  // 11: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
-	10, // 12: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	8,  // [8:13] is the sub-list for method output_type
-	3,  // [3:8] is the sub-list for method input_type
-	3,  // [3:3] is the sub-list for extension type_name
-	3,  // [3:3] is the sub-list for extension extendee
-	0,  // [0:3] is the sub-list for field type_name
+	11, // 0: io.oxia.proto.v1.DataServer.metadata:type_name -> io.oxia.proto.v1.DataServer.MetadataEntry
+	13, // 1: io.oxia.proto.v1.DataServer.supported_features:type_name -> replication.Feature
+	1,  // 2: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
+	12, // 3: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
+	7,  // 4: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
+	0,  // 5: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
+	3,  // 6: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	4,  // 7: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	6,  // 8: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
+	9,  // 9: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	2,  // 10: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	1,  // 11: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.DataServer
+	5,  // 12: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	8,  // 13: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
+	10, // 14: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	10, // [10:15] is the sub-list for method output_type
+	5,  // [5:10] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_admin_proto_init() }
@@ -667,6 +692,7 @@ func file_admin_proto_init() {
 	if File_admin_proto != nil {
 		return
 	}
+	file_replication_proto_init()
 	file_admin_proto_msgTypes[1].OneofWrappers = []any{}
 	file_admin_proto_msgTypes[7].OneofWrappers = []any{}
 	file_admin_proto_msgTypes[9].OneofWrappers = []any{}
@@ -676,7 +702,7 @@ func file_admin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -178,6 +178,50 @@ func (x *ListDataServersResponse) GetDataServers() []*DataServer {
 	return nil
 }
 
+type GetDataServerRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DataServer    string                 `protobuf:"bytes,1,opt,name=data_server,json=dataServer,proto3" json:"data_server,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetDataServerRequest) Reset() {
+	*x = GetDataServerRequest{}
+	mi := &file_admin_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetDataServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetDataServerRequest) ProtoMessage() {}
+
+func (x *GetDataServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetDataServerRequest.ProtoReflect.Descriptor instead.
+func (*GetDataServerRequest) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *GetDataServerRequest) GetDataServer() string {
+	if x != nil {
+		return x.DataServer
+	}
+	return ""
+}
+
 type ListNamespacesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -186,7 +230,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_admin_proto_msgTypes[3]
+	mi := &file_admin_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -198,7 +242,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[3]
+	mi := &file_admin_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -211,7 +255,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{3}
+	return file_admin_proto_rawDescGZIP(), []int{4}
 }
 
 type ListNamespacesResponse struct {
@@ -223,7 +267,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_admin_proto_msgTypes[4]
+	mi := &file_admin_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -235,7 +279,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[4]
+	mi := &file_admin_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -248,7 +292,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{4}
+	return file_admin_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []string {
@@ -266,7 +310,7 @@ type ListNodesRequest struct {
 
 func (x *ListNodesRequest) Reset() {
 	*x = ListNodesRequest{}
-	mi := &file_admin_proto_msgTypes[5]
+	mi := &file_admin_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -278,7 +322,7 @@ func (x *ListNodesRequest) String() string {
 func (*ListNodesRequest) ProtoMessage() {}
 
 func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[5]
+	mi := &file_admin_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -291,7 +335,7 @@ func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesRequest.ProtoReflect.Descriptor instead.
 func (*ListNodesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{5}
+	return file_admin_proto_rawDescGZIP(), []int{6}
 }
 
 type Node struct {
@@ -306,7 +350,7 @@ type Node struct {
 
 func (x *Node) Reset() {
 	*x = Node{}
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -318,7 +362,7 @@ func (x *Node) String() string {
 func (*Node) ProtoMessage() {}
 
 func (x *Node) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -331,7 +375,7 @@ func (x *Node) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Node.ProtoReflect.Descriptor instead.
 func (*Node) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{6}
+	return file_admin_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Node) GetName() string {
@@ -371,7 +415,7 @@ type ListNodesResponse struct {
 
 func (x *ListNodesResponse) Reset() {
 	*x = ListNodesResponse{}
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -383,7 +427,7 @@ func (x *ListNodesResponse) String() string {
 func (*ListNodesResponse) ProtoMessage() {}
 
 func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -396,7 +440,7 @@ func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesResponse.ProtoReflect.Descriptor instead.
 func (*ListNodesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{7}
+	return file_admin_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListNodesResponse) GetNodes() []*Node {
@@ -418,7 +462,7 @@ type SplitShardRequest struct {
 
 func (x *SplitShardRequest) Reset() {
 	*x = SplitShardRequest{}
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -430,7 +474,7 @@ func (x *SplitShardRequest) String() string {
 func (*SplitShardRequest) ProtoMessage() {}
 
 func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -443,7 +487,7 @@ func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardRequest.ProtoReflect.Descriptor instead.
 func (*SplitShardRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{8}
+	return file_admin_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *SplitShardRequest) GetNamespace() string {
@@ -477,7 +521,7 @@ type SplitShardResponse struct {
 
 func (x *SplitShardResponse) Reset() {
 	*x = SplitShardResponse{}
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -489,7 +533,7 @@ func (x *SplitShardResponse) String() string {
 func (*SplitShardResponse) ProtoMessage() {}
 
 func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -502,7 +546,7 @@ func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardResponse.ProtoReflect.Descriptor instead.
 func (*SplitShardResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{9}
+	return file_admin_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *SplitShardResponse) GetLeftChildShard() int64 {
@@ -532,7 +576,10 @@ const file_admin_proto_rawDesc = "" +
 	"\x10internal_address\x18\x03 \x01(\tR\x0finternalAddressB\a\n" +
 	"\x05_name\"Z\n" +
 	"\x17ListDataServersResponse\x12?\n" +
-	"\fdata_servers\x18\x01 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\vdataServers\"\x17\n" +
+	"\fdata_servers\x18\x01 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\vdataServers\"7\n" +
+	"\x14GetDataServerRequest\x12\x1f\n" +
+	"\vdata_server\x18\x01 \x01(\tR\n" +
+	"dataServer\"\x17\n" +
 	"\x15ListNamespacesRequest\"8\n" +
 	"\x16ListNamespacesResponse\x12\x1e\n" +
 	"\n" +
@@ -558,9 +605,10 @@ const file_admin_proto_rawDesc = "" +
 	"\f_split_point\"j\n" +
 	"\x12SplitShardResponse\x12(\n" +
 	"\x10left_child_shard\x18\x01 \x01(\x03R\x0eleftChildShard\x12*\n" +
-	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\x87\x03\n" +
+	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xde\x03\n" +
 	"\tOxiaAdmin\x12f\n" +
-	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12c\n" +
+	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12U\n" +
+	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a\x1c.io.oxia.proto.v1.DataServer\x12c\n" +
 	"\x0eListNamespaces\x12'.io.oxia.proto.v1.ListNamespacesRequest\x1a(.io.oxia.proto.v1.ListNamespacesResponse\x12T\n" +
 	"\tListNodes\x12\".io.oxia.proto.v1.ListNodesRequest\x1a#.io.oxia.proto.v1.ListNodesResponse\x12W\n" +
 	"\n" +
@@ -578,34 +626,37 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_admin_proto_goTypes = []any{
 	(*ListDataServersRequest)(nil),  // 0: io.oxia.proto.v1.ListDataServersRequest
 	(*DataServer)(nil),              // 1: io.oxia.proto.v1.DataServer
 	(*ListDataServersResponse)(nil), // 2: io.oxia.proto.v1.ListDataServersResponse
-	(*ListNamespacesRequest)(nil),   // 3: io.oxia.proto.v1.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),  // 4: io.oxia.proto.v1.ListNamespacesResponse
-	(*ListNodesRequest)(nil),        // 5: io.oxia.proto.v1.ListNodesRequest
-	(*Node)(nil),                    // 6: io.oxia.proto.v1.Node
-	(*ListNodesResponse)(nil),       // 7: io.oxia.proto.v1.ListNodesResponse
-	(*SplitShardRequest)(nil),       // 8: io.oxia.proto.v1.SplitShardRequest
-	(*SplitShardResponse)(nil),      // 9: io.oxia.proto.v1.SplitShardResponse
-	nil,                             // 10: io.oxia.proto.v1.Node.MetadataEntry
+	(*GetDataServerRequest)(nil),    // 3: io.oxia.proto.v1.GetDataServerRequest
+	(*ListNamespacesRequest)(nil),   // 4: io.oxia.proto.v1.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),  // 5: io.oxia.proto.v1.ListNamespacesResponse
+	(*ListNodesRequest)(nil),        // 6: io.oxia.proto.v1.ListNodesRequest
+	(*Node)(nil),                    // 7: io.oxia.proto.v1.Node
+	(*ListNodesResponse)(nil),       // 8: io.oxia.proto.v1.ListNodesResponse
+	(*SplitShardRequest)(nil),       // 9: io.oxia.proto.v1.SplitShardRequest
+	(*SplitShardResponse)(nil),      // 10: io.oxia.proto.v1.SplitShardResponse
+	nil,                             // 11: io.oxia.proto.v1.Node.MetadataEntry
 }
 var file_admin_proto_depIdxs = []int32{
 	1,  // 0: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	10, // 1: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
-	6,  // 2: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
+	11, // 1: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
+	7,  // 2: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
 	0,  // 3: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	3,  // 4: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	5,  // 5: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
-	8,  // 6: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	2,  // 7: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	4,  // 8: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	7,  // 9: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
-	9,  // 10: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	7,  // [7:11] is the sub-list for method output_type
-	3,  // [3:7] is the sub-list for method input_type
+	3,  // 4: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	4,  // 5: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	6,  // 6: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
+	9,  // 7: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	2,  // 8: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	1,  // 9: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.DataServer
+	5,  // 10: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	8,  // 11: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
+	10, // 12: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	8,  // [8:13] is the sub-list for method output_type
+	3,  // [3:8] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -617,15 +668,15 @@ func file_admin_proto_init() {
 		return
 	}
 	file_admin_proto_msgTypes[1].OneofWrappers = []any{}
-	file_admin_proto_msgTypes[6].OneofWrappers = []any{}
-	file_admin_proto_msgTypes[8].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[7].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[9].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -25,6 +25,7 @@ option java_multiple_files = true;
 service OxiaAdmin {
 
   rpc ListDataServers(ListDataServersRequest) returns (ListDataServersResponse);
+  rpc GetDataServer(GetDataServerRequest) returns (DataServer);
 
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
 
@@ -50,6 +51,10 @@ message DataServer {
 
 message ListDataServersResponse {
   repeated DataServer data_servers = 1;
+}
+
+message GetDataServerRequest {
+  string data_server = 1;
 }
 
 message ListNamespacesRequest {

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -19,6 +19,8 @@ syntax = "proto3";
 
 package io.oxia.proto.v1;
 
+import "replication.proto";
+
 option go_package = "github.com/oxia-db/oxia/common/proto";
 option java_multiple_files = true;
 
@@ -47,6 +49,8 @@ message DataServer {
   optional string name = 1;
   string public_address = 2;
   string internal_address = 3;
+  map<string, string> metadata = 4;
+  repeated replication.Feature supported_features = 5;
 }
 
 message ListDataServersResponse {

--- a/common/proto/admin_grpc.pb.go
+++ b/common/proto/admin_grpc.pb.go
@@ -37,6 +37,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	OxiaAdmin_ListDataServers_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/ListDataServers"
+	OxiaAdmin_GetDataServer_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/GetDataServer"
 	OxiaAdmin_ListNamespaces_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
 	OxiaAdmin_ListNodes_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/ListNodes"
 	OxiaAdmin_SplitShard_FullMethodName      = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
@@ -47,6 +48,7 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type OxiaAdminClient interface {
 	ListDataServers(ctx context.Context, in *ListDataServersRequest, opts ...grpc.CallOption) (*ListDataServersResponse, error)
+	GetDataServer(ctx context.Context, in *GetDataServerRequest, opts ...grpc.CallOption) (*DataServer, error)
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// Deprecated: Use ListDataServers instead.
 	ListNodes(ctx context.Context, in *ListNodesRequest, opts ...grpc.CallOption) (*ListNodesResponse, error)
@@ -68,6 +70,16 @@ func (c *oxiaAdminClient) ListDataServers(ctx context.Context, in *ListDataServe
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListDataServersResponse)
 	err := c.cc.Invoke(ctx, OxiaAdmin_ListDataServers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *oxiaAdminClient) GetDataServer(ctx context.Context, in *GetDataServerRequest, opts ...grpc.CallOption) (*DataServer, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DataServer)
+	err := c.cc.Invoke(ctx, OxiaAdmin_GetDataServer_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,6 +121,7 @@ func (c *oxiaAdminClient) SplitShard(ctx context.Context, in *SplitShardRequest,
 // for forward compatibility.
 type OxiaAdminServer interface {
 	ListDataServers(context.Context, *ListDataServersRequest) (*ListDataServersResponse, error)
+	GetDataServer(context.Context, *GetDataServerRequest) (*DataServer, error)
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// Deprecated: Use ListDataServers instead.
 	ListNodes(context.Context, *ListNodesRequest) (*ListNodesResponse, error)
@@ -128,6 +141,9 @@ type UnimplementedOxiaAdminServer struct{}
 
 func (UnimplementedOxiaAdminServer) ListDataServers(context.Context, *ListDataServersRequest) (*ListDataServersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListDataServers not implemented")
+}
+func (UnimplementedOxiaAdminServer) GetDataServer(context.Context, *GetDataServerRequest) (*DataServer, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetDataServer not implemented")
 }
 func (UnimplementedOxiaAdminServer) ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNamespaces not implemented")
@@ -173,6 +189,24 @@ func _OxiaAdmin_ListDataServers_Handler(srv interface{}, ctx context.Context, de
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(OxiaAdminServer).ListDataServers(ctx, req.(*ListDataServersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OxiaAdmin_GetDataServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetDataServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaAdminServer).GetDataServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaAdmin_GetDataServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaAdminServer).GetDataServer(ctx, req.(*GetDataServerRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -241,6 +275,10 @@ var OxiaAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListDataServers",
 			Handler:    _OxiaAdmin_ListDataServers_Handler,
+		},
+		{
+			MethodName: "GetDataServer",
+			Handler:    _OxiaAdmin_GetDataServer_Handler,
 		},
 		{
 			MethodName: "ListNamespaces",

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -47,6 +47,18 @@ func (m *DataServer) CloneVT() *DataServer {
 		tmpVal := *rhs
 		r.Name = &tmpVal
 	}
+	if rhs := m.Metadata; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Metadata = tmpContainer
+	}
+	if rhs := m.SupportedFeatures; rhs != nil {
+		tmpContainer := make([]Feature, len(rhs))
+		copy(tmpContainer, rhs)
+		r.SupportedFeatures = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -273,6 +285,27 @@ func (this *DataServer) EqualVT(that *DataServer) bool {
 	}
 	if this.InternalAddress != that.InternalAddress {
 		return false
+	}
+	if len(this.Metadata) != len(that.Metadata) {
+		return false
+	}
+	for i, vx := range this.Metadata {
+		vy, ok := that.Metadata[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	if len(this.SupportedFeatures) != len(that.SupportedFeatures) {
+		return false
+	}
+	for i, vx := range this.SupportedFeatures {
+		vy := that.SupportedFeatures[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -572,6 +605,46 @@ func (m *DataServer) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.SupportedFeatures) > 0 {
+		var pksize2 int
+		for _, num := range m.SupportedFeatures {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.SupportedFeatures {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if len(m.Metadata) > 0 {
+		for k := range m.Metadata {
+			v := m.Metadata[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x22
+		}
 	}
 	if len(m.InternalAddress) > 0 {
 		i -= len(m.InternalAddress)
@@ -1029,6 +1102,21 @@ func (m *DataServer) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if len(m.Metadata) > 0 {
+		for k, v := range m.Metadata {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.SupportedFeatures) > 0 {
+		l = 0
+		for _, e := range m.SupportedFeatures {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -1358,6 +1446,202 @@ func (m *DataServer) UnmarshalVT(dAtA []byte) error {
 			}
 			m.InternalAddress = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Metadata[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 5:
+			if wireType == 0 {
+				var v Feature
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= Feature(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.SupportedFeatures = append(m.SupportedFeatures, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.SupportedFeatures) == 0 {
+					m.SupportedFeatures = make([]Feature, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v Feature
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= Feature(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.SupportedFeatures = append(m.SupportedFeatures, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field SupportedFeatures", wireType)
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -2493,6 +2777,210 @@ func (m *DataServer) UnmarshalVTUnsafe(dAtA []byte) error {
 			}
 			m.InternalAddress = stringValue
 			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapvalue == 0 {
+						mapvalue = ""
+					} else {
+						mapvalue = unsafe.String(&dAtA[iNdEx], intStringLenmapvalue)
+					}
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Metadata[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 5:
+			if wireType == 0 {
+				var v Feature
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= Feature(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.SupportedFeatures = append(m.SupportedFeatures, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.SupportedFeatures) == 0 {
+					m.SupportedFeatures = make([]Feature, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v Feature
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= Feature(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.SupportedFeatures = append(m.SupportedFeatures, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field SupportedFeatures", wireType)
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -81,6 +81,23 @@ func (m *ListDataServersResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *GetDataServerRequest) CloneVT() *GetDataServerRequest {
+	if m == nil {
+		return (*GetDataServerRequest)(nil)
+	}
+	r := new(GetDataServerRequest)
+	r.DataServer = m.DataServer
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetDataServerRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListNamespacesRequest) CloneVT() *ListNamespacesRequest {
 	if m == nil {
 		return (*ListNamespacesRequest)(nil)
@@ -295,6 +312,25 @@ func (this *ListDataServersResponse) EqualVT(that *ListDataServersResponse) bool
 
 func (this *ListDataServersResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*ListDataServersResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *GetDataServerRequest) EqualVT(that *GetDataServerRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.DataServer != that.DataServer {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetDataServerRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*GetDataServerRequest)
 	if !ok {
 		return false
 	}
@@ -602,6 +638,46 @@ func (m *ListDataServersResponse) MarshalToSizedBufferVT(dAtA []byte) (int, erro
 			i--
 			dAtA[i] = 0xa
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetDataServerRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetDataServerRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetDataServerRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.DataServer) > 0 {
+		i -= len(m.DataServer)
+		copy(dAtA[i:], m.DataServer)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DataServer)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -968,6 +1044,20 @@ func (m *ListDataServersResponse) SizeVT() (n int) {
 			l = e.SizeVT()
 			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetDataServerRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DataServer)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1352,6 +1442,89 @@ func (m *ListDataServersResponse) UnmarshalVT(dAtA []byte) error {
 			if err := m.DataServers[len(m.DataServers)-1].UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetDataServerRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataServer = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -2404,6 +2577,93 @@ func (m *ListDataServersResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 			if err := m.DataServers[len(m.DataServers)-1].UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *GetDataServerRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DataServer = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/common/proto/client.pb.go
+++ b/common/proto/client.pb.go
@@ -312,6 +312,7 @@ func (x *ShardAssignmentsRequest) GetNamespace() string {
 type ShardAssignments struct {
 	state         protoimpl.MessageState                `protogen:"open.v1"`
 	Namespaces    map[string]*NamespaceShardsAssignment `protobuf:"bytes,1,rep,name=namespaces,proto3" json:"namespaces,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	ClusterId     string                                `protobuf:"bytes,2,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -351,6 +352,13 @@ func (x *ShardAssignments) GetNamespaces() map[string]*NamespaceShardsAssignment
 		return x.Namespaces
 	}
 	return nil
+}
+
+func (x *ShardAssignments) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
 }
 
 // *
@@ -2332,6 +2340,7 @@ type LeaderHint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Shard         int64                  `protobuf:"varint,1,opt,name=shard,proto3" json:"shard,omitempty"`
 	LeaderAddress string                 `protobuf:"bytes,2,opt,name=leader_address,json=leaderAddress,proto3" json:"leader_address,omitempty"`
+	ClusterId     string                 `protobuf:"bytes,3,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2380,17 +2389,26 @@ func (x *LeaderHint) GetLeaderAddress() string {
 	return ""
 }
 
+func (x *LeaderHint) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
+}
+
 var File_client_proto protoreflect.FileDescriptor
 
 const file_client_proto_rawDesc = "" +
 	"\n" +
 	"\fclient.proto\x12\x10io.oxia.proto.v1\"7\n" +
 	"\x17ShardAssignmentsRequest\x12\x1c\n" +
-	"\tnamespace\x18\x01 \x01(\tR\tnamespace\"\xd2\x01\n" +
+	"\tnamespace\x18\x01 \x01(\tR\tnamespace\"\xf1\x01\n" +
 	"\x10ShardAssignments\x12R\n" +
 	"\n" +
 	"namespaces\x18\x01 \x03(\v22.io.oxia.proto.v1.ShardAssignments.NamespacesEntryR\n" +
-	"namespaces\x1aj\n" +
+	"namespaces\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\x02 \x01(\tR\tclusterId\x1aj\n" +
 	"\x0fNamespacesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12A\n" +
 	"\x05value\x18\x02 \x01(\v2+.io.oxia.proto.v1.NamespaceShardsAssignmentR\x05value:\x028\x01\"\xac\x01\n" +
@@ -2548,11 +2566,13 @@ const file_client_proto_rawDesc = "" +
 	"version_id\x18\x02 \x01(\x03H\x00R\tversionId\x88\x01\x01\x12)\n" +
 	"\x0ekey_range_last\x18\x03 \x01(\tH\x01R\fkeyRangeLast\x88\x01\x01B\r\n" +
 	"\v_version_idB\x11\n" +
-	"\x0f_key_range_last\"I\n" +
+	"\x0f_key_range_last\"h\n" +
 	"\n" +
 	"LeaderHint\x12\x14\n" +
 	"\x05shard\x18\x01 \x01(\x03R\x05shard\x12%\n" +
-	"\x0eleader_address\x18\x02 \x01(\tR\rleaderAddress**\n" +
+	"\x0eleader_address\x18\x02 \x01(\tR\rleaderAddress\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\x03 \x01(\tR\tclusterId**\n" +
 	"\x0eShardKeyRouter\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aXXHASH3\x10\x01*M\n" +

--- a/common/proto/client.proto
+++ b/common/proto/client.proto
@@ -128,6 +128,7 @@ message ShardAssignmentsRequest {
  */
 message ShardAssignments {
   map<string, NamespaceShardsAssignment> namespaces = 1;
+  string cluster_id = 2;
 }
 
 /**
@@ -520,4 +521,5 @@ message Notification {
 message LeaderHint {
   int64 shard = 1;
   string leader_address = 2;
+  string cluster_id = 3;
 }

--- a/common/proto/client_vtproto.pb.go
+++ b/common/proto/client_vtproto.pb.go
@@ -43,6 +43,7 @@ func (m *ShardAssignments) CloneVT() *ShardAssignments {
 		return (*ShardAssignments)(nil)
 	}
 	r := new(ShardAssignments)
+	r.ClusterId = m.ClusterId
 	if rhs := m.Namespaces; rhs != nil {
 		tmpContainer := make(map[string]*NamespaceShardsAssignment, len(rhs))
 		for k, v := range rhs {
@@ -832,6 +833,7 @@ func (m *LeaderHint) CloneVT() *LeaderHint {
 	r := new(LeaderHint)
 	r.Shard = m.Shard
 	r.LeaderAddress = m.LeaderAddress
+	r.ClusterId = m.ClusterId
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -887,6 +889,9 @@ func (this *ShardAssignments) EqualVT(that *ShardAssignments) bool {
 				return false
 			}
 		}
+	}
+	if this.ClusterId != that.ClusterId {
+		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -1894,6 +1899,9 @@ func (this *LeaderHint) EqualVT(that *LeaderHint) bool {
 	if this.LeaderAddress != that.LeaderAddress {
 		return false
 	}
+	if this.ClusterId != that.ClusterId {
+		return false
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -1973,6 +1981,13 @@ func (m *ShardAssignments) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ClusterId) > 0 {
+		i -= len(m.ClusterId)
+		copy(dAtA[i:], m.ClusterId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterId)))
+		i--
+		dAtA[i] = 0x12
 	}
 	if len(m.Namespaces) > 0 {
 		for k := range m.Namespaces {
@@ -3730,6 +3745,13 @@ func (m *LeaderHint) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ClusterId) > 0 {
+		i -= len(m.ClusterId)
+		copy(dAtA[i:], m.ClusterId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ClusterId)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if len(m.LeaderAddress) > 0 {
 		i -= len(m.LeaderAddress)
 		copy(dAtA[i:], m.LeaderAddress)
@@ -3777,6 +3799,10 @@ func (m *ShardAssignments) SizeVT() (n int) {
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
 		}
+	}
+	l = len(m.ClusterId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -4461,6 +4487,10 @@ func (m *LeaderHint) SizeVT() (n int) {
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	l = len(m.ClusterId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -4705,6 +4735,38 @@ func (m *ShardAssignments) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.Namespaces[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterId = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -8791,6 +8853,38 @@ func (m *LeaderHint) UnmarshalVT(dAtA []byte) error {
 			}
 			m.LeaderAddress = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ClusterId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -9061,6 +9155,42 @@ func (m *ShardAssignments) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 			}
 			m.Namespaces[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ClusterId = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -13252,6 +13382,42 @@ func (m *LeaderHint) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.LeaderAddress = stringValue
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ClusterId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.ClusterId = stringValue
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -24,6 +24,7 @@ type AdminClient interface {
 	io.Closer
 
 	ListDataServers() ([]*proto.DataServer, error)
+	GetDataServer(dataServer string) (*proto.DataServer, error)
 
 	ListNamespaces() *ListNamespacesResult
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -50,6 +50,23 @@ func (admin *adminClientImpl) ListDataServers() ([]*proto.DataServer, error) {
 	return response.DataServers, nil
 }
 
+func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServer, error) {
+	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+
+	if client == nil {
+		return nil, wrapAdminError(ErrUnknown, errors.New("unable to connect to admin server"))
+	}
+
+	response, err := client.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: dataServer})
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	return response, nil
+}
+
 func (admin *adminClientImpl) ListNodes() *ListNodesResult {
 	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
 	if err != nil {

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -34,10 +34,16 @@ import (
 type mockAdminRpcClient struct {
 	listDataServersResponse *proto.ListDataServersResponse
 	listDataServersErr      error
+	getDataServerResponse   *proto.DataServer
+	getDataServerErr        error
 }
 
 func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataServersRequest, ...grpc.CallOption) (*proto.ListDataServersResponse, error) {
 	return m.listDataServersResponse, m.listDataServersErr
+}
+
+func (m *mockAdminRpcClient) GetDataServer(context.Context, *proto.GetDataServerRequest, ...grpc.CallOption) (*proto.DataServer, error) {
+	return m.getDataServerResponse, m.getDataServerErr
 }
 
 func (*mockAdminRpcClient) ListNamespaces(context.Context, *proto.ListNamespacesRequest, ...grpc.CallOption) (*proto.ListNamespacesResponse, error) {
@@ -168,6 +174,30 @@ func TestAdminClientListDataServersReturnsResponse(t *testing.T) {
 	assert.Equal(t, serverName, *dataServers[0].Name)
 	assert.Equal(t, "public-1", dataServers[0].PublicAddress)
 	assert.Equal(t, "internal-1", dataServers[0].InternalAddress)
+}
+
+func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
+	serverName := "server-1"
+	admin := &adminClientImpl{
+		adminAddr: "admin-addr",
+		clientPool: &mockAdminClientPool{
+			adminClient: &mockAdminRpcClient{
+				getDataServerResponse: &proto.DataServer{
+					Name:            &serverName,
+					PublicAddress:   "public-1",
+					InternalAddress: "internal-1",
+				},
+			},
+		},
+	}
+
+	dataServer, err := admin.GetDataServer(serverName)
+	require.NoError(t, err)
+	require.NotNil(t, dataServer)
+	require.NotNil(t, dataServer.Name)
+	assert.Equal(t, serverName, *dataServer.Name)
+	assert.Equal(t, "public-1", dataServer.PublicAddress)
+	assert.Equal(t, "internal-1", dataServer.InternalAddress)
 }
 
 func TestWrapAdminErrorPreservesCause(t *testing.T) {

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -183,9 +183,11 @@ func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
 		clientPool: &mockAdminClientPool{
 			adminClient: &mockAdminRpcClient{
 				getDataServerResponse: &proto.DataServer{
-					Name:            &serverName,
-					PublicAddress:   "public-1",
-					InternalAddress: "internal-1",
+					Name:              &serverName,
+					PublicAddress:     "public-1",
+					InternalAddress:   "internal-1",
+					Metadata:          map[string]string{"rack": "r1"},
+					SupportedFeatures: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM},
 				},
 			},
 		},
@@ -198,6 +200,8 @@ func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
 	assert.Equal(t, serverName, *dataServer.Name)
 	assert.Equal(t, "public-1", dataServer.PublicAddress)
 	assert.Equal(t, "internal-1", dataServer.InternalAddress)
+	assert.Equal(t, map[string]string{"rack": "r1"}, dataServer.Metadata)
+	assert.Equal(t, []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}, dataServer.SupportedFeatures)
 }
 
 func TestWrapAdminErrorPreservesCause(t *testing.T) {

--- a/oxia/internal/executor.go
+++ b/oxia/internal/executor.go
@@ -100,6 +100,9 @@ func (e *executorImpl) ExecuteRangeScan(ctx context.Context, request *proto.Rang
 func (e *executorImpl) rpc(shardId *int64, hint *proto.LeaderHint) (proto.OxiaClientClient, error) {
 	var target string
 	if hint.GetLeaderAddress() != "" {
+		if _, err := validateClusterID(e.ShardManager.ClusterID(), hint.GetClusterId()); err != nil {
+			return nil, err
+		}
 		target = hint.GetLeaderAddress()
 	} else {
 		if shardId != nil {

--- a/oxia/internal/shard_manager.go
+++ b/oxia/internal/shard_manager.go
@@ -35,12 +35,15 @@ import (
 	"github.com/oxia-db/oxia/common/proto"
 )
 
+var ErrClusterIDMismatch = errors.New("oxia: cluster id mismatch")
+
 type ShardManager interface {
 	io.Closer
 	Get(key string) int64
 	GetAll() []int64
 	Leader(shardId int64) string
 	Exists(shardId int64) bool
+	ClusterID() string
 }
 
 type shardManagerImpl struct {
@@ -56,6 +59,7 @@ type shardManagerImpl struct {
 	cancel         context.CancelFunc
 	logger         *slog.Logger
 	requestTimeout time.Duration
+	clusterID      string
 }
 
 func NewShardManager(shardStrategy ShardStrategy, clientPool rpc.ClientPool,
@@ -147,6 +151,12 @@ func (s *shardManagerImpl) Exists(shardId int64) bool {
 	return ok
 }
 
+func (s *shardManagerImpl) ClusterID() string {
+	s.RLock()
+	defer s.RUnlock()
+	return s.clusterID
+}
+
 func (s *shardManagerImpl) isClosed() bool {
 	return s.ctx.Err() != nil
 }
@@ -212,6 +222,13 @@ func (s *shardManagerImpl) receive(backOff backoff.BackOff) error {
 		if !ok {
 			return errors.New("namespace not found in shards assignments")
 		}
+		clusterID, err := validateClusterID(s.ClusterID(), response.GetClusterId())
+		if err != nil {
+			return err
+		}
+		s.Lock()
+		s.clusterID = clusterID
+		s.Unlock()
 
 		shards := make([]Shard, len(assignments.Assignments))
 		for i, assignment := range assignments.Assignments {
@@ -251,10 +268,27 @@ func overlap(a HashRange, b HashRange) bool {
 }
 
 func isErrorRetryable(err error) bool {
+	if errors.Is(err, ErrClusterIDMismatch) {
+		return false
+	}
 	switch status.Code(err) {
 	case constant.CodeNamespaceNotFound, codes.Unauthenticated:
 		return false
 	default:
 		return true
 	}
+}
+
+func validateClusterID(currentClusterID string, responseClusterID string) (string, error) {
+	if responseClusterID == "" {
+		return currentClusterID, nil
+	}
+	if currentClusterID == "" {
+		return responseClusterID, nil
+	}
+	if currentClusterID != responseClusterID {
+		return currentClusterID, errors.Wrapf(ErrClusterIDMismatch,
+			"expected cluster %q, received cluster %q", currentClusterID, responseClusterID)
+	}
+	return currentClusterID, nil
 }

--- a/oxia/internal/shard_manager_test.go
+++ b/oxia/internal/shard_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOverlap(t *testing.T) {
@@ -34,4 +35,22 @@ func TestOverlap(t *testing.T) {
 	} {
 		assert.Equal(t, overlap(item.a, item.b), item.isOverlap)
 	}
+}
+
+func TestValidateClusterID(t *testing.T) {
+	clusterID, err := validateClusterID("", "cluster-a")
+	require.NoError(t, err)
+	assert.Equal(t, "cluster-a", clusterID)
+
+	clusterID, err = validateClusterID("cluster-a", "cluster-a")
+	require.NoError(t, err)
+	assert.Equal(t, "cluster-a", clusterID)
+
+	clusterID, err = validateClusterID("cluster-a", "")
+	require.NoError(t, err)
+	assert.Equal(t, "cluster-a", clusterID)
+
+	_, err = validateClusterID("cluster-a", "cluster-b")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrClusterIDMismatch)
 }

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -24,6 +24,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/coordinator/controller"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	"github.com/oxia-db/oxia/oxiad/coordinator/resource"
 )
@@ -31,6 +32,10 @@ import (
 // ShardSplitter is implemented by the coordinator to initiate shard splits.
 type ShardSplitter interface {
 	InitiateSplit(namespace string, parentShardId int64, splitPoint *uint32) (leftChild, rightChild int64, err error)
+}
+
+type DataServerFeatureProvider interface {
+	NodeControllers() map[string]controller.DataServerController
 }
 
 var _ proto.OxiaAdminServer = (*adminServer)(nil)
@@ -41,6 +46,7 @@ type adminServer struct {
 	statusResource resource.StatusResource
 	clusterConfig  func() (model.ClusterConfig, error)
 	shardSplitter  ShardSplitter
+	featureSource  DataServerFeatureProvider
 }
 
 func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
@@ -51,11 +57,7 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 
 	dataServers := make([]*proto.DataServer, len(cnf.Servers))
 	for i, server := range cnf.Servers {
-		dataServers[i] = &proto.DataServer{
-			Name:            server.Name,
-			PublicAddress:   server.Public,
-			InternalAddress: server.Internal,
-		}
+		dataServers[i] = admin.toProtoDataServer(cnf, server)
 	}
 
 	return &proto.ListDataServersResponse{DataServers: dataServers}, nil
@@ -71,14 +73,36 @@ func (admin *adminServer) GetDataServer(_ context.Context, req *proto.GetDataSer
 		if server.GetIdentifier() != req.DataServer {
 			continue
 		}
-		return &proto.DataServer{
-			Name:            server.Name,
-			PublicAddress:   server.Public,
-			InternalAddress: server.Internal,
-		}, nil
+		return admin.toProtoDataServer(cnf, server), nil
 	}
 
 	return nil, grpcstatus.Errorf(codes.NotFound, "data server %q not found", req.DataServer)
+}
+
+func (admin *adminServer) toProtoDataServer(cnf model.ClusterConfig, server model.Server) *proto.DataServer {
+	identifier := server.GetIdentifier()
+	nodeMeta := cnf.ServerMetadata[identifier]
+
+	return &proto.DataServer{
+		Name:              server.Name,
+		PublicAddress:     server.Public,
+		InternalAddress:   server.Internal,
+		Metadata:          nodeMeta.Labels,
+		SupportedFeatures: admin.supportedFeatures(identifier),
+	}
+}
+
+func (admin *adminServer) supportedFeatures(dataServer string) []proto.Feature {
+	if admin.featureSource == nil {
+		return nil
+	}
+
+	nodeController, ok := admin.featureSource.NodeControllers()[dataServer]
+	if !ok || nodeController == nil {
+		return nil
+	}
+
+	return nodeController.SupportedFeatures()
 }
 
 func (admin *adminServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
@@ -147,10 +171,12 @@ func newAdminServer(
 	statusResource resource.StatusResource,
 	clusterConfig func() (model.ClusterConfig, error),
 	shardSplitter ShardSplitter,
+	featureSource DataServerFeatureProvider,
 ) *adminServer {
 	return &adminServer{
 		statusResource: statusResource,
 		clusterConfig:  clusterConfig,
 		shardSplitter:  shardSplitter,
+		featureSource:  featureSource,
 	}
 }

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/emirpasic/gods/v2/sets/hashset"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
@@ -57,6 +59,26 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 	}
 
 	return &proto.ListDataServersResponse{DataServers: dataServers}, nil
+}
+
+func (admin *adminServer) GetDataServer(_ context.Context, req *proto.GetDataServerRequest) (*proto.DataServer, error) {
+	cnf, err := admin.clusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, server := range cnf.Servers {
+		if server.GetIdentifier() != req.DataServer {
+			continue
+		}
+		return &proto.DataServer{
+			Name:            server.Name,
+			PublicAddress:   server.Public,
+			InternalAddress: server.Internal,
+		}, nil
+	}
+
+	return nil, grpcstatus.Errorf(codes.NotFound, "data server %q not found", req.DataServer)
 }
 
 func (admin *adminServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {

--- a/oxiad/coordinator/admin_server_test.go
+++ b/oxiad/coordinator/admin_server_test.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
@@ -62,4 +64,46 @@ func TestAdminServerListDataServers(t *testing.T) {
 	assert.Equal(t, serverName3, *res.DataServers[2].Name)
 	assert.Equal(t, "public-3", res.DataServers[2].PublicAddress)
 	assert.Equal(t, "internal-3", res.DataServers[2].InternalAddress)
+}
+
+func TestAdminServerGetDataServer(t *testing.T) {
+	serverName := "server-2"
+
+	admin := newAdminServer(
+		nil,
+		func() (model.ClusterConfig, error) {
+			return model.ClusterConfig{
+				Servers: []model.Server{
+					{Public: "public-1", Internal: "internal-1"},
+					{Name: &serverName, Public: "public-2", Internal: "internal-2"},
+				},
+			}, nil
+		},
+		nil,
+	)
+
+	res, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: serverName})
+	require.NoError(t, err)
+	require.NotNil(t, res.Name)
+	assert.Equal(t, serverName, *res.Name)
+	assert.Equal(t, "public-2", res.PublicAddress)
+	assert.Equal(t, "internal-2", res.InternalAddress)
+}
+
+func TestAdminServerGetDataServerNotFound(t *testing.T) {
+	admin := newAdminServer(
+		nil,
+		func() (model.ClusterConfig, error) {
+			return model.ClusterConfig{
+				Servers: []model.Server{
+					{Public: "public-1", Internal: "internal-1"},
+				},
+			}, nil
+		},
+		nil,
+	)
+
+	_, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: "missing"})
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, grpcstatus.Code(err))
 }

--- a/oxiad/coordinator/admin_server_test.go
+++ b/oxiad/coordinator/admin_server_test.go
@@ -24,8 +24,34 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxiad/coordinator/controller"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 )
+
+type testDataServerController struct {
+	features []proto.Feature
+}
+
+func (*testDataServerController) Close() error {
+	return nil
+}
+
+func (*testDataServerController) Status() controller.DataServerStatus {
+	return controller.Running
+}
+
+func (t *testDataServerController) SupportedFeatures() []proto.Feature {
+	return t.features
+}
+
+func (*testDataServerController) SetStatus(controller.DataServerStatus) {
+}
+
+type testDataServerFeatureProvider map[string]controller.DataServerController
+
+func (t testDataServerFeatureProvider) NodeControllers() map[string]controller.DataServerController {
+	return t
+}
 
 func TestAdminServerListDataServers(t *testing.T) {
 	serverName1 := "server-1"
@@ -41,9 +67,15 @@ func TestAdminServerListDataServers(t *testing.T) {
 					{Name: &serverName2, Public: "public-2", Internal: "internal-2"},
 					{Name: &serverName3, Public: "public-3", Internal: "internal-3"},
 				},
+				ServerMetadata: map[string]model.ServerMetadata{
+					serverName2: {Labels: map[string]string{"rack": "r2"}},
+				},
 			}, nil
 		},
 		nil,
+		testDataServerFeatureProvider{
+			serverName2: &testDataServerController{features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}},
+		},
 	)
 
 	res, err := admin.ListDataServers(context.Background(), &proto.ListDataServersRequest{})
@@ -59,11 +91,15 @@ func TestAdminServerListDataServers(t *testing.T) {
 	assert.Equal(t, serverName2, *res.DataServers[1].Name)
 	assert.Equal(t, "public-2", res.DataServers[1].PublicAddress)
 	assert.Equal(t, "internal-2", res.DataServers[1].InternalAddress)
+	assert.Equal(t, map[string]string{"rack": "r2"}, res.DataServers[1].Metadata)
+	assert.Equal(t, []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}, res.DataServers[1].SupportedFeatures)
 
 	require.NotNil(t, res.DataServers[2].Name)
 	assert.Equal(t, serverName3, *res.DataServers[2].Name)
 	assert.Equal(t, "public-3", res.DataServers[2].PublicAddress)
 	assert.Equal(t, "internal-3", res.DataServers[2].InternalAddress)
+	assert.Nil(t, res.DataServers[2].Metadata)
+	assert.Nil(t, res.DataServers[2].SupportedFeatures)
 }
 
 func TestAdminServerGetDataServer(t *testing.T) {
@@ -77,9 +113,15 @@ func TestAdminServerGetDataServer(t *testing.T) {
 					{Public: "public-1", Internal: "internal-1"},
 					{Name: &serverName, Public: "public-2", Internal: "internal-2"},
 				},
+				ServerMetadata: map[string]model.ServerMetadata{
+					serverName: {Labels: map[string]string{"zone": "z1"}},
+				},
 			}, nil
 		},
 		nil,
+		testDataServerFeatureProvider{
+			serverName: &testDataServerController{features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}},
+		},
 	)
 
 	res, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: serverName})
@@ -88,6 +130,8 @@ func TestAdminServerGetDataServer(t *testing.T) {
 	assert.Equal(t, serverName, *res.Name)
 	assert.Equal(t, "public-2", res.PublicAddress)
 	assert.Equal(t, "internal-2", res.InternalAddress)
+	assert.Equal(t, map[string]string{"zone": "z1"}, res.Metadata)
+	assert.Equal(t, []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}, res.SupportedFeatures)
 }
 
 func TestAdminServerGetDataServerNotFound(t *testing.T) {
@@ -100,6 +144,7 @@ func TestAdminServerGetDataServerNotFound(t *testing.T) {
 				},
 			}, nil
 		},
+		nil,
 		nil,
 	)
 

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	pb "google.golang.org/protobuf/proto"
@@ -326,6 +327,18 @@ func (c *coordinator) WaitForNextUpdate(ctx context.Context, currentValue *proto
 	return c.assignments, nil
 }
 
+func (c *coordinator) ensureClusterID() {
+	status := c.statusResource.Load()
+	if status.ClusterId != "" {
+		return
+	}
+
+	cloned := status.Clone()
+	cloned.ClusterId = uuid.NewString()
+	c.Info("Assigning persistent cluster ID", slog.String("cluster-id", cloned.ClusterId))
+	c.statusResource.Update(cloned)
+}
+
 func (c *coordinator) startBackgroundActionWorker() {
 	defer c.Done()
 	for {
@@ -386,10 +399,11 @@ func (c *coordinator) handleActionChangeEnsemble(ac action.Action) {
 
 // This is called while already holding the lock on the coordinator.
 func (c *coordinator) computeNewAssignments() {
+	status := c.statusResource.Load()
 	c.assignments = &proto.ShardAssignments{
+		ClusterId:  status.ClusterId,
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{},
 	}
-	status := c.statusResource.Load()
 	// Update the leader for the shards on all the namespaces
 	for name, ns := range status.Namespaces {
 		nsAssignments := &proto.NamespaceShardsAssignment{
@@ -730,6 +744,7 @@ func NewCoordinator(meta metadata.Provider,
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	c.assignmentsChanged = concurrent.NewConditionContext(c)
 	c.statusResource = resource.NewStatusResource(meta)
+	c.ensureClusterID()
 
 	c.configResource = resource.NewClusterConfigResource(c.ctx, clusterConfigProvider, clusterConfigNotificationsCh, c)
 

--- a/oxiad/coordinator/model/cluster_status.go
+++ b/oxiad/coordinator/model/cluster_status.go
@@ -14,6 +14,8 @@
 
 package model
 
+import "github.com/google/uuid"
+
 type Int32HashRange struct {
 	// The minimum inclusive hash that the shard can contain
 	Min uint32 `json:"min"`
@@ -109,6 +111,7 @@ type NamespaceStatus struct {
 }
 
 type ClusterStatus struct {
+	ClusterId        string                     `json:"clusterId" yaml:"clusterId"`
 	Namespaces       map[string]NamespaceStatus `json:"namespaces" yaml:"namespaces"`
 	ShardIdGenerator int64                      `json:"shardIdGenerator" yaml:"shardIdGenerator"`
 	ServerIdx        uint32                     `json:"serverIdx" yaml:"serverIdx"`
@@ -116,6 +119,7 @@ type ClusterStatus struct {
 
 func NewClusterStatus() *ClusterStatus {
 	return &ClusterStatus{
+		ClusterId:        uuid.NewString(),
 		Namespaces:       map[string]NamespaceStatus{},
 		ShardIdGenerator: 0,
 		ServerIdx:        0,
@@ -163,6 +167,7 @@ func (n NamespaceStatus) Clone() NamespaceStatus {
 
 func (c ClusterStatus) Clone() *ClusterStatus {
 	r := &ClusterStatus{
+		ClusterId:        c.ClusterId,
 		Namespaces:       make(map[string]NamespaceStatus),
 		ShardIdGenerator: c.ShardIdGenerator,
 		ServerIdx:        c.ServerIdx,

--- a/oxiad/coordinator/model/cluster_status_test.go
+++ b/oxiad/coordinator/model/cluster_status_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestClusterStatus_Clone(t *testing.T) {
 	cs1 := &ClusterStatus{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]NamespaceStatus{
 			"test-ns": {
 				ReplicationFactor: 3,
@@ -65,6 +66,12 @@ func TestClusterStatus_Clone(t *testing.T) {
 
 	assert.Equal(t, cs1.ShardIdGenerator, cs2.ShardIdGenerator)
 	assert.Equal(t, cs1.ServerIdx, cs2.ServerIdx)
+	assert.Equal(t, cs1.ClusterId, cs2.ClusterId)
+}
+
+func TestNewClusterStatusAssignsClusterID(t *testing.T) {
+	cs := NewClusterStatus()
+	assert.NotEmpty(t, cs.ClusterId)
 }
 
 func TestSplitMetadata_Clone(t *testing.T) {

--- a/oxiad/coordinator/resource/status_resource.go
+++ b/oxiad/coordinator/resource/status_resource.go
@@ -127,7 +127,7 @@ func (s *status) ensureLoaded() {
 		)
 	})
 	if s.current == nil {
-		s.current = &model.ClusterStatus{}
+		s.current = model.NewClusterStatus()
 	}
 }
 

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -202,6 +202,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 		coordinatorInstance.StatusResource(),
 		clusterConfigProvider,
 		coordinatorInstance,
+		coordinatorInstance,
 	)
 	adminGrpcServer, err := rpc2.Default.StartGrpcServer("admin", adminSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		proto.RegisterOxiaAdminServer(registrar, admin)

--- a/oxiad/dataserver/assignment/assignment_dispatcher.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/emirpasic/gods/v2/trees/redblacktree"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -52,6 +53,7 @@ type ShardAssignmentsDispatcher interface {
 	PushShardAssignments(stream proto.OxiaCoordination_PushShardAssignmentsServer) error
 	RegisterForUpdates(req *proto.ShardAssignmentsRequest, client Client) error
 	GetLeader(shard int64) string
+	ClusterID() string
 }
 
 type shardAssignmentDispatcher struct {
@@ -153,6 +155,7 @@ func (s *shardAssignmentDispatcher) RegisterForUpdates(req *proto.ShardAssignmen
 
 func filterByNamespace(assignments *proto.ShardAssignments, namespace string) *proto.ShardAssignments {
 	filtered := &proto.ShardAssignments{
+		ClusterId:  assignments.GetClusterId(),
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{},
 	}
 
@@ -305,6 +308,15 @@ func (s *shardAssignmentDispatcher) GetLeader(shardId int64) string {
 	return shard.GetLeader()
 }
 
+func (s *shardAssignmentDispatcher) ClusterID() string {
+	s.RLock()
+	defer s.RUnlock()
+	if s.assignments == nil {
+		return ""
+	}
+	return s.assignments.GetClusterId()
+}
+
 func NewShardAssignmentDispatcher(healthServer rpc2.HealthServer) ShardAssignmentsDispatcher {
 	s := &shardAssignmentDispatcher{
 		assignments:           nil,
@@ -334,6 +346,7 @@ func NewStandaloneShardAssignmentDispatcher(numShards uint32) ShardAssignmentsDi
 	assignmentDispatcher := NewShardAssignmentDispatcher(rpc2.NewClosableHealthServer(context.Background())).(*shardAssignmentDispatcher) //nolint:revive
 	assignmentDispatcher.standalone = true
 	res := &proto.ShardAssignments{
+		ClusterId: uuid.NewString(),
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
 				ShardKeyRouter: proto.ShardKeyRouter_XXHASH3,

--- a/oxiad/dataserver/assignment/assignment_dispatcher_test.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher_test.go
@@ -55,6 +55,7 @@ func TestShardAssignmentDispatcher_Initialized(t *testing.T) {
 
 	assert.False(t, dispatcher.Initialized())
 	coordinatorStream.AddRequest(&proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
 				Assignments: []*proto.ShardAssignment{
@@ -103,6 +104,7 @@ func TestShardAssignmentDispatcher_ReadinessProbe(t *testing.T) {
 	assert.Nil(t, resp)
 
 	coordinatorStream.AddRequest(&proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
 				Assignments: []*proto.ShardAssignment{
@@ -140,6 +142,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 	}()
 
 	request := &proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
 				Assignments: []*proto.ShardAssignment{
@@ -170,6 +173,7 @@ func TestShardAssignmentDispatcher_AddClient(t *testing.T) {
 	assert.True(t, pb.Equal(request, response))
 
 	request = &proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
 				Assignments: []*proto.ShardAssignment{
@@ -220,6 +224,7 @@ func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
 	}()
 
 	request := &proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			"default": {
 				Assignments: []*proto.ShardAssignment{
@@ -265,6 +270,7 @@ func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
 
 	response := mockClient.GetResponse()
 	assert.True(t, pb.Equal(&proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			"test-ns-1": {
 				Assignments: []*proto.ShardAssignment{
@@ -290,6 +296,7 @@ func TestShardAssignmentDispatcher_MultipleNamespaces(t *testing.T) {
 
 	response = mockClient.GetResponse()
 	assert.True(t, pb.Equal(&proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			"default": {
 				Assignments: []*proto.ShardAssignment{
@@ -326,6 +333,7 @@ func TestShardAssignmentDispatcher_GetLeader(t *testing.T) {
 	}()
 
 	coordinatorStream.AddRequest(&proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
 				Assignments: []*proto.ShardAssignment{
@@ -346,6 +354,7 @@ func TestShardAssignmentDispatcher_GetLeader(t *testing.T) {
 
 	// Update assignments - shard 1 moves to server3
 	coordinatorStream.AddRequest(&proto.ShardAssignments{
+		ClusterId: "cluster-1",
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{
 			constant.DefaultNamespace: {
 				Assignments: []*proto.ShardAssignment{

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -480,7 +480,7 @@ func (s *publicRpcServer) getLeader(shardId *int64) (lead.LeaderController, erro
 	lc, err := s.shardsDirector.GetLeader(shardID)
 	if err != nil {
 		if status.Code(err) == constant.CodeNodeIsNotLeader {
-			return nil, constant.NewNodeIsNotLeaderWithHint(shardID, s.assignmentDispatcher.GetLeader(shardID))
+			return nil, constant.NewNodeIsNotLeaderWithHint(shardID, s.assignmentDispatcher.GetLeader(shardID), s.assignmentDispatcher.ClusterID())
 		}
 		s.log.Warn("Failed to get the leader controller", slog.Any("error", err))
 		return nil, err


### PR DESCRIPTION
## Summary
- add a `GetDataServer` admin RPC and wire it through the admin client
- add the `oxia admin get-data-server` CLI command and its mock/test coverage
- add coordinator-side tests for found and not-found lookups

## Testing
- `go test ./cmd/admin/getdataserver ./oxia ./oxiad/coordinator`
- `make test` was started and progressed through repo-wide package runs, but the final `go test -cover -race ...` process stalled without reporting a failure in this environment