### PR TITLE
feat: validate public RPC authority against shard assignments

### DIFF
--- a/oxia/internal/batch/rpc_errors.go
+++ b/oxia/internal/batch/rpc_errors.go
@@ -41,6 +41,7 @@ func IsRetriable(err error) bool {
 	switch code {
 	case
 		codes.Unavailable,            // Failure to connect is ok to re-attempt
+		constant.CodeNotInitialized,  // Server is still warming up and should become ready shortly
 		constant.CodeInvalidStatus,   // Leader has fenced the shard, though we expect a new leader to be elected
 		constant.CodeAlreadyClosed,   // Leader is closing, though we expect a new leader to be elected
 		constant.CodeNodeIsNotLeader: /* We're making a request to a node that is not leader anymore. Retry to make

--- a/oxia/internal/batch/rpc_errors_test.go
+++ b/oxia/internal/batch/rpc_errors_test.go
@@ -1,0 +1,27 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package batch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oxia-db/oxia/common/constant"
+)
+
+func TestIsRetriable_NotInitialized(t *testing.T) {
+	assert.True(t, IsRetriable(constant.ErrNotInitialized))
+}

--- a/oxiad/common/rpc/authority.go
+++ b/oxiad/common/rpc/authority.go
@@ -1,0 +1,64 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func GetAuthority(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if authority := md.Get(":authority"); len(authority) > 0 {
+			if err := validateAuthorityAddress(authority[0]); err != nil {
+				return "", status.Errorf(codes.InvalidArgument, "oxia: invalid authority address: %v", err)
+			}
+			return authority[0], nil
+		}
+	}
+	return "", status.Errorf(codes.InvalidArgument, "oxia: authority not identified")
+}
+
+func validateAuthorityAddress(addr string) error {
+	if strings.Contains(addr, "://") {
+		return errors.Errorf("authority address %q must not contain a scheme", addr)
+	}
+	if strings.Contains(addr, "/") {
+		return errors.Errorf("authority address %q must not contain a path", addr)
+	}
+	if strings.Contains(addr, "?") {
+		return errors.Errorf("authority address %q must not contain a query string", addr)
+	}
+	if strings.Contains(addr, "#") {
+		return errors.Errorf("authority address %q must not contain a fragment", addr)
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return errors.Errorf("authority address %q is not a valid host:port pair: %v", addr, err)
+	}
+	if host == "" {
+		return errors.Errorf("authority address %q has an empty host", addr)
+	}
+
+	return nil
+}

--- a/oxiad/common/rpc/authority.go
+++ b/oxiad/common/rpc/authority.go
@@ -20,9 +20,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 func GetAuthority(ctx context.Context) (string, error) {
@@ -30,12 +28,12 @@ func GetAuthority(ctx context.Context) (string, error) {
 	if ok {
 		if authority := md.Get(":authority"); len(authority) > 0 {
 			if err := validateAuthorityAddress(authority[0]); err != nil {
-				return "", status.Errorf(codes.InvalidArgument, "oxia: invalid authority address: %v", err)
+				return "", err
 			}
 			return authority[0], nil
 		}
 	}
-	return "", status.Errorf(codes.InvalidArgument, "oxia: authority not identified")
+	return "", errors.New("authority not identified")
 }
 
 func validateAuthorityAddress(addr string) error {

--- a/oxiad/common/rpc/authority.go
+++ b/oxiad/common/rpc/authority.go
@@ -27,7 +27,7 @@ func GetAuthority(ctx context.Context) (string, error) {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if ok {
 		if authority := md.Get(":authority"); len(authority) > 0 {
-			if err := validateAuthorityAddress(authority[0]); err != nil {
+			if err := ValidateAuthorityAddress(authority[0]); err != nil {
 				return "", err
 			}
 			return authority[0], nil
@@ -36,7 +36,7 @@ func GetAuthority(ctx context.Context) (string, error) {
 	return "", errors.New("authority not identified")
 }
 
-func validateAuthorityAddress(addr string) error {
+func ValidateAuthorityAddress(addr string) error {
 	if strings.Contains(addr, "://") {
 		return errors.Errorf("authority address %q must not contain a scheme", addr)
 	}

--- a/oxiad/dataserver/assignment/assignment_dispatcher.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher.go
@@ -237,7 +237,7 @@ func (s *shardAssignmentDispatcher) Close() error {
 func (s *shardAssignmentDispatcher) Initialized() bool {
 	s.RLock()
 	defer s.RUnlock()
-	return s.assignments != nil
+	return s.standalone || s.assignments != nil
 }
 
 func (s *shardAssignmentDispatcher) PushShardAssignments(stream proto.OxiaCoordination_PushShardAssignmentsServer) error {

--- a/oxiad/dataserver/assignment/assignment_dispatcher.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc/status"
 	pb "google.golang.org/protobuf/proto"
 
-	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/oxiad/common/sharding"
@@ -62,7 +62,7 @@ type shardAssignmentDispatcher struct {
 	clients      map[int64]chan *proto.ShardAssignments
 	nextClientId int64
 	standalone   bool
-	healthServer rpc2.HealthServer
+	healthServer oxiadcommonrpc.HealthServer
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -187,7 +187,7 @@ func (s *shardAssignmentDispatcher) assignmentsInterceptorFunc(clientStream Clie
 }
 
 func authority(ctx context.Context) (string, error) {
-	addr, err := rpc2.GetAuthority(ctx)
+	addr, err := oxiadcommonrpc.GetAuthority(ctx)
 	if err == nil {
 		return addr, nil
 	}
@@ -227,7 +227,7 @@ func (s *shardAssignmentDispatcher) PushShardAssignments(stream proto.OxiaCoordi
 func (s *shardAssignmentDispatcher) updateShardAssignment(assignments *proto.ShardAssignments) error {
 	// Once we receive the first update of the shards mapping, this service can be
 	// considered "ready" and it will be able to respond to service discovery requests
-	s.healthServer.SetServingStatus(rpc2.ReadinessProbeService, grpc_health_v1.HealthCheckResponse_SERVING)
+	s.healthServer.SetServingStatus(oxiadcommonrpc.ReadinessProbeService, grpc_health_v1.HealthCheckResponse_SERVING)
 
 	s.Lock()
 	defer s.Unlock()
@@ -291,7 +291,7 @@ func (s *shardAssignmentDispatcher) HasAuthority(authority string) bool {
 	return s.validAuthorities.Contains(strings.ToLower(authority))
 }
 
-func NewShardAssignmentDispatcher(healthServer rpc2.HealthServer) ShardAssignmentsDispatcher {
+func NewShardAssignmentDispatcher(healthServer oxiadcommonrpc.HealthServer) ShardAssignmentsDispatcher {
 	s := &shardAssignmentDispatcher{
 		assignments:           nil,
 		shardAssignmentsIndex: redblacktree.New[int64, *proto.ShardAssignment](),
@@ -318,7 +318,7 @@ func NewShardAssignmentDispatcher(healthServer rpc2.HealthServer) ShardAssignmen
 }
 
 func NewStandaloneShardAssignmentDispatcher(numShards uint32) ShardAssignmentsDispatcher {
-	assignmentDispatcher := NewShardAssignmentDispatcher(rpc2.NewClosableHealthServer(context.Background())).(*shardAssignmentDispatcher) //nolint:revive
+	assignmentDispatcher := NewShardAssignmentDispatcher(oxiadcommonrpc.NewClosableHealthServer(context.Background())).(*shardAssignmentDispatcher) //nolint:revive
 	assignmentDispatcher.standalone = true
 	res := &proto.ShardAssignments{
 		Namespaces: map[string]*proto.NamespaceShardsAssignment{

--- a/oxiad/dataserver/assignment/assignment_dispatcher.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/emirpasic/gods/v2/sets/hashset"
 	"github.com/emirpasic/gods/v2/trees/redblacktree"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -52,12 +53,14 @@ type ShardAssignmentsDispatcher interface {
 	PushShardAssignments(stream proto.OxiaCoordination_PushShardAssignmentsServer) error
 	RegisterForUpdates(req *proto.ShardAssignmentsRequest, client Client) error
 	GetLeader(shard int64) string
+	HasAuthority(authority string) bool
 }
 
 type shardAssignmentDispatcher struct {
 	sync.RWMutex
 	assignments           *proto.ShardAssignments
 	shardAssignmentsIndex *redblacktree.Tree[int64, *proto.ShardAssignment]
+	validAuthorities      *hashset.Set[string]
 
 	clients      map[int64]chan *proto.ShardAssignments
 	nextClientId int64
@@ -271,12 +274,17 @@ func (s *shardAssignmentDispatcher) updateShardAssignment(assignments *proto.Sha
 	s.assignments = assignments
 
 	shardIndex := redblacktree.New[int64, *proto.ShardAssignment]()
+	validAuthorities := hashset.New[string]()
 	for _, namespace := range assignments.Namespaces {
 		for idx, shardAssignment := range namespace.Assignments {
 			shardIndex.Put(shardAssignment.GetShard(), namespace.Assignments[idx])
+			if leader := shardAssignment.GetLeader(); leader != "" {
+				validAuthorities.Add(strings.ToLower(leader))
+			}
 		}
 	}
 	s.shardAssignmentsIndex = shardIndex
+	s.validAuthorities = validAuthorities
 
 	// Update all the clients, without getting stuck if any client is not responsive
 	for id, clientCh := range s.clients {
@@ -305,10 +313,20 @@ func (s *shardAssignmentDispatcher) GetLeader(shardId int64) string {
 	return shard.GetLeader()
 }
 
+func (s *shardAssignmentDispatcher) HasAuthority(authority string) bool {
+	s.RLock()
+	defer s.RUnlock()
+	if s.standalone {
+		return true
+	}
+	return s.validAuthorities.Contains(strings.ToLower(authority))
+}
+
 func NewShardAssignmentDispatcher(healthServer rpc2.HealthServer) ShardAssignmentsDispatcher {
 	s := &shardAssignmentDispatcher{
 		assignments:           nil,
 		shardAssignmentsIndex: redblacktree.New[int64, *proto.ShardAssignment](),
+		validAuthorities:      hashset.New[string](),
 		healthServer:          healthServer,
 		clients:               make(map[int64]chan *proto.ShardAssignments),
 		log: slog.With(

--- a/oxiad/dataserver/assignment/assignment_dispatcher.go
+++ b/oxiad/dataserver/assignment/assignment_dispatcher.go
@@ -18,16 +18,13 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"net"
 	"strings"
 	"sync"
 
 	"github.com/emirpasic/gods/v2/sets/hashset"
 	"github.com/emirpasic/gods/v2/trees/redblacktree"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	pb "google.golang.org/protobuf/proto"
@@ -189,43 +186,15 @@ func (s *shardAssignmentDispatcher) assignmentsInterceptorFunc(clientStream Clie
 	}, nil
 }
 
-func validateAuthorityAddress(addr string) error {
-	if strings.Contains(addr, "://") {
-		return errors.Errorf("authority address %q must not contain a scheme", addr)
-	}
-	if strings.Contains(addr, "/") {
-		return errors.Errorf("authority address %q must not contain a path", addr)
-	}
-	if strings.Contains(addr, "?") {
-		return errors.Errorf("authority address %q must not contain a query string", addr)
-	}
-	if strings.Contains(addr, "#") {
-		return errors.Errorf("authority address %q must not contain a fragment", addr)
-	}
-
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return errors.Errorf("authority address %q is not a valid host:port pair: %v", addr, err)
-	}
-	if host == "" {
-		return errors.Errorf("authority address %q has an empty host", addr)
-	}
-
-	return nil
-}
-
 func authority(ctx context.Context) (string, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if ok {
-		addr := md[":authority"]
-		if len(addr) > 0 {
-			if err := validateAuthorityAddress(addr[0]); err != nil {
-				return "", status.Errorf(codes.InvalidArgument, "oxia: invalid authority address: %v", err)
-			}
-			return addr[0], nil
-		}
+	addr, err := rpc2.GetAuthority(ctx)
+	if err == nil {
+		return addr, nil
 	}
-	return "", status.Errorf(codes.Internal, "oxia: authority not identified")
+	if err.Error() == "authority not identified" {
+		return "", status.Errorf(codes.Internal, "oxia: authority not identified")
+	}
+	return "", status.Errorf(codes.InvalidArgument, "oxia: invalid authority address: %v", err)
 }
 
 func (s *shardAssignmentDispatcher) Close() error {

--- a/oxiad/dataserver/assignment/authority_test.go
+++ b/oxiad/dataserver/assignment/authority_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
 )
 
 func TestValidateAuthorityAddress(t *testing.T) {
@@ -88,7 +90,7 @@ func TestValidateAuthorityAddress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateAuthorityAddress(tt.addr)
+			err := rpc2.ValidateAuthorityAddress(tt.addr)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, tt.errMsg)

--- a/oxiad/dataserver/option/option.go
+++ b/oxiad/dataserver/option/option.go
@@ -27,9 +27,10 @@ import (
 )
 
 type PublicServerOptions struct {
-	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the public API server,example=0.0.0.0:6648,format=hostname"`
-	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the public API"`
-	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing public API connections"`
+	BindAddress       string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the public API server,example=0.0.0.0:6648,format=hostname"`
+	AdvertisedAddress string              `yaml:"advertisedAddress,omitempty" json:"advertisedAddress,omitempty" jsonschema:"description=Canonical public host:port clients must use for this server,example=oxia-0.oxia-headless.ns.svc.cluster.local:6648,format=hostname"`
+	Auth              auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the public API"`
+	TLS               security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing public API connections"`
 }
 
 func (pso *PublicServerOptions) WithDefault() {

--- a/oxiad/dataserver/option/option.go
+++ b/oxiad/dataserver/option/option.go
@@ -27,10 +27,9 @@ import (
 )
 
 type PublicServerOptions struct {
-	BindAddress       string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the public API server,example=0.0.0.0:6648,format=hostname"`
-	AdvertisedAddress string              `yaml:"advertisedAddress,omitempty" json:"advertisedAddress,omitempty" jsonschema:"description=Canonical public host:port clients must use for this server,example=oxia-0.oxia-headless.ns.svc.cluster.local:6648,format=hostname"`
-	Auth              auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the public API"`
-	TLS               security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing public API connections"`
+	BindAddress string              `yaml:"bindAddress" json:"bindAddress" jsonschema:"description=Bind address for the public API server,example=0.0.0.0:6648,format=hostname"`
+	Auth        auth.Options        `yaml:"auth,omitempty" json:"auth,omitempty" jsonschema:"description=Authentication configuration for the public API"`
+	TLS         security.TLSOptions `yaml:"tls,omitempty" json:"tls,omitempty" jsonschema:"description=TLS configuration for securing public API connections"`
 }
 
 func (pso *PublicServerOptions) WithDefault() {

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -59,17 +59,19 @@ const (
 type publicRpcServer struct {
 	proto.UnimplementedOxiaClientServer
 
-	shardsDirector       controller.ShardsDirector
-	assignmentDispatcher assignment.ShardAssignmentsDispatcher
-	grpcServer           oxiadcommonrpc.GrpcServer
-	log                  *slog.Logger
+	shardsDirector             controller.ShardsDirector
+	assignmentDispatcher       assignment.ShardAssignmentsDispatcher
+	disableAuthorityValidation bool
+	grpcServer                 oxiadcommonrpc.GrpcServer
+	log                        *slog.Logger
 }
 
 func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	disableAuthorityValidation bool, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
-		shardsDirector:       shardsDirector,
-		assignmentDispatcher: assignmentDispatcher,
+		shardsDirector:             shardsDirector,
+		assignmentDispatcher:       assignmentDispatcher,
+		disableAuthorityValidation: disableAuthorityValidation,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
 		),
@@ -88,6 +90,10 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 }
 
 func (s *publicRpcServer) validateAuthority(ctx context.Context) error {
+	if s.disableAuthorityValidation {
+		return nil
+	}
+
 	if !s.assignmentDispatcher.Initialized() {
 		return constant.ErrNotInitialized
 	}

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"net"
-	"strings"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -89,20 +87,14 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 	return server, nil
 }
 
-func (s *publicRpcServer) validateAuthority(ctx context.Context, shardId int64) error {
+func (s *publicRpcServer) validateAuthority(ctx context.Context) error {
 	actualAuthority, err := oxiadcommonrpc.GetAuthority(ctx)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "oxia: invalid authority: %v", err)
 	}
 
-	expectedAuthority := s.assignmentDispatcher.GetLeader(shardId)
-	if expectedAuthority == "" {
-		return nil
-	}
-
-	if !sameAuthority(actualAuthority, expectedAuthority) {
-		return status.Errorf(codes.PermissionDenied, "oxia: authority mismatch: got %q, expected %q",
-			actualAuthority, expectedAuthority)
+	if !s.assignmentDispatcher.HasAuthority(actualAuthority) {
+		return status.Errorf(codes.PermissionDenied, "oxia: unexpected authority %q", actualAuthority)
 	}
 
 	return nil
@@ -506,7 +498,7 @@ func (s *publicRpcServer) resolveLeader(ctx context.Context, shardId *int64) (le
 		s.log.Warn("Failed to get the leader controller", slog.Any("error", err))
 		return nil, err
 	}
-	if err := s.validateAuthority(ctx, shardID); err != nil {
+	if err := s.validateAuthority(ctx); err != nil {
 		return nil, err
 	}
 	return lc, nil
@@ -514,18 +506,6 @@ func (s *publicRpcServer) resolveLeader(ctx context.Context, shardId *int64) (le
 
 func (s *publicRpcServer) Close() error {
 	return s.grpcServer.Close()
-}
-
-func sameAuthority(left string, right string) bool {
-	leftHost, leftPort, err := net.SplitHostPort(left)
-	if err != nil {
-		return false
-	}
-	rightHost, rightPort, err := net.SplitHostPort(right)
-	if err != nil {
-		return false
-	}
-	return strings.EqualFold(leftHost, rightHost) && leftPort == rightPort
 }
 
 // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -498,15 +498,15 @@ func (s *publicRpcServer) resolveLeader(ctx context.Context, shardId *int64) (le
 		return nil, status.Error(codes.InvalidArgument, "shard id is required")
 	}
 	shardID := *shardId
-	if err := s.validateAuthority(ctx, shardID); err != nil {
-		return nil, err
-	}
 	lc, err := s.shardsDirector.GetLeader(shardID)
 	if err != nil {
 		if status.Code(err) == constant.CodeNodeIsNotLeader {
 			return nil, constant.NewNodeIsNotLeaderWithHint(shardID, s.assignmentDispatcher.GetLeader(shardID))
 		}
 		s.log.Warn("Failed to get the leader controller", slog.Any("error", err))
+		return nil, err
+	}
+	if err := s.validateAuthority(ctx, shardID); err != nil {
 		return nil, err
 	}
 	return lc, nil

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -127,20 +127,13 @@ func (s *publicRpcServer) GetShardAssignments(req *proto.ShardAssignmentsRequest
 }
 
 func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
-	if write.Shard == nil {
-		return nil, status.Error(codes.InvalidArgument, "shard id is required")
-	}
-	if err := s.validateAuthority(ctx, *write.Shard); err != nil {
-		return nil, err
-	}
-
 	s.log.Debug(
 		"Write request",
 		slog.String("peer", rpc.GetPeer(ctx)),
 		slog.Any("req", write),
 	)
 
-	lc, err := s.getLeader(write.Shard)
+	lc, err := s.resolveLeader(ctx, write.Shard)
 	if err != nil {
 		return nil, err
 	}
@@ -203,9 +196,6 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 	if err != nil {
 		return err
 	}
-	if err := s.validateAuthority(stream.Context(), shardId); err != nil {
-		return err
-	}
 	streamCtx := stream.Context()
 
 	log := s.log.With(
@@ -216,7 +206,7 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 	log.Debug("Write request")
 
 	var lc lead.LeaderController
-	lc, err = s.getLeader(&shardId)
+	lc, err = s.resolveLeader(stream.Context(), &shardId)
 	if err != nil {
 		return err
 	}
@@ -250,20 +240,13 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {
-	if request.Shard == nil {
-		return status.Error(codes.InvalidArgument, "shard id is required")
-	}
-	if err := s.validateAuthority(stream.Context(), *request.Shard); err != nil {
-		return err
-	}
-
 	s.log.Debug(
 		"Read request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
 		slog.Any("req", request),
 	)
 
-	lc, err := s.getLeader(request.Shard)
+	lc, err := s.resolveLeader(stream.Context(), request.Shard)
 	if err != nil {
 		return err
 	}
@@ -294,19 +277,12 @@ func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClient_ListServer) error {
-	if request.Shard == nil {
-		return status.Error(codes.InvalidArgument, "shard id is required")
-	}
-	if err := s.validateAuthority(stream.Context(), *request.Shard); err != nil {
-		return err
-	}
-
 	s.log.Debug(
 		"List request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
 		slog.Any("req", request),
 	)
-	lc, err := s.getLeader(request.Shard)
+	lc, err := s.resolveLeader(stream.Context(), request.Shard)
 	if err != nil {
 		return err
 	}
@@ -334,13 +310,6 @@ func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream proto.OxiaClient_RangeScanServer) error {
-	if request.Shard == nil {
-		return status.Error(codes.InvalidArgument, "shard id is required")
-	}
-	if err := s.validateAuthority(stream.Context(), *request.Shard); err != nil {
-		return err
-	}
-
 	s.log.Debug(
 		"RangeScan request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
@@ -350,7 +319,7 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 
 	var lc lead.LeaderController
 	var err error
-	if lc, err = s.getLeader(request.Shard); err != nil {
+	if lc, err = s.resolveLeader(stream.Context(), request.Shard); err != nil {
 		return err
 	}
 
@@ -384,10 +353,6 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 }
 
 func (s *publicRpcServer) GetNotifications(req *proto.NotificationsRequest, stream proto.OxiaClient_GetNotificationsServer) error {
-	if err := s.validateAuthority(stream.Context(), req.Shard); err != nil {
-		return err
-	}
-
 	s.log.Debug(
 		"Get notifications",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
@@ -396,7 +361,7 @@ func (s *publicRpcServer) GetNotifications(req *proto.NotificationsRequest, stre
 
 	var lc lead.LeaderController
 	var err error
-	if lc, err = s.getLeader(&req.Shard); err != nil {
+	if lc, err = s.resolveLeader(stream.Context(), &req.Shard); err != nil {
 		return err
 	}
 
@@ -430,16 +395,12 @@ func (s *publicRpcServer) Port() int {
 }
 
 func (s *publicRpcServer) CreateSession(ctx context.Context, req *proto.CreateSessionRequest) (*proto.CreateSessionResponse, error) {
-	if err := s.validateAuthority(ctx, req.Shard); err != nil {
-		return nil, err
-	}
-
 	s.log.Debug(
 		"Create session request",
 		slog.String("peer", rpc.GetPeer(ctx)),
 		slog.Any("req", req),
 	)
-	lc, err := s.getLeader(&req.Shard)
+	lc, err := s.resolveLeader(ctx, &req.Shard)
 	if err != nil {
 		return nil, err
 	}
@@ -455,17 +416,13 @@ func (s *publicRpcServer) CreateSession(ctx context.Context, req *proto.CreateSe
 }
 
 func (s *publicRpcServer) KeepAlive(ctx context.Context, req *proto.SessionHeartbeat) (*proto.KeepAliveResponse, error) {
-	if err := s.validateAuthority(ctx, req.Shard); err != nil {
-		return nil, err
-	}
-
 	s.log.Debug(
 		"Session keep alive",
 		slog.Int64("shard", req.Shard),
 		slog.Int64("session", req.SessionId),
 		slog.String("peer", rpc.GetPeer(ctx)),
 	)
-	lc, err := s.getLeader(&req.Shard)
+	lc, err := s.resolveLeader(ctx, &req.Shard)
 	if err != nil {
 		return nil, err
 	}
@@ -481,16 +438,12 @@ func (s *publicRpcServer) KeepAlive(ctx context.Context, req *proto.SessionHeart
 }
 
 func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSessionRequest) (*proto.CloseSessionResponse, error) {
-	if err := s.validateAuthority(ctx, req.Shard); err != nil {
-		return nil, err
-	}
-
 	s.log.Debug(
 		"Close session request",
 		slog.String("peer", rpc.GetPeer(ctx)),
 		slog.Any("req", req),
 	)
-	lc, err := s.getLeader(&req.Shard)
+	lc, err := s.resolveLeader(ctx, &req.Shard)
 	if err != nil {
 		return nil, err
 	}
@@ -505,16 +458,12 @@ func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSess
 }
 
 func (s *publicRpcServer) GetSequenceUpdates(req *proto.GetSequenceUpdatesRequest, stream proto.OxiaClient_GetSequenceUpdatesServer) error {
-	if err := s.validateAuthority(stream.Context(), req.Shard); err != nil {
-		return err
-	}
-
 	s.log.Debug(
 		"Get sequence update request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
 		slog.Any("req", req),
 	)
-	lc, err := s.getLeader(&req.Shard)
+	lc, err := s.resolveLeader(stream.Context(), &req.Shard)
 	if err != nil {
 		return err
 	}
@@ -544,11 +493,14 @@ func (s *publicRpcServer) GetSequenceUpdates(req *proto.GetSequenceUpdatesReques
 	}
 }
 
-func (s *publicRpcServer) getLeader(shardId *int64) (lead.LeaderController, error) {
+func (s *publicRpcServer) resolveLeader(ctx context.Context, shardId *int64) (lead.LeaderController, error) {
 	if shardId == nil {
 		return nil, status.Error(codes.InvalidArgument, "shard id is required")
 	}
 	shardID := *shardId
+	if err := s.validateAuthority(ctx, shardID); err != nil {
+		return nil, err
+	}
 	lc, err := s.shardsDirector.GetLeader(shardID)
 	if err != nil {
 		if status.Code(err) == constant.CodeNodeIsNotLeader {

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -65,15 +65,13 @@ type publicRpcServer struct {
 	assignmentDispatcher assignment.ShardAssignmentsDispatcher
 	grpcServer           rpc2.GrpcServer
 	log                  *slog.Logger
-	expectedAuthority    string
 }
 
 func newPublicRpcServer(provider rpc2.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	expectedAuthority string, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,
-		expectedAuthority:    expectedAuthority,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
 		),
@@ -91,19 +89,20 @@ func newPublicRpcServer(provider rpc2.GrpcProvider, bindAddress string, shardsDi
 	return server, nil
 }
 
-func (s *publicRpcServer) validateAuthority(ctx context.Context) error {
-	if s.expectedAuthority == "" {
-		return nil
-	}
-
+func (s *publicRpcServer) validateAuthority(ctx context.Context, shardId int64) error {
 	actualAuthority, err := requestAuthority(ctx)
 	if err != nil {
 		return err
 	}
 
-	if !sameAuthority(actualAuthority, s.expectedAuthority) {
+	expectedAuthority := s.assignmentDispatcher.GetLeader(shardId)
+	if expectedAuthority == "" {
+		return nil
+	}
+
+	if !sameAuthority(actualAuthority, expectedAuthority) {
 		return status.Errorf(codes.PermissionDenied, "oxia: authority mismatch: got %q, expected %q",
-			actualAuthority, s.expectedAuthority)
+			actualAuthority, expectedAuthority)
 	}
 
 	return nil
@@ -128,7 +127,10 @@ func (s *publicRpcServer) GetShardAssignments(req *proto.ShardAssignmentsRequest
 }
 
 func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
-	if err := s.validateAuthority(ctx); err != nil {
+	if write.Shard == nil {
+		return nil, status.Error(codes.InvalidArgument, "shard id is required")
+	}
+	if err := s.validateAuthority(ctx, *write.Shard); err != nil {
 		return nil, err
 	}
 
@@ -187,10 +189,6 @@ func processWriteStream(streamCtx context.Context, finished chan<- error, stream
 }
 
 func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer) error {
-	if err := s.validateAuthority(stream.Context()); err != nil {
-		return err
-	}
-
 	// Add entries receives an incoming stream of request, the shard_id needs to be encoded
 	// as a property in the metadata
 	md, ok := metadata.FromIncomingContext(stream.Context())
@@ -203,6 +201,9 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 	}
 	namespace, err := readHeader(md, constant.MetadataNamespace)
 	if err != nil {
+		return err
+	}
+	if err := s.validateAuthority(stream.Context(), shardId); err != nil {
 		return err
 	}
 	streamCtx := stream.Context()
@@ -249,7 +250,10 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {
-	if err := s.validateAuthority(stream.Context()); err != nil {
+	if request.Shard == nil {
+		return status.Error(codes.InvalidArgument, "shard id is required")
+	}
+	if err := s.validateAuthority(stream.Context(), *request.Shard); err != nil {
 		return err
 	}
 
@@ -290,7 +294,10 @@ func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClient_ListServer) error {
-	if err := s.validateAuthority(stream.Context()); err != nil {
+	if request.Shard == nil {
+		return status.Error(codes.InvalidArgument, "shard id is required")
+	}
+	if err := s.validateAuthority(stream.Context(), *request.Shard); err != nil {
 		return err
 	}
 
@@ -327,7 +334,10 @@ func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream proto.OxiaClient_RangeScanServer) error {
-	if err := s.validateAuthority(stream.Context()); err != nil {
+	if request.Shard == nil {
+		return status.Error(codes.InvalidArgument, "shard id is required")
+	}
+	if err := s.validateAuthority(stream.Context(), *request.Shard); err != nil {
 		return err
 	}
 
@@ -374,7 +384,7 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 }
 
 func (s *publicRpcServer) GetNotifications(req *proto.NotificationsRequest, stream proto.OxiaClient_GetNotificationsServer) error {
-	if err := s.validateAuthority(stream.Context()); err != nil {
+	if err := s.validateAuthority(stream.Context(), req.Shard); err != nil {
 		return err
 	}
 
@@ -420,7 +430,7 @@ func (s *publicRpcServer) Port() int {
 }
 
 func (s *publicRpcServer) CreateSession(ctx context.Context, req *proto.CreateSessionRequest) (*proto.CreateSessionResponse, error) {
-	if err := s.validateAuthority(ctx); err != nil {
+	if err := s.validateAuthority(ctx, req.Shard); err != nil {
 		return nil, err
 	}
 
@@ -445,7 +455,7 @@ func (s *publicRpcServer) CreateSession(ctx context.Context, req *proto.CreateSe
 }
 
 func (s *publicRpcServer) KeepAlive(ctx context.Context, req *proto.SessionHeartbeat) (*proto.KeepAliveResponse, error) {
-	if err := s.validateAuthority(ctx); err != nil {
+	if err := s.validateAuthority(ctx, req.Shard); err != nil {
 		return nil, err
 	}
 
@@ -471,7 +481,7 @@ func (s *publicRpcServer) KeepAlive(ctx context.Context, req *proto.SessionHeart
 }
 
 func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSessionRequest) (*proto.CloseSessionResponse, error) {
-	if err := s.validateAuthority(ctx); err != nil {
+	if err := s.validateAuthority(ctx, req.Shard); err != nil {
 		return nil, err
 	}
 
@@ -495,7 +505,7 @@ func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSess
 }
 
 func (s *publicRpcServer) GetSequenceUpdates(req *proto.GetSequenceUpdatesRequest, stream proto.OxiaClient_GetSequenceUpdatesServer) error {
-	if err := s.validateAuthority(stream.Context()); err != nil {
+	if err := s.validateAuthority(stream.Context(), req.Shard); err != nil {
 		return err
 	}
 

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -88,6 +88,10 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 }
 
 func (s *publicRpcServer) validateAuthority(ctx context.Context) error {
+	if !s.assignmentDispatcher.Initialized() {
+		return constant.ErrNotInitialized
+	}
+
 	actualAuthority, err := oxiadcommonrpc.GetAuthority(ctx)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "oxia: invalid authority: %v", err)

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -30,7 +30,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protowire"
 
-	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller"
@@ -63,11 +63,11 @@ type publicRpcServer struct {
 
 	shardsDirector       controller.ShardsDirector
 	assignmentDispatcher assignment.ShardAssignmentsDispatcher
-	grpcServer           rpc2.GrpcServer
+	grpcServer           oxiadcommonrpc.GrpcServer
 	log                  *slog.Logger
 }
 
-func newPublicRpcServer(provider rpc2.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
+func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
 	tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:       shardsDirector,
@@ -90,9 +90,9 @@ func newPublicRpcServer(provider rpc2.GrpcProvider, bindAddress string, shardsDi
 }
 
 func (s *publicRpcServer) validateAuthority(ctx context.Context, shardId int64) error {
-	actualAuthority, err := rpc2.GetAuthority(ctx)
+	actualAuthority, err := oxiadcommonrpc.GetAuthority(ctx)
 	if err != nil {
-		return err
+		return status.Errorf(codes.InvalidArgument, "oxia: invalid authority: %v", err)
 	}
 
 	expectedAuthority := s.assignmentDispatcher.GetLeader(shardId)

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"strings"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -63,13 +65,15 @@ type publicRpcServer struct {
 	assignmentDispatcher assignment.ShardAssignmentsDispatcher
 	grpcServer           rpc2.GrpcServer
 	log                  *slog.Logger
+	expectedAuthority    string
 }
 
 func newPublicRpcServer(provider rpc2.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector, assignmentDispatcher assignment.ShardAssignmentsDispatcher,
-	tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
+	expectedAuthority string, tlsConf *tls.Config, options *auth.Options) (*publicRpcServer, error) {
 	server := &publicRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,
+		expectedAuthority:    expectedAuthority,
 		log: slog.With(
 			slog.String("component", "public-rpc-server"),
 		),
@@ -85,6 +89,24 @@ func newPublicRpcServer(provider rpc2.GrpcProvider, bindAddress string, shardsDi
 	}
 
 	return server, nil
+}
+
+func (s *publicRpcServer) validateAuthority(ctx context.Context) error {
+	if s.expectedAuthority == "" {
+		return nil
+	}
+
+	actualAuthority, err := requestAuthority(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !sameAuthority(actualAuthority, s.expectedAuthority) {
+		return status.Errorf(codes.PermissionDenied, "oxia: authority mismatch: got %q, expected %q",
+			actualAuthority, s.expectedAuthority)
+	}
+
+	return nil
 }
 
 func (s *publicRpcServer) GetShardAssignments(req *proto.ShardAssignmentsRequest, srv proto.OxiaClient_GetShardAssignmentsServer) error {
@@ -106,6 +128,10 @@ func (s *publicRpcServer) GetShardAssignments(req *proto.ShardAssignmentsRequest
 }
 
 func (s *publicRpcServer) Write(ctx context.Context, write *proto.WriteRequest) (*proto.WriteResponse, error) {
+	if err := s.validateAuthority(ctx); err != nil {
+		return nil, err
+	}
+
 	s.log.Debug(
 		"Write request",
 		slog.String("peer", rpc.GetPeer(ctx)),
@@ -161,6 +187,10 @@ func processWriteStream(streamCtx context.Context, finished chan<- error, stream
 }
 
 func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer) error {
+	if err := s.validateAuthority(stream.Context()); err != nil {
+		return err
+	}
+
 	// Add entries receives an incoming stream of request, the shard_id needs to be encoded
 	// as a property in the metadata
 	md, ok := metadata.FromIncomingContext(stream.Context())
@@ -219,6 +249,10 @@ func (s *publicRpcServer) WriteStream(stream proto.OxiaClient_WriteStreamServer)
 }
 
 func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClient_ReadServer) error {
+	if err := s.validateAuthority(stream.Context()); err != nil {
+		return err
+	}
+
 	s.log.Debug(
 		"Read request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
@@ -256,6 +290,10 @@ func (s *publicRpcServer) Read(request *proto.ReadRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClient_ListServer) error {
+	if err := s.validateAuthority(stream.Context()); err != nil {
+		return err
+	}
+
 	s.log.Debug(
 		"List request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
@@ -289,6 +327,10 @@ func (s *publicRpcServer) List(request *proto.ListRequest, stream proto.OxiaClie
 }
 
 func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream proto.OxiaClient_RangeScanServer) error {
+	if err := s.validateAuthority(stream.Context()); err != nil {
+		return err
+	}
+
 	s.log.Debug(
 		"RangeScan request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
@@ -332,6 +374,10 @@ func (s *publicRpcServer) RangeScan(request *proto.RangeScanRequest, stream prot
 }
 
 func (s *publicRpcServer) GetNotifications(req *proto.NotificationsRequest, stream proto.OxiaClient_GetNotificationsServer) error {
+	if err := s.validateAuthority(stream.Context()); err != nil {
+		return err
+	}
+
 	s.log.Debug(
 		"Get notifications",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
@@ -374,6 +420,10 @@ func (s *publicRpcServer) Port() int {
 }
 
 func (s *publicRpcServer) CreateSession(ctx context.Context, req *proto.CreateSessionRequest) (*proto.CreateSessionResponse, error) {
+	if err := s.validateAuthority(ctx); err != nil {
+		return nil, err
+	}
+
 	s.log.Debug(
 		"Create session request",
 		slog.String("peer", rpc.GetPeer(ctx)),
@@ -395,6 +445,10 @@ func (s *publicRpcServer) CreateSession(ctx context.Context, req *proto.CreateSe
 }
 
 func (s *publicRpcServer) KeepAlive(ctx context.Context, req *proto.SessionHeartbeat) (*proto.KeepAliveResponse, error) {
+	if err := s.validateAuthority(ctx); err != nil {
+		return nil, err
+	}
+
 	s.log.Debug(
 		"Session keep alive",
 		slog.Int64("shard", req.Shard),
@@ -417,6 +471,10 @@ func (s *publicRpcServer) KeepAlive(ctx context.Context, req *proto.SessionHeart
 }
 
 func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSessionRequest) (*proto.CloseSessionResponse, error) {
+	if err := s.validateAuthority(ctx); err != nil {
+		return nil, err
+	}
+
 	s.log.Debug(
 		"Close session request",
 		slog.String("peer", rpc.GetPeer(ctx)),
@@ -437,6 +495,10 @@ func (s *publicRpcServer) CloseSession(ctx context.Context, req *proto.CloseSess
 }
 
 func (s *publicRpcServer) GetSequenceUpdates(req *proto.GetSequenceUpdatesRequest, stream proto.OxiaClient_GetSequenceUpdatesServer) error {
+	if err := s.validateAuthority(stream.Context()); err != nil {
+		return err
+	}
+
 	s.log.Debug(
 		"Get sequence update request",
 		slog.String("peer", rpc.GetPeer(stream.Context())),
@@ -490,6 +552,56 @@ func (s *publicRpcServer) getLeader(shardId *int64) (lead.LeaderController, erro
 
 func (s *publicRpcServer) Close() error {
 	return s.grpcServer.Close()
+}
+
+func requestAuthority(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if authority := md.Get(":authority"); len(authority) > 0 {
+			if err := validateAuthorityAddress(authority[0]); err != nil {
+				return "", status.Errorf(codes.InvalidArgument, "oxia: invalid authority address: %v", err)
+			}
+			return authority[0], nil
+		}
+	}
+	return "", status.Errorf(codes.InvalidArgument, "oxia: authority not identified")
+}
+
+func validateAuthorityAddress(addr string) error {
+	if strings.Contains(addr, "://") {
+		return errors.Errorf("authority address %q must not contain a scheme", addr)
+	}
+	if strings.Contains(addr, "/") {
+		return errors.Errorf("authority address %q must not contain a path", addr)
+	}
+	if strings.Contains(addr, "?") {
+		return errors.Errorf("authority address %q must not contain a query string", addr)
+	}
+	if strings.Contains(addr, "#") {
+		return errors.Errorf("authority address %q must not contain a fragment", addr)
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return errors.Errorf("authority address %q is not a valid host:port pair: %v", addr, err)
+	}
+	if host == "" {
+		return errors.Errorf("authority address %q has an empty host", addr)
+	}
+
+	return nil
+}
+
+func sameAuthority(left string, right string) bool {
+	leftHost, leftPort, err := net.SplitHostPort(left)
+	if err != nil {
+		return false
+	}
+	rightHost, rightPort, err := net.SplitHostPort(right)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(leftHost, rightHost) && leftPort == rightPort
 }
 
 // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -90,7 +90,7 @@ func newPublicRpcServer(provider rpc2.GrpcProvider, bindAddress string, shardsDi
 }
 
 func (s *publicRpcServer) validateAuthority(ctx context.Context, shardId int64) error {
-	actualAuthority, err := requestAuthority(ctx)
+	actualAuthority, err := rpc2.GetAuthority(ctx)
 	if err != nil {
 		return err
 	}
@@ -514,44 +514,6 @@ func (s *publicRpcServer) resolveLeader(ctx context.Context, shardId *int64) (le
 
 func (s *publicRpcServer) Close() error {
 	return s.grpcServer.Close()
-}
-
-func requestAuthority(ctx context.Context) (string, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if ok {
-		if authority := md.Get(":authority"); len(authority) > 0 {
-			if err := validateAuthorityAddress(authority[0]); err != nil {
-				return "", status.Errorf(codes.InvalidArgument, "oxia: invalid authority address: %v", err)
-			}
-			return authority[0], nil
-		}
-	}
-	return "", status.Errorf(codes.InvalidArgument, "oxia: authority not identified")
-}
-
-func validateAuthorityAddress(addr string) error {
-	if strings.Contains(addr, "://") {
-		return errors.Errorf("authority address %q must not contain a scheme", addr)
-	}
-	if strings.Contains(addr, "/") {
-		return errors.Errorf("authority address %q must not contain a path", addr)
-	}
-	if strings.Contains(addr, "?") {
-		return errors.Errorf("authority address %q must not contain a query string", addr)
-	}
-	if strings.Contains(addr, "#") {
-		return errors.Errorf("authority address %q must not contain a fragment", addr)
-	}
-
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return errors.Errorf("authority address %q is not a valid host:port pair: %v", addr, err)
-	}
-	if host == "" {
-		return errors.Errorf("authority address %q has an empty host", addr)
-	}
-
-	return nil
 }
 
 func sameAuthority(left string, right string) bool {

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -137,3 +137,16 @@ func TestValidateAuthorityReturnsNotInitializedBeforeAssignmentsReady(t *testing
 	require.Error(t, err)
 	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
 }
+
+func TestValidateAuthorityCanBeDisabled(t *testing.T) {
+	server := &publicRpcServer{
+		disableAuthorityValidation: true,
+		assignmentDispatcher:       &testAssignmentDispatcher{},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		":authority": "wrong-host:6648",
+	}))
+
+	require.NoError(t, server.validateAuthority(ctx))
+}

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 
+	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
@@ -39,11 +40,14 @@ func init() {
 }
 
 type testAssignmentDispatcher struct {
+	initialized      bool
 	validAuthorities map[string]bool
 }
 
-func (*testAssignmentDispatcher) Close() error      { return nil }
-func (*testAssignmentDispatcher) Initialized() bool { return true }
+func (*testAssignmentDispatcher) Close() error { return nil }
+func (t *testAssignmentDispatcher) Initialized() bool {
+	return t.initialized
+}
 func (*testAssignmentDispatcher) PushShardAssignments(proto.OxiaCoordination_PushShardAssignmentsServer) error {
 	panic("unexpected call")
 }
@@ -106,7 +110,7 @@ func TestWriteClientClose(t *testing.T) {
 
 func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
 	server := &publicRpcServer{
-		assignmentDispatcher: &testAssignmentDispatcher{validAuthorities: map[string]bool{
+		assignmentDispatcher: &testAssignmentDispatcher{initialized: true, validAuthorities: map[string]bool{
 			"expected-host:6648": true,
 		}},
 	}
@@ -118,4 +122,18 @@ func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
 	err := server.validateAuthority(ctx)
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
+}
+
+func TestValidateAuthorityReturnsNotInitializedBeforeAssignmentsReady(t *testing.T) {
+	server := &publicRpcServer{
+		assignmentDispatcher: &testAssignmentDispatcher{},
+	}
+
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		":authority": "expected-host:6648",
+	}))
+
+	err := server.validateAuthority(ctx)
+	require.Error(t, err)
+	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
 }

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 type testAssignmentDispatcher struct {
-	leader string
+	validAuthorities map[string]bool
 }
 
 func (*testAssignmentDispatcher) Close() error      { return nil }
@@ -50,8 +50,10 @@ func (*testAssignmentDispatcher) PushShardAssignments(proto.OxiaCoordination_Pus
 func (*testAssignmentDispatcher) RegisterForUpdates(*proto.ShardAssignmentsRequest, assignment.Client) error {
 	panic("unexpected call")
 }
-func (t *testAssignmentDispatcher) GetLeader(int64) string { return t.leader }
-func (*testAssignmentDispatcher) ClusterID() string        { return "" }
+func (*testAssignmentDispatcher) GetLeader(int64) string { return "" }
+func (t *testAssignmentDispatcher) HasAuthority(authority string) bool {
+	return t.validAuthorities[authority]
+}
 
 func TestWriteClientClose(t *testing.T) {
 	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
@@ -104,14 +106,16 @@ func TestWriteClientClose(t *testing.T) {
 
 func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
 	server := &publicRpcServer{
-		assignmentDispatcher: &testAssignmentDispatcher{leader: "expected-host:6648"},
+		assignmentDispatcher: &testAssignmentDispatcher{validAuthorities: map[string]bool{
+			"expected-host:6648": true,
+		}},
 	}
 
 	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
 		":authority": "wrong-host:6648",
 	}))
 
-	err := server.validateAuthority(ctx, 0)
+	err := server.validateAuthority(ctx)
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
 }

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
@@ -39,6 +41,7 @@ func TestWriteClientClose(t *testing.T) {
 	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
 	assert.NoError(t, err)
 	defer standaloneServer.Close()
+	standaloneServer.rpc.expectedAuthority = standaloneServer.ServiceAddr()
 
 	// Connect to the standalone dataserver
 	conn, err := grpc.NewClient(standaloneServer.ServiceAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -82,4 +85,28 @@ func TestWriteClientClose(t *testing.T) {
 	t.Logf("resp %v err %v", resp, err)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestCreateSessionRejectsWrongAuthority(t *testing.T) {
+	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
+	require.NoError(t, err)
+	defer standaloneServer.Close()
+	standaloneServer.rpc.expectedAuthority = standaloneServer.ServiceAddr()
+
+	conn, err := grpc.NewClient(
+		standaloneServer.ServiceAddr(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithAuthority("wrong-host:6648"),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := proto.NewOxiaClientClient(conn)
+	_, err = client.CreateSession(context.Background(), &proto.CreateSessionRequest{
+		Shard:            0,
+		SessionTimeoutMs: 1000,
+		ClientIdentity:   "test-client",
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
 }

--- a/oxiad/dataserver/public_rpc_server_test.go
+++ b/oxiad/dataserver/public_rpc_server_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
+	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 )
 
 func init() {
@@ -37,11 +38,25 @@ func init() {
 	logging.ConfigureLogger()
 }
 
+type testAssignmentDispatcher struct {
+	leader string
+}
+
+func (*testAssignmentDispatcher) Close() error      { return nil }
+func (*testAssignmentDispatcher) Initialized() bool { return true }
+func (*testAssignmentDispatcher) PushShardAssignments(proto.OxiaCoordination_PushShardAssignmentsServer) error {
+	panic("unexpected call")
+}
+func (*testAssignmentDispatcher) RegisterForUpdates(*proto.ShardAssignmentsRequest, assignment.Client) error {
+	panic("unexpected call")
+}
+func (t *testAssignmentDispatcher) GetLeader(int64) string { return t.leader }
+func (*testAssignmentDispatcher) ClusterID() string        { return "" }
+
 func TestWriteClientClose(t *testing.T) {
 	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
 	assert.NoError(t, err)
 	defer standaloneServer.Close()
-	standaloneServer.rpc.expectedAuthority = standaloneServer.ServiceAddr()
 
 	// Connect to the standalone dataserver
 	conn, err := grpc.NewClient(standaloneServer.ServiceAddr(), grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -87,26 +102,16 @@ func TestWriteClientClose(t *testing.T) {
 	assert.ErrorIs(t, err, io.EOF)
 }
 
-func TestCreateSessionRejectsWrongAuthority(t *testing.T) {
-	standaloneServer, err := NewStandalone(NewTestConfig(t.TempDir()))
-	require.NoError(t, err)
-	defer standaloneServer.Close()
-	standaloneServer.rpc.expectedAuthority = standaloneServer.ServiceAddr()
+func TestValidateAuthorityRejectsWrongAuthority(t *testing.T) {
+	server := &publicRpcServer{
+		assignmentDispatcher: &testAssignmentDispatcher{leader: "expected-host:6648"},
+	}
 
-	conn, err := grpc.NewClient(
-		standaloneServer.ServiceAddr(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithAuthority("wrong-host:6648"),
-	)
-	require.NoError(t, err)
-	defer conn.Close()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+		":authority": "wrong-host:6648",
+	}))
 
-	client := proto.NewOxiaClientClient(conn)
-	_, err = client.CreateSession(context.Background(), &proto.CreateSessionRequest{
-		Shard:            0,
-		SessionTimeoutMs: 1000,
-		ClientIdentity:   "test-client",
-	})
+	err := server.validateAuthority(ctx, 0)
 	require.Error(t, err)
 	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
 }

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -66,11 +66,12 @@ func New(parent context.Context, watchableOption *commonoption.Watch[*option.Opt
 	if err != nil {
 		return nil, err
 	}
-	grpcProvider, err := NewWithGrpcProvider(parent, watchableOption, rpc2.Default, provider)
+	grpcProvider, err := NewWithGrpcProvider(parent, watchableOption, rpc2.Default, provider, false)
 	return grpcProvider, err
 }
 
-func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.Watch[*option.Options], provider rpc2.GrpcProvider, replicationRpcProvider rpc.ReplicationRpcProvider) (*Server, error) {
+func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.Watch[*option.Options], provider rpc2.GrpcProvider,
+	replicationRpcProvider rpc.ReplicationRpcProvider, disableAuthorityValidation bool) (*Server, error) {
 	options, _ := watchableOption.Load()
 	slog.Info("Starting Oxia dataServer", slog.Any("options", options))
 
@@ -133,7 +134,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, disableAuthorityValidation, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -133,7 +133,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, publicServer.AdvertisedAddress, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -133,7 +133,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 		return nil, err
 	}
 	s.publicRpcServer, err = newPublicRpcServer(provider, publicServer.BindAddress, s.shardsDirector,
-		s.shardAssignmentDispatcher, publicServerTLS, &publicServer.Auth)
+		s.shardAssignmentDispatcher, publicServer.AdvertisedAddress, publicServerTLS, &publicServer.Auth)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -114,7 +114,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		nil, serverTLS, &auth.Disabled)
+		nil, publicServer.AdvertisedAddress, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -114,7 +114,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		nil, publicServer.AdvertisedAddress, serverTLS, &auth.Disabled)
+		nil, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -114,7 +114,7 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		nil, serverTLS, &auth.Disabled)
+		nil, false, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/standalone.go
+++ b/oxiad/dataserver/standalone.go
@@ -108,18 +108,18 @@ func NewStandalone(config StandaloneConfig) (*Standalone, error) {
 		return nil, err
 	}
 
+	s.shardAssignmentDispatcher = assignment.NewStandaloneShardAssignmentDispatcher(config.NumShards)
+
 	publicServer := config.DataServerOptions.Server.Public
 	serverTLS, err := publicServer.TLS.TryIntoServerTLSConf()
 	if err != nil {
 		return nil, err
 	}
 	s.rpc, err = newPublicRpcServer(rpc2.Default, publicServer.BindAddress, s.shardsDirector,
-		nil, false, serverTLS, &auth.Disabled)
+		s.shardAssignmentDispatcher, false, serverTLS, &auth.Disabled)
 	if err != nil {
 		return nil, err
 	}
-	s.shardAssignmentDispatcher = assignment.NewStandaloneShardAssignmentDispatcher(config.NumShards)
-	s.rpc.assignmentDispatcher = s.shardAssignmentDispatcher
 
 	metricOptions := config.DataServerOptions.Observability.Metric
 	if metricOptions.IsEnabled() {

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -196,7 +196,13 @@ func main() {
 		dataServerOption.Observability.Metric.Enabled = &constant.FlagFalse
 		dataServerOption.Storage.Database.Dir = filepath.Join(dataDir, thisNode, "db")
 		dataServerOption.Storage.WAL.Dir = filepath.Join(dataDir, thisNode, "wal")
-		_, err := dataserver.NewWithGrpcProvider(context.Background(), commonoption.NewWatch(dataServerOption), grpcProvider, replicationGrpcProvider)
+		_, err := dataserver.NewWithGrpcProvider(
+			context.Background(),
+			commonoption.NewWatch(dataServerOption),
+			grpcProvider,
+			replicationGrpcProvider,
+			true,
+		)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
## Motivation

Oxia clients can connect to a dataserver public endpoint through a stable hostname while the underlying network path changes underneath it. In Kubernetes this can happen during pod restart, stale resolution, or routing races. If the request reaches the wrong server, Oxia should reject it instead of serving the RPC through the wrong public endpoint.

This PR adds server-side validation for public client RPCs using the existing shard-assignment view of valid public addresses.

## Modification

- validate incoming `:authority` on public client RPCs except `GetShardAssignments`
- treat authority validation as a public-protocol guard only
- use the cluster-wide set of valid public authorities derived from shard assignments
- return `server not initialized yet` before validating authority if assignments are not ready
- keep `server not initialized yet` retryable on the client side
- initialize the standalone shard-assignment dispatcher before starting the public RPC server
- add dataserver tests for wrong authority and not-initialized behavior
- add client retry coverage for `CodeNotInitialized`
