### PR TITLE
fix: remove commit-offset label from checksum metrics

### DIFF
--- a/oxiad/dataserver/controller/follow/follower_controller.go
+++ b/oxiad/dataserver/controller/follow/follower_controller.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/multierr"
 
 	"github.com/oxia-db/oxia/oxiad/common/crc"
@@ -465,8 +464,8 @@ func (fc *followerController) processCommittedEntriesLoop(reader wal.Reader, max
 			return err
 		}
 		if resp.Checksum != nil {
-			fc.checksumGauge.Record(int64(*resp.Checksum), attribute.Int64("commit-offset", entry.Offset))
-			fc.walChecksumGauge.Record(int64(entryCrc), attribute.Int64("commit-offset", entry.Offset))
+			fc.checksumGauge.Record(int64(*resp.Checksum))
+			fc.walChecksumGauge.Record(int64(entryCrc))
 		}
 
 		fc.commitOffset.Store(entry.Offset)

--- a/oxiad/dataserver/controller/lead/leader_controller.go
+++ b/oxiad/dataserver/controller/lead/leader_controller.go
@@ -23,7 +23,6 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/multierr"
 	"google.golang.org/grpc/status"
 
@@ -661,8 +660,8 @@ func (lc *leaderController) applyAllEntriesIntoDB() error {
 			return errors.Wrap(err, "failed to applies wal entries to db")
 		}
 		if resp.Checksum != nil {
-			lc.checksumGauge.Record(int64(*resp.Checksum), attribute.Int64("commit-offset", entry.Offset))
-			lc.walChecksumGauge.Record(int64(entryCrc), attribute.Int64("commit-offset", entry.Offset))
+			lc.checksumGauge.Record(int64(*resp.Checksum))
+			lc.walChecksumGauge.Record(int64(entryCrc))
 		}
 	}
 
@@ -1039,8 +1038,8 @@ func (lc *leaderController) propose(ctx context.Context, proposalSupplier func(o
 					return
 				}
 				if response.Checksum != nil {
-					lc.checksumGauge.Record(int64(*response.Checksum), attribute.Int64("commit-offset", newOffset))
-					lc.walChecksumGauge.Record(int64(entryCrc), attribute.Int64("commit-offset", newOffset))
+					lc.checksumGauge.Record(int64(*response.Checksum))
+					lc.walChecksumGauge.Record(int64(entryCrc))
 				}
 				cb.OnComplete(response)
 			}, func(err error) {

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -121,38 +120,25 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 	lead.ProposeRecordChecksum(context.Background())
 
 	// Verify the DB checksum gauge metric appears in the Prometheus endpoint
-	// with the expected labels and a non-zero value
-	var firstDbMetrics map[int64]string
+	// as a shard-scoped series with a non-zero value.
+	var firstDbMetric checksumMetric
 	assert.Eventually(t, func() bool {
-		firstDbMetrics = parseChecksumMetrics(t, metricsURL, "oxia_dataserver_db_checksum")
-		return len(firstDbMetrics) > 0
+		var found bool
+		firstDbMetric, found = parseChecksumMetric(t, metricsURL, "oxia_dataserver_db_checksum")
+		return found
 	}, 30*time.Second, 200*time.Millisecond)
-
-	// Capture the first commit offset and checksum value
-	var firstOffset int64
-	var firstChecksum string
-	for offset, checksum := range firstDbMetrics {
-		firstOffset = offset
-		firstChecksum = checksum
-	}
-	assert.NotZero(t, firstOffset)
-	assert.NotEqual(t, "0", firstChecksum)
+	assert.NotContains(t, firstDbMetric.labels, "commit_offset")
+	assert.NotEqual(t, "0", firstDbMetric.value)
 
 	// Verify the WAL checksum gauge also appears
-	var firstWalMetrics map[int64]string
+	var firstWalMetric checksumMetric
 	assert.Eventually(t, func() bool {
-		firstWalMetrics = parseChecksumMetrics(t, metricsURL, "oxia_dataserver_wal_checksum")
-		return len(firstWalMetrics) > 0
+		var found bool
+		firstWalMetric, found = parseChecksumMetric(t, metricsURL, "oxia_dataserver_wal_checksum")
+		return found
 	}, 30*time.Second, 200*time.Millisecond)
-
-	var firstWalOffset int64
-	var firstWalChecksum string
-	for offset, checksum := range firstWalMetrics {
-		firstWalOffset = offset
-		firstWalChecksum = checksum
-	}
-	assert.NotZero(t, firstWalOffset)
-	assert.NotEqual(t, "0", firstWalChecksum)
+	assert.NotContains(t, firstWalMetric.labels, "commit_offset")
+	assert.NotEqual(t, "0", firstWalMetric.value)
 
 	// Write more data and record the checksum again
 	_, _, err = client.Put(context.Background(), "/key4", []byte("value4"))
@@ -160,45 +146,38 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 
 	lead.ProposeRecordChecksum(context.Background())
 
-	// Verify a new DB metric line appears with a higher commit offset and different checksum
+	// Verify the DB checksum series updates in place with a different value.
 	assert.Eventually(t, func() bool {
-		metrics := parseChecksumMetrics(t, metricsURL, "oxia_dataserver_db_checksum")
-		for offset, checksum := range metrics {
-			if offset > firstOffset && checksum != firstChecksum {
-				return true
-			}
-		}
-		return false
+		metric, found := parseChecksumMetric(t, metricsURL, "oxia_dataserver_db_checksum")
+		return found && metric.labels == firstDbMetric.labels && metric.value != firstDbMetric.value
 	}, 30*time.Second, 200*time.Millisecond)
 
-	// Verify a new WAL metric line appears with a higher commit offset and different checksum
+	// Verify the WAL checksum series also updates in place with a different value.
 	assert.Eventually(t, func() bool {
-		metrics := parseChecksumMetrics(t, metricsURL, "oxia_dataserver_wal_checksum")
-		for offset, checksum := range metrics {
-			if offset > firstWalOffset && checksum != firstWalChecksum {
-				return true
-			}
-		}
-		return false
+		metric, found := parseChecksumMetric(t, metricsURL, "oxia_dataserver_wal_checksum")
+		return found && metric.labels == firstWalMetric.labels && metric.value != firstWalMetric.value
 	}, 30*time.Second, 200*time.Millisecond)
 }
 
-// parseChecksumMetrics scrapes the Prometheus endpoint and returns a map of
-// commit_offset -> checksum_value for all lines matching the given metricName
-// with shard=0 and namespace=default.
-func parseChecksumMetrics(t *testing.T, url string, metricName string) map[int64]string {
+type checksumMetric struct {
+	labels string
+	value  string
+}
+
+// parseChecksumMetric scrapes the Prometheus endpoint and returns the shard-scoped
+// checksum series for the given metricName with shard=0 and namespace=default.
+func parseChecksumMetric(t *testing.T, url string, metricName string) (checksumMetric, bool) {
 	t.Helper()
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil
+		return checksumMetric{}, false
 	}
 	defer resp.Body.Close()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil
+		return checksumMetric{}, false
 	}
 
-	result := make(map[int64]string)
 	for _, line := range strings.Split(string(raw), "\n") {
 		if strings.HasPrefix(line, "#") || !strings.Contains(line, metricName) {
 			continue
@@ -206,30 +185,26 @@ func parseChecksumMetrics(t *testing.T, url string, metricName string) map[int64
 		if !strings.Contains(line, `shard="0"`) || !strings.Contains(line, `oxia_namespace="default"`) {
 			continue
 		}
-		// Extract commit_offset from label like commit_offset="42"
-		offsetIdx := strings.Index(line, `commit_offset="`)
-		if offsetIdx < 0 {
-			continue
-		}
-		offsetStart := offsetIdx + len(`commit_offset="`)
-		offsetEnd := strings.Index(line[offsetStart:], `"`)
-		if offsetEnd < 0 {
-			continue
-		}
-		offset, err := strconv.ParseInt(line[offsetStart:offsetStart+offsetEnd], 10, 64)
-		if err != nil {
+		if strings.Contains(line, `commit_offset="`) {
 			continue
 		}
 
-		// The metric value is the last whitespace-separated field
+		labelStart := strings.Index(line, "{")
+		labelEnd := strings.Index(line, "}")
+		if labelStart < 0 || labelEnd < 0 || labelEnd <= labelStart {
+			continue
+		}
+
 		parts := strings.Fields(line)
 		if len(parts) < 2 {
 			continue
 		}
-		value := parts[len(parts)-1]
-		if value != "0" {
-			result[offset] = value
+		if value := parts[len(parts)-1]; value != "0" {
+			return checksumMetric{
+				labels: line[labelStart+1 : labelEnd],
+				value:  value,
+			}, true
 		}
 	}
-	return result
+	return checksumMetric{}, false
 }


### PR DESCRIPTION
## Motivation

The checksum metrics are currently recorded with a dynamic `commit-offset` attribute. With longer scrape intervals, that produces a new time series for each offset value and makes the metrics expensive and noisy to use in Grafana.

For these checksum metrics, the useful signal is the latest value per shard, not a separate series per commit offset.

## Modification

- remove the dynamic `commit-offset` attribute from `oxia_dataserver_db_checksum`
- remove the dynamic `commit-offset` attribute from `oxia_dataserver_wal_checksum`
- keep checksum metrics emitted from both leader and follower paths with shard-level labels only
- leave the existing offset gauges available for lag and replication progress views

## Testing

- go test ./oxiad/dataserver/controller/lead
- go test ./oxiad/dataserver/controller/follow