### PR TITLE
feat: add create data server admin endpoint

### DIFF
--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -17,13 +17,14 @@ package admin
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/oxia-db/oxia/cmd/admin/commons"
 	"github.com/oxia-db/oxia/cmd/admin/dataserver"
 	"github.com/oxia-db/oxia/cmd/admin/listnamespaces"
 	"github.com/oxia-db/oxia/cmd/admin/listnodes"
 	"github.com/oxia-db/oxia/cmd/admin/splitshard"
 	oxiacommon "github.com/oxia-db/oxia/common/constant"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -19,13 +19,10 @@ import (
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
 	"github.com/oxia-db/oxia/cmd/admin/dataserver"
+	"github.com/oxia-db/oxia/cmd/admin/listnamespaces"
 	"github.com/oxia-db/oxia/cmd/admin/listnodes"
 	"github.com/oxia-db/oxia/cmd/admin/splitshard"
-
-	"github.com/oxia-db/oxia/cmd/admin/listnamespaces"
-
 	oxiacommon "github.com/oxia-db/oxia/common/constant"
-
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -63,6 +63,14 @@ func (m *MockAdminClient) GetDataServer(dataServer string) (*proto.DataServerInf
 	return nil, errors.New("data server not found")
 }
 
+func (m *MockAdminClient) CreateDataServer(dataServerInfo *proto.DataServerInfo) (*proto.DataServerInfo, error) {
+	args := m.MethodCalled("CreateDataServer", dataServerInfo)
+	if v, ok := args.Get(0).(*proto.DataServerInfo); ok {
+		return v, args.Error(1)
+	}
+	return nil, errors.New("create data server failed")
+}
+
 func (m *MockAdminClient) ListNodes() *oxia.ListNodesResult {
 	args := m.MethodCalled("ListNodes")
 	if v, ok := args.Get(0).(*oxia.ListNodesResult); ok {

--- a/cmd/admin/dataserver/cmd.go
+++ b/cmd/admin/dataserver/cmd.go
@@ -15,10 +15,11 @@
 package dataserver
 
 import (
+	"github.com/spf13/cobra"
+
 	createcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/create"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/get"
 	listcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/list"
-	"github.com/spf13/cobra"
 )
 
 var (

--- a/cmd/admin/dataserver/cmd.go
+++ b/cmd/admin/dataserver/cmd.go
@@ -15,9 +15,9 @@
 package dataserver
 
 import (
+	createcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/create"
 	getcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/get"
 	listcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/list"
-
 	"github.com/spf13/cobra"
 )
 
@@ -30,6 +30,7 @@ var (
 )
 
 func init() {
+	Cmd.AddCommand(createcmd.Cmd)
 	Cmd.AddCommand(getcmd.Cmd)
 	Cmd.AddCommand(listcmd.Cmd)
 }

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -30,7 +30,7 @@ var (
 	name            string
 	publicAddress   string
 	internalAddress string
-	metadataFlags   []string
+	labelsFlags     []string
 )
 
 var Cmd = &cobra.Command{
@@ -46,7 +46,7 @@ func init() {
 	Cmd.Flags().StringVar(&name, "name", "", "Unique data server name")
 	Cmd.Flags().StringVar(&publicAddress, "public-address", "", "Public data server address")
 	Cmd.Flags().StringVar(&internalAddress, "internal-address", "", "Internal data server address")
-	Cmd.Flags().StringSliceVar(&metadataFlags, "metadata", nil, "Metadata label in key=value form")
+	Cmd.Flags().StringSliceVar(&labelsFlags, "labels", nil, "Data server labels in key=value form")
 
 	_ = Cmd.MarkFlagRequired("public-address")
 	_ = Cmd.MarkFlagRequired("internal-address")
@@ -61,7 +61,7 @@ func exec(cmd *cobra.Command, _ []string) error {
 		_ = client.Close()
 	}(client)
 
-	metadata, err := parseMetadataFlags(metadataFlags)
+	metadata, err := parseMetadataFlags(labelsFlags)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func exec(cmd *cobra.Command, _ []string) error {
 
 func parseMetadataFlags(entries []string) (map[string]string, error) {
 	if len(entries) == 0 {
-		return nil, nil
+		return map[string]string{}, nil
 	}
 
 	metadata := make(map[string]string, len(entries))

--- a/cmd/admin/dataserver/create/cmd.go
+++ b/cmd/admin/dataserver/create/cmd.go
@@ -1,0 +1,106 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	cc "github.com/oxia-db/oxia/cmd/client/common"
+	"github.com/oxia-db/oxia/common/proto"
+	"github.com/oxia-db/oxia/oxia"
+)
+
+var (
+	name            string
+	publicAddress   string
+	internalAddress string
+	metadataFlags   []string
+)
+
+var Cmd = &cobra.Command{
+	Use:          "create",
+	Short:        "Create a data server",
+	Long:         `Create a data server`,
+	Args:         cobra.ExactArgs(0),
+	RunE:         exec,
+	SilenceUsage: true,
+}
+
+func init() {
+	Cmd.Flags().StringVar(&name, "name", "", "Unique data server name")
+	Cmd.Flags().StringVar(&publicAddress, "public-address", "", "Public data server address")
+	Cmd.Flags().StringVar(&internalAddress, "internal-address", "", "Internal data server address")
+	Cmd.Flags().StringSliceVar(&metadataFlags, "metadata", nil, "Metadata label in key=value form")
+
+	_ = Cmd.MarkFlagRequired("public-address")
+	_ = Cmd.MarkFlagRequired("internal-address")
+}
+
+func exec(cmd *cobra.Command, _ []string) error {
+	client, err := commons.AdminConfig.NewAdminClient()
+	if err != nil {
+		return err
+	}
+	defer func(client oxia.AdminClient) {
+		_ = client.Close()
+	}(client)
+
+	metadata, err := parseMetadataFlags(metadataFlags)
+	if err != nil {
+		return err
+	}
+
+	dataServer := &proto.DataServer{
+		PublicAddress:   publicAddress,
+		InternalAddress: internalAddress,
+	}
+	if name != "" {
+		dataServer.Name = &name
+	}
+
+	created, err := client.CreateDataServer(&proto.DataServerInfo{
+		DataServer: dataServer,
+		Metadata:   metadata,
+	})
+	if err != nil {
+		return err
+	}
+
+	cc.WriteOutput(cmd.OutOrStdout(), created)
+	return nil
+}
+
+func parseMetadataFlags(entries []string) (map[string]string, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	metadata := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, found := strings.Cut(entry, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid metadata entry %q: expected key=value", entry)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("invalid metadata entry %q: key must not be empty", entry)
+		}
+		metadata[key] = value
+	}
+	return metadata, nil
+}

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -70,7 +70,7 @@ func Test_cmd_createDataServer(t *testing.T) {
 		"--name", serverName,
 		"--public-address", "public-4:6648",
 		"--internal-address", "internal-4:6649",
-		"--metadata", "rack=a",
+		"--labels", "rack=a",
 	)
 
 	require.NoError(t, err)

--- a/cmd/admin/dataserver/create/cmd_test.go
+++ b/cmd/admin/dataserver/create/cmd_test.go
@@ -1,0 +1,93 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package create
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oxia-db/oxia/cmd/admin/commons"
+	"github.com/oxia-db/oxia/common/proto"
+)
+
+func runCmd(args ...string) (string, error) {
+	actual := new(bytes.Buffer)
+	Cmd.SetOut(actual)
+	Cmd.SetErr(actual)
+	Cmd.SetArgs(args)
+	err := Cmd.Execute()
+	return strings.TrimSpace(actual.String()), err
+}
+
+func Test_cmd_createDataServer(t *testing.T) {
+	commons.MockedAdminClient = commons.NewMockAdminClient()
+	t.Cleanup(func() {
+		commons.MockedAdminClient = nil
+	})
+
+	serverName := "server-4"
+	commons.MockedAdminClient.On("Close").Return(nil)
+	commons.MockedAdminClient.
+		On("CreateDataServer", mock.MatchedBy(func(dataServerInfo *proto.DataServerInfo) bool {
+			if dataServerInfo == nil || dataServerInfo.DataServer == nil || dataServerInfo.DataServer.Name == nil {
+				return false
+			}
+			return *dataServerInfo.DataServer.Name == serverName &&
+				dataServerInfo.DataServer.PublicAddress == "public-4:6648" &&
+				dataServerInfo.DataServer.InternalAddress == "internal-4:6649" &&
+				dataServerInfo.Metadata["rack"] == "a"
+		})).
+		Return(&proto.DataServerInfo{
+			DataServer: &proto.DataServer{
+				Name:            &serverName,
+				PublicAddress:   "public-4:6648",
+				InternalAddress: "internal-4:6649",
+			},
+			Metadata: map[string]string{
+				"rack": "a",
+			},
+		}, nil)
+
+	out, err := runCmd(
+		"--name", serverName,
+		"--public-address", "public-4:6648",
+		"--internal-address", "internal-4:6649",
+		"--metadata", "rack=a",
+	)
+
+	require.NoError(t, err)
+
+	var dataServerInfo proto.DataServerInfo
+	require.NoError(t, json.Unmarshal([]byte(out), &dataServerInfo))
+	require.NotNil(t, dataServerInfo.DataServer)
+	require.NotNil(t, dataServerInfo.DataServer.Name)
+	assert.Equal(t, serverName, *dataServerInfo.DataServer.Name)
+	assert.Equal(t, "public-4:6648", dataServerInfo.DataServer.PublicAddress)
+	assert.Equal(t, "internal-4:6649", dataServerInfo.DataServer.InternalAddress)
+	assert.Equal(t, "a", dataServerInfo.Metadata["rack"])
+}
+
+func Test_parseMetadataFlagsRejectsInvalidEntries(t *testing.T) {
+	metadata, err := parseMetadataFlags([]string{"rack"})
+
+	assert.Error(t, err)
+	assert.Nil(t, metadata)
+}

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -318,6 +318,94 @@ func (x *GetDataServerResponse) GetDataServerInfo() *DataServerInfo {
 	return nil
 }
 
+type CreateDataServerRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	DataServerInfo *DataServerInfo        `protobuf:"bytes,1,opt,name=data_server_info,json=dataServerInfo,proto3" json:"data_server_info,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CreateDataServerRequest) Reset() {
+	*x = CreateDataServerRequest{}
+	mi := &file_admin_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDataServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDataServerRequest) ProtoMessage() {}
+
+func (x *CreateDataServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDataServerRequest.ProtoReflect.Descriptor instead.
+func (*CreateDataServerRequest) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *CreateDataServerRequest) GetDataServerInfo() *DataServerInfo {
+	if x != nil {
+		return x.DataServerInfo
+	}
+	return nil
+}
+
+type CreateDataServerResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	DataServerInfo *DataServerInfo        `protobuf:"bytes,1,opt,name=data_server_info,json=dataServerInfo,proto3" json:"data_server_info,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *CreateDataServerResponse) Reset() {
+	*x = CreateDataServerResponse{}
+	mi := &file_admin_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateDataServerResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateDataServerResponse) ProtoMessage() {}
+
+func (x *CreateDataServerResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateDataServerResponse.ProtoReflect.Descriptor instead.
+func (*CreateDataServerResponse) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *CreateDataServerResponse) GetDataServerInfo() *DataServerInfo {
+	if x != nil {
+		return x.DataServerInfo
+	}
+	return nil
+}
+
 type ListNamespacesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -326,7 +414,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -338,7 +426,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -351,7 +439,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{6}
+	return file_admin_proto_rawDescGZIP(), []int{8}
 }
 
 type ListNamespacesResponse struct {
@@ -363,7 +451,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -375,7 +463,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -388,7 +476,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{7}
+	return file_admin_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []string {
@@ -406,7 +494,7 @@ type ListNodesRequest struct {
 
 func (x *ListNodesRequest) Reset() {
 	*x = ListNodesRequest{}
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -418,7 +506,7 @@ func (x *ListNodesRequest) String() string {
 func (*ListNodesRequest) ProtoMessage() {}
 
 func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -431,7 +519,7 @@ func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesRequest.ProtoReflect.Descriptor instead.
 func (*ListNodesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{8}
+	return file_admin_proto_rawDescGZIP(), []int{10}
 }
 
 type Node struct {
@@ -446,7 +534,7 @@ type Node struct {
 
 func (x *Node) Reset() {
 	*x = Node{}
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -458,7 +546,7 @@ func (x *Node) String() string {
 func (*Node) ProtoMessage() {}
 
 func (x *Node) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -471,7 +559,7 @@ func (x *Node) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Node.ProtoReflect.Descriptor instead.
 func (*Node) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{9}
+	return file_admin_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *Node) GetName() string {
@@ -511,7 +599,7 @@ type ListNodesResponse struct {
 
 func (x *ListNodesResponse) Reset() {
 	*x = ListNodesResponse{}
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -523,7 +611,7 @@ func (x *ListNodesResponse) String() string {
 func (*ListNodesResponse) ProtoMessage() {}
 
 func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -536,7 +624,7 @@ func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesResponse.ProtoReflect.Descriptor instead.
 func (*ListNodesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{10}
+	return file_admin_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ListNodesResponse) GetNodes() []*Node {
@@ -558,7 +646,7 @@ type SplitShardRequest struct {
 
 func (x *SplitShardRequest) Reset() {
 	*x = SplitShardRequest{}
-	mi := &file_admin_proto_msgTypes[11]
+	mi := &file_admin_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -570,7 +658,7 @@ func (x *SplitShardRequest) String() string {
 func (*SplitShardRequest) ProtoMessage() {}
 
 func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[11]
+	mi := &file_admin_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -583,7 +671,7 @@ func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardRequest.ProtoReflect.Descriptor instead.
 func (*SplitShardRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{11}
+	return file_admin_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *SplitShardRequest) GetNamespace() string {
@@ -617,7 +705,7 @@ type SplitShardResponse struct {
 
 func (x *SplitShardResponse) Reset() {
 	*x = SplitShardResponse{}
-	mi := &file_admin_proto_msgTypes[12]
+	mi := &file_admin_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -629,7 +717,7 @@ func (x *SplitShardResponse) String() string {
 func (*SplitShardResponse) ProtoMessage() {}
 
 func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[12]
+	mi := &file_admin_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -642,7 +730,7 @@ func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardResponse.ProtoReflect.Descriptor instead.
 func (*SplitShardResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{12}
+	return file_admin_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SplitShardResponse) GetLeftChildShard() int64 {
@@ -684,6 +772,10 @@ const file_admin_proto_rawDesc = "" +
 	"\vdata_server\x18\x01 \x01(\tR\n" +
 	"dataServer\"c\n" +
 	"\x15GetDataServerResponse\x12J\n" +
+	"\x10data_server_info\x18\x01 \x01(\v2 .io.oxia.proto.v1.DataServerInfoR\x0edataServerInfo\"e\n" +
+	"\x17CreateDataServerRequest\x12J\n" +
+	"\x10data_server_info\x18\x01 \x01(\v2 .io.oxia.proto.v1.DataServerInfoR\x0edataServerInfo\"f\n" +
+	"\x18CreateDataServerResponse\x12J\n" +
 	"\x10data_server_info\x18\x01 \x01(\v2 .io.oxia.proto.v1.DataServerInfoR\x0edataServerInfo\"\x17\n" +
 	"\x15ListNamespacesRequest\"8\n" +
 	"\x16ListNamespacesResponse\x12\x1e\n" +
@@ -710,10 +802,11 @@ const file_admin_proto_rawDesc = "" +
 	"\f_split_point\"j\n" +
 	"\x12SplitShardResponse\x12(\n" +
 	"\x10left_child_shard\x18\x01 \x01(\x03R\x0eleftChildShard\x12*\n" +
-	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xe9\x03\n" +
+	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xd4\x04\n" +
 	"\tOxiaAdmin\x12f\n" +
 	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12`\n" +
-	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a'.io.oxia.proto.v1.GetDataServerResponse\x12c\n" +
+	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a'.io.oxia.proto.v1.GetDataServerResponse\x12i\n" +
+	"\x10CreateDataServer\x12).io.oxia.proto.v1.CreateDataServerRequest\x1a*.io.oxia.proto.v1.CreateDataServerResponse\x12c\n" +
 	"\x0eListNamespaces\x12'.io.oxia.proto.v1.ListNamespacesRequest\x1a(.io.oxia.proto.v1.ListNamespacesResponse\x12T\n" +
 	"\tListNodes\x12\".io.oxia.proto.v1.ListNodesRequest\x1a#.io.oxia.proto.v1.ListNodesResponse\x12W\n" +
 	"\n" +
@@ -731,46 +824,52 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_admin_proto_goTypes = []any{
-	(*ListDataServersRequest)(nil),  // 0: io.oxia.proto.v1.ListDataServersRequest
-	(*DataServer)(nil),              // 1: io.oxia.proto.v1.DataServer
-	(*DataServerInfo)(nil),          // 2: io.oxia.proto.v1.DataServerInfo
-	(*ListDataServersResponse)(nil), // 3: io.oxia.proto.v1.ListDataServersResponse
-	(*GetDataServerRequest)(nil),    // 4: io.oxia.proto.v1.GetDataServerRequest
-	(*GetDataServerResponse)(nil),   // 5: io.oxia.proto.v1.GetDataServerResponse
-	(*ListNamespacesRequest)(nil),   // 6: io.oxia.proto.v1.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),  // 7: io.oxia.proto.v1.ListNamespacesResponse
-	(*ListNodesRequest)(nil),        // 8: io.oxia.proto.v1.ListNodesRequest
-	(*Node)(nil),                    // 9: io.oxia.proto.v1.Node
-	(*ListNodesResponse)(nil),       // 10: io.oxia.proto.v1.ListNodesResponse
-	(*SplitShardRequest)(nil),       // 11: io.oxia.proto.v1.SplitShardRequest
-	(*SplitShardResponse)(nil),      // 12: io.oxia.proto.v1.SplitShardResponse
-	nil,                             // 13: io.oxia.proto.v1.DataServerInfo.MetadataEntry
-	nil,                             // 14: io.oxia.proto.v1.Node.MetadataEntry
+	(*ListDataServersRequest)(nil),   // 0: io.oxia.proto.v1.ListDataServersRequest
+	(*DataServer)(nil),               // 1: io.oxia.proto.v1.DataServer
+	(*DataServerInfo)(nil),           // 2: io.oxia.proto.v1.DataServerInfo
+	(*ListDataServersResponse)(nil),  // 3: io.oxia.proto.v1.ListDataServersResponse
+	(*GetDataServerRequest)(nil),     // 4: io.oxia.proto.v1.GetDataServerRequest
+	(*GetDataServerResponse)(nil),    // 5: io.oxia.proto.v1.GetDataServerResponse
+	(*CreateDataServerRequest)(nil),  // 6: io.oxia.proto.v1.CreateDataServerRequest
+	(*CreateDataServerResponse)(nil), // 7: io.oxia.proto.v1.CreateDataServerResponse
+	(*ListNamespacesRequest)(nil),    // 8: io.oxia.proto.v1.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),   // 9: io.oxia.proto.v1.ListNamespacesResponse
+	(*ListNodesRequest)(nil),         // 10: io.oxia.proto.v1.ListNodesRequest
+	(*Node)(nil),                     // 11: io.oxia.proto.v1.Node
+	(*ListNodesResponse)(nil),        // 12: io.oxia.proto.v1.ListNodesResponse
+	(*SplitShardRequest)(nil),        // 13: io.oxia.proto.v1.SplitShardRequest
+	(*SplitShardResponse)(nil),       // 14: io.oxia.proto.v1.SplitShardResponse
+	nil,                              // 15: io.oxia.proto.v1.DataServerInfo.MetadataEntry
+	nil,                              // 16: io.oxia.proto.v1.Node.MetadataEntry
 }
 var file_admin_proto_depIdxs = []int32{
 	1,  // 0: io.oxia.proto.v1.DataServerInfo.data_server:type_name -> io.oxia.proto.v1.DataServer
-	13, // 1: io.oxia.proto.v1.DataServerInfo.metadata:type_name -> io.oxia.proto.v1.DataServerInfo.MetadataEntry
+	15, // 1: io.oxia.proto.v1.DataServerInfo.metadata:type_name -> io.oxia.proto.v1.DataServerInfo.MetadataEntry
 	1,  // 2: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
 	2,  // 3: io.oxia.proto.v1.GetDataServerResponse.data_server_info:type_name -> io.oxia.proto.v1.DataServerInfo
-	14, // 4: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
-	9,  // 5: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
-	0,  // 6: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	4,  // 7: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
-	6,  // 8: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	8,  // 9: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
-	11, // 10: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	3,  // 11: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	5,  // 12: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
-	7,  // 13: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	10, // 14: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
-	12, // 15: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	11, // [11:16] is the sub-list for method output_type
-	6,  // [6:11] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	2,  // 4: io.oxia.proto.v1.CreateDataServerRequest.data_server_info:type_name -> io.oxia.proto.v1.DataServerInfo
+	2,  // 5: io.oxia.proto.v1.CreateDataServerResponse.data_server_info:type_name -> io.oxia.proto.v1.DataServerInfo
+	16, // 6: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
+	11, // 7: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
+	0,  // 8: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
+	4,  // 9: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	6,  // 10: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:input_type -> io.oxia.proto.v1.CreateDataServerRequest
+	8,  // 11: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	10, // 12: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
+	13, // 13: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	3,  // 14: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	5,  // 15: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.GetDataServerResponse
+	7,  // 16: io.oxia.proto.v1.OxiaAdmin.CreateDataServer:output_type -> io.oxia.proto.v1.CreateDataServerResponse
+	9,  // 17: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	12, // 18: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
+	14, // 19: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	14, // [14:20] is the sub-list for method output_type
+	8,  // [8:14] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_admin_proto_init() }
@@ -779,15 +878,15 @@ func file_admin_proto_init() {
 		return
 	}
 	file_admin_proto_msgTypes[1].OneofWrappers = []any{}
-	file_admin_proto_msgTypes[9].OneofWrappers = []any{}
 	file_admin_proto_msgTypes[11].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[13].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -26,6 +26,7 @@ service OxiaAdmin {
 
   rpc ListDataServers(ListDataServersRequest) returns (ListDataServersResponse);
   rpc GetDataServer(GetDataServerRequest) returns (GetDataServerResponse);
+  rpc CreateDataServer(CreateDataServerRequest) returns (CreateDataServerResponse);
 
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
 
@@ -63,6 +64,14 @@ message GetDataServerRequest {
 }
 
 message GetDataServerResponse {
+  DataServerInfo data_server_info = 1;
+}
+
+message CreateDataServerRequest {
+  DataServerInfo data_server_info = 1;
+}
+
+message CreateDataServerResponse {
   DataServerInfo data_server_info = 1;
 }
 

--- a/common/proto/admin_grpc.pb.go
+++ b/common/proto/admin_grpc.pb.go
@@ -36,11 +36,12 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	OxiaAdmin_ListDataServers_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/ListDataServers"
-	OxiaAdmin_GetDataServer_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/GetDataServer"
-	OxiaAdmin_ListNamespaces_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
-	OxiaAdmin_ListNodes_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/ListNodes"
-	OxiaAdmin_SplitShard_FullMethodName      = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
+	OxiaAdmin_ListDataServers_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/ListDataServers"
+	OxiaAdmin_GetDataServer_FullMethodName    = "/io.oxia.proto.v1.OxiaAdmin/GetDataServer"
+	OxiaAdmin_CreateDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/CreateDataServer"
+	OxiaAdmin_ListNamespaces_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
+	OxiaAdmin_ListNodes_FullMethodName        = "/io.oxia.proto.v1.OxiaAdmin/ListNodes"
+	OxiaAdmin_SplitShard_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
 )
 
 // OxiaAdminClient is the client API for OxiaAdmin service.
@@ -49,6 +50,7 @@ const (
 type OxiaAdminClient interface {
 	ListDataServers(ctx context.Context, in *ListDataServersRequest, opts ...grpc.CallOption) (*ListDataServersResponse, error)
 	GetDataServer(ctx context.Context, in *GetDataServerRequest, opts ...grpc.CallOption) (*GetDataServerResponse, error)
+	CreateDataServer(ctx context.Context, in *CreateDataServerRequest, opts ...grpc.CallOption) (*CreateDataServerResponse, error)
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// Deprecated: Use ListDataServers instead.
 	ListNodes(ctx context.Context, in *ListNodesRequest, opts ...grpc.CallOption) (*ListNodesResponse, error)
@@ -80,6 +82,16 @@ func (c *oxiaAdminClient) GetDataServer(ctx context.Context, in *GetDataServerRe
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetDataServerResponse)
 	err := c.cc.Invoke(ctx, OxiaAdmin_GetDataServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *oxiaAdminClient) CreateDataServer(ctx context.Context, in *CreateDataServerRequest, opts ...grpc.CallOption) (*CreateDataServerResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateDataServerResponse)
+	err := c.cc.Invoke(ctx, OxiaAdmin_CreateDataServer_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +134,7 @@ func (c *oxiaAdminClient) SplitShard(ctx context.Context, in *SplitShardRequest,
 type OxiaAdminServer interface {
 	ListDataServers(context.Context, *ListDataServersRequest) (*ListDataServersResponse, error)
 	GetDataServer(context.Context, *GetDataServerRequest) (*GetDataServerResponse, error)
+	CreateDataServer(context.Context, *CreateDataServerRequest) (*CreateDataServerResponse, error)
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// Deprecated: Use ListDataServers instead.
 	ListNodes(context.Context, *ListNodesRequest) (*ListNodesResponse, error)
@@ -144,6 +157,9 @@ func (UnimplementedOxiaAdminServer) ListDataServers(context.Context, *ListDataSe
 }
 func (UnimplementedOxiaAdminServer) GetDataServer(context.Context, *GetDataServerRequest) (*GetDataServerResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDataServer not implemented")
+}
+func (UnimplementedOxiaAdminServer) CreateDataServer(context.Context, *CreateDataServerRequest) (*CreateDataServerResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateDataServer not implemented")
 }
 func (UnimplementedOxiaAdminServer) ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNamespaces not implemented")
@@ -207,6 +223,24 @@ func _OxiaAdmin_GetDataServer_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(OxiaAdminServer).GetDataServer(ctx, req.(*GetDataServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OxiaAdmin_CreateDataServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateDataServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaAdminServer).CreateDataServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaAdmin_CreateDataServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaAdminServer).CreateDataServer(ctx, req.(*CreateDataServerRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -279,6 +313,10 @@ var OxiaAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDataServer",
 			Handler:    _OxiaAdmin_GetDataServer_Handler,
+		},
+		{
+			MethodName: "CreateDataServer",
+			Handler:    _OxiaAdmin_CreateDataServer_Handler,
 		},
 		{
 			MethodName: "ListNamespaces",

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -139,6 +139,40 @@ func (m *GetDataServerResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *CreateDataServerRequest) CloneVT() *CreateDataServerRequest {
+	if m == nil {
+		return (*CreateDataServerRequest)(nil)
+	}
+	r := new(CreateDataServerRequest)
+	r.DataServerInfo = m.DataServerInfo.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateDataServerRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *CreateDataServerResponse) CloneVT() *CreateDataServerResponse {
+	if m == nil {
+		return (*CreateDataServerResponse)(nil)
+	}
+	r := new(CreateDataServerResponse)
+	r.DataServerInfo = m.DataServerInfo.CloneVT()
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *CreateDataServerResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListNamespacesRequest) CloneVT() *ListNamespacesRequest {
 	if m == nil {
 		return (*ListNamespacesRequest)(nil)
@@ -422,6 +456,44 @@ func (this *GetDataServerResponse) EqualVT(that *GetDataServerResponse) bool {
 
 func (this *GetDataServerResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*GetDataServerResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateDataServerRequest) EqualVT(that *CreateDataServerRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.DataServerInfo.EqualVT(that.DataServerInfo) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateDataServerRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateDataServerRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *CreateDataServerResponse) EqualVT(that *CreateDataServerResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !this.DataServerInfo.EqualVT(that.DataServerInfo) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *CreateDataServerResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*CreateDataServerResponse)
 	if !ok {
 		return false
 	}
@@ -878,6 +950,92 @@ func (m *GetDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error)
 	return len(dAtA) - i, nil
 }
 
+func (m *CreateDataServerRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateDataServerRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateDataServerRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.DataServerInfo != nil {
+		size, err := m.DataServerInfo.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *CreateDataServerResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *CreateDataServerResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *CreateDataServerResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.DataServerInfo != nil {
+		size, err := m.DataServerInfo.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *ListNamespacesRequest) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -1282,6 +1440,34 @@ func (m *GetDataServerRequest) SizeVT() (n int) {
 }
 
 func (m *GetDataServerResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.DataServerInfo != nil {
+		l = m.DataServerInfo.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateDataServerRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.DataServerInfo != nil {
+		l = m.DataServerInfo.SizeVT()
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *CreateDataServerResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -2021,6 +2207,180 @@ func (m *GetDataServerResponse) UnmarshalVT(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: GetDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServerInfo", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServerInfo == nil {
+				m.DataServerInfo = &DataServerInfo{}
+			}
+			if err := m.DataServerInfo.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServerInfo", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServerInfo == nil {
+				m.DataServerInfo = &DataServerInfo{}
+			}
+			if err := m.DataServerInfo.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -3469,6 +3829,180 @@ func (m *GetDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: GetDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServerInfo", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServerInfo == nil {
+				m.DataServerInfo = &DataServerInfo{}
+			}
+			if err := m.DataServerInfo.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServerInfo", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.DataServerInfo == nil {
+				m.DataServerInfo = &DataServerInfo{}
+			}
+			if err := m.DataServerInfo.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *CreateDataServerResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: CreateDataServerResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: CreateDataServerResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -25,6 +25,7 @@ type AdminClient interface {
 
 	ListDataServers() ([]*proto.DataServer, error)
 	GetDataServer(dataServer string) (*proto.DataServerInfo, error)
+	CreateDataServer(dataServerInfo *proto.DataServerInfo) (*proto.DataServerInfo, error)
 
 	ListNamespaces() *ListNamespacesResult
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 
 	"github.com/oxia-db/oxia/common/auth"
-
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/common/rpc"
 )
@@ -61,6 +60,25 @@ func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServe
 	}
 
 	response, err := client.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: dataServer})
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	return response.DataServerInfo, nil
+}
+
+func (admin *adminClientImpl) CreateDataServer(dataServerInfo *proto.DataServerInfo) (*proto.DataServerInfo, error) {
+	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+
+	if client == nil {
+		return nil, wrapAdminError(ErrUnknown, errors.New("unable to connect to admin server"))
+	}
+
+	response, err := client.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{
+		DataServerInfo: dataServerInfo,
+	})
 	if err != nil {
 		return nil, mapAdminError(err)
 	}

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -26,6 +26,8 @@ import (
 
 var _ AdminClient = (*adminClientImpl)(nil)
 
+const errUnableToConnectToAdminServer = "unable to connect to admin server"
+
 type adminClientImpl struct {
 	adminAddr string
 
@@ -39,7 +41,7 @@ func (admin *adminClientImpl) ListDataServers() ([]*proto.DataServer, error) {
 	}
 
 	if client == nil {
-		return nil, wrapAdminError(ErrUnknown, errors.New("unable to connect to admin server"))
+		return nil, wrapAdminError(ErrUnknown, errors.New(errUnableToConnectToAdminServer))
 	}
 
 	response, err := client.ListDataServers(context.Background(), &proto.ListDataServersRequest{})
@@ -56,7 +58,7 @@ func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServe
 	}
 
 	if client == nil {
-		return nil, wrapAdminError(ErrUnknown, errors.New("unable to connect to admin server"))
+		return nil, wrapAdminError(ErrUnknown, errors.New(errUnableToConnectToAdminServer))
 	}
 
 	response, err := client.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: dataServer})
@@ -73,7 +75,7 @@ func (admin *adminClientImpl) CreateDataServer(dataServerInfo *proto.DataServerI
 	}
 
 	if client == nil {
-		return nil, wrapAdminError(ErrUnknown, errors.New("unable to connect to admin server"))
+		return nil, wrapAdminError(ErrUnknown, errors.New(errUnableToConnectToAdminServer))
 	}
 
 	response, err := client.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{
@@ -95,7 +97,7 @@ func (admin *adminClientImpl) ListNodes() *ListNodesResult {
 
 	if client == nil {
 		return &ListNodesResult{
-			Error: errors.New("unable to connect to admin server"),
+			Error: errors.New(errUnableToConnectToAdminServer),
 		}
 	}
 

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -36,6 +36,8 @@ type mockAdminRpcClient struct {
 	listDataServersErr      error
 	getDataServerResponse   *proto.GetDataServerResponse
 	getDataServerErr        error
+	createDataServerResp    *proto.CreateDataServerResponse
+	createDataServerErr     error
 }
 
 func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataServersRequest, ...grpc.CallOption) (*proto.ListDataServersResponse, error) {
@@ -44,6 +46,10 @@ func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataSer
 
 func (m *mockAdminRpcClient) GetDataServer(context.Context, *proto.GetDataServerRequest, ...grpc.CallOption) (*proto.GetDataServerResponse, error) {
 	return m.getDataServerResponse, m.getDataServerErr
+}
+
+func (m *mockAdminRpcClient) CreateDataServer(context.Context, *proto.CreateDataServerRequest, ...grpc.CallOption) (*proto.CreateDataServerResponse, error) {
+	return m.createDataServerResp, m.createDataServerErr
 }
 
 func (*mockAdminRpcClient) ListNamespaces(context.Context, *proto.ListNamespacesRequest, ...grpc.CallOption) (*proto.ListNamespacesResponse, error) {
@@ -205,6 +211,48 @@ func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
 	assert.Equal(t, "public-1", dataServer.DataServer.PublicAddress)
 	assert.Equal(t, "internal-1", dataServer.DataServer.InternalAddress)
 	assert.Equal(t, map[string]string{"rack": "rack-1"}, dataServer.Metadata)
+}
+
+func TestAdminClientCreateDataServerReturnsResponse(t *testing.T) {
+	serverName := "server-4"
+	admin := &adminClientImpl{
+		adminAddr: "admin-addr",
+		clientPool: &mockAdminClientPool{
+			adminClient: &mockAdminRpcClient{
+				createDataServerResp: &proto.CreateDataServerResponse{
+					DataServerInfo: &proto.DataServerInfo{
+						DataServer: &proto.DataServer{
+							Name:            &serverName,
+							PublicAddress:   "public-4",
+							InternalAddress: "internal-4",
+						},
+						Metadata: map[string]string{
+							"rack": "a",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dataServerInfo, err := admin.CreateDataServer(&proto.DataServerInfo{
+		DataServer: &proto.DataServer{
+			Name:            &serverName,
+			PublicAddress:   "public-4",
+			InternalAddress: "internal-4",
+		},
+		Metadata: map[string]string{
+			"rack": "a",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, dataServerInfo)
+	require.NotNil(t, dataServerInfo.DataServer)
+	require.NotNil(t, dataServerInfo.DataServer.Name)
+	assert.Equal(t, serverName, *dataServerInfo.DataServer.Name)
+	assert.Equal(t, "public-4", dataServerInfo.DataServer.PublicAddress)
+	assert.Equal(t, "internal-4", dataServerInfo.DataServer.InternalAddress)
+	assert.Equal(t, "a", dataServerInfo.Metadata["rack"])
 }
 
 func TestWrapAdminErrorPreservesCause(t *testing.T) {

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -24,6 +24,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/proto"
+	oxiadcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	"github.com/oxia-db/oxia/oxiad/coordinator/resource"
 )
@@ -66,6 +67,26 @@ func (admin *adminServer) GetDataServer(_ context.Context, req *proto.GetDataSer
 
 	return &proto.GetDataServerResponse{
 		DataServerInfo: dataServerInfo.ToAdminProto(),
+	}, nil
+}
+
+func (admin *adminServer) CreateDataServer(_ context.Context, req *proto.CreateDataServerRequest) (*proto.CreateDataServerResponse, error) {
+	if req.GetDataServerInfo() == nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data_server_info is required")
+	}
+
+	dataServerInfo, err := validateCreateDataServerRequest(req.GetDataServerInfo())
+	if err != nil {
+		return nil, err
+	}
+
+	createdDataServerInfo, err := admin.ccr.CreateDataServer(dataServerInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &proto.CreateDataServerResponse{
+		DataServerInfo: createdDataServerInfo.ToAdminProto(),
 	}, nil
 }
 
@@ -136,4 +157,52 @@ func newAdminServer(
 		ccr:            ccr,
 		shardSplitter:  shardSplitter,
 	}
+}
+
+func validateCreateDataServerRequest(dataServerInfo *proto.DataServerInfo) (*model.DataServerInfo, error) {
+	dataServer := dataServerInfo.GetDataServer()
+	if dataServer == nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data_server_info.data_server is required")
+	}
+
+	if dataServer.GetPublicAddress() == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "public_address is required")
+	}
+	if err := oxiadcommonrpc.ValidateAuthorityAddress(dataServer.GetPublicAddress()); err != nil {
+		return nil, grpcstatus.Errorf(codes.InvalidArgument, "invalid public_address: %v", err)
+	}
+
+	if dataServer.GetInternalAddress() == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "internal_address is required")
+	}
+	if err := oxiadcommonrpc.ValidateAuthorityAddress(dataServer.GetInternalAddress()); err != nil {
+		return nil, grpcstatus.Errorf(codes.InvalidArgument, "invalid internal_address: %v", err)
+	}
+
+	if dataServer.Name != nil && *dataServer.Name == "" {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "name must not be empty")
+	}
+
+	return &model.DataServerInfo{
+		Server: &model.Server{
+			Name:     dataServer.Name,
+			Public:   dataServer.GetPublicAddress(),
+			Internal: dataServer.GetInternalAddress(),
+		},
+		Metadata: model.ServerMetadata{
+			Labels: cloneStringMap(dataServerInfo.GetMetadata()),
+		},
+	}, nil
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	if len(source) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(source))
+	for key, value := range source {
+		cloned[key] = value
+	}
+	return cloned
 }

--- a/oxiad/coordinator/admin_server_test.go
+++ b/oxiad/coordinator/admin_server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Oxia Authors
+// Copyright 2023-2026 The Oxia Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package coordinator
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +39,87 @@ func newTestClusterConfigResource(t *testing.T, config model.ClusterConfig) reso
 		},
 		nil,
 		nil,
+	)
+	t.Cleanup(func() {
+		require.NoError(t, configResource.Close())
+	})
+	return configResource
+}
+
+type inMemoryClusterConfigManager struct {
+	clusterConfig                model.ClusterConfig
+	clusterConfigNotificationsCh chan any
+}
+
+func (m *inMemoryClusterConfigManager) Load() (model.ClusterConfig, error) {
+	return cloneClusterConfig(m.clusterConfig), nil
+}
+
+func (m *inMemoryClusterConfigManager) Update(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error) {
+	clusterConfig := cloneClusterConfig(m.clusterConfig)
+	if err := mutator(&clusterConfig); err != nil {
+		return model.ClusterConfig{}, err
+	}
+	if err := clusterConfig.Validate(); err != nil {
+		return model.ClusterConfig{}, err
+	}
+	m.clusterConfig = cloneClusterConfig(clusterConfig)
+	if m.clusterConfigNotificationsCh != nil {
+		m.clusterConfigNotificationsCh <- struct{}{}
+	}
+	return cloneClusterConfig(m.clusterConfig), nil
+}
+
+type noopClusterConfigEventListener struct{}
+
+func (noopClusterConfigEventListener) ConfigChanged(*model.ClusterConfig) {}
+
+func cloneClusterConfig(config model.ClusterConfig) model.ClusterConfig {
+	cloned := config
+	cloned.Namespaces = append([]model.NamespaceConfig(nil), config.Namespaces...)
+	cloned.Servers = append([]model.Server(nil), config.Servers...)
+	cloned.AllowExtraAuthorities = append([]string(nil), config.AllowExtraAuthorities...)
+	if config.ServerMetadata != nil {
+		cloned.ServerMetadata = make(map[string]model.ServerMetadata, len(config.ServerMetadata))
+		for key, metadata := range config.ServerMetadata {
+			cloned.ServerMetadata[key] = model.ServerMetadata{
+				Labels: cloneLabels(metadata.Labels),
+			}
+		}
+	}
+	if config.LoadBalancer != nil {
+		loadBalancer := *config.LoadBalancer
+		cloned.LoadBalancer = &loadBalancer
+	}
+	return cloned
+}
+
+func cloneLabels(labels map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(labels))
+	for key, value := range labels {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func newWritableTestClusterConfigResource(
+	t *testing.T,
+	manager *inMemoryClusterConfigManager,
+	clusterConfigNotificationsCh chan any,
+	listener resource.ClusterConfigEventListener,
+) resource.ClusterConfigResource {
+	t.Helper()
+
+	configResource := resource.NewClusterConfigResource(
+		t.Context(),
+		manager.Load,
+		clusterConfigNotificationsCh,
+		listener,
+		resource.WithClusterConfigUpdater(manager.Update),
 	)
 	t.Cleanup(func() {
 		require.NoError(t, configResource.Close())
@@ -145,6 +227,129 @@ func TestAdminServerGetDataServerByName(t *testing.T) {
 	assert.Equal(t, "public-2", res.DataServerInfo.DataServer.PublicAddress)
 	assert.Equal(t, "internal-2", res.DataServerInfo.DataServer.InternalAddress)
 	assert.Equal(t, map[string]string{"zone": "zone-2"}, res.DataServerInfo.Metadata)
+}
+
+func TestAdminServerCreateDataServerStoresMetadata(t *testing.T) {
+	existingName := "server-1"
+	manager := &inMemoryClusterConfigManager{
+		clusterConfig: model.ClusterConfig{
+			Namespaces: []model.NamespaceConfig{{
+				Name:              "default",
+				ReplicationFactor: 1,
+				InitialShardCount: 1,
+			}},
+			Servers: []model.Server{
+				{Name: &existingName, Public: "public-1:6648", Internal: "internal-1:6649"},
+			},
+		},
+	}
+
+	admin := newAdminServer(nil, newWritableTestClusterConfigResource(t, manager, nil, nil), nil)
+
+	newName := "server-2"
+	res, err := admin.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{
+		DataServerInfo: &proto.DataServerInfo{
+			DataServer: &proto.DataServer{
+				Name:            &newName,
+				PublicAddress:   "public-2:6648",
+				InternalAddress: "internal-2:6649",
+			},
+			Metadata: map[string]string{
+				"rack": "a",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.NotNil(t, res.DataServerInfo)
+	require.NotNil(t, res.DataServerInfo.DataServer)
+	require.NotNil(t, res.DataServerInfo.DataServer.Name)
+	assert.Equal(t, newName, *res.DataServerInfo.DataServer.Name)
+	assert.Equal(t, "public-2:6648", res.DataServerInfo.DataServer.PublicAddress)
+	assert.Equal(t, "internal-2:6649", res.DataServerInfo.DataServer.InternalAddress)
+	assert.Equal(t, map[string]string{"rack": "a"}, res.DataServerInfo.Metadata)
+
+	require.Len(t, manager.clusterConfig.Servers, 2)
+	assert.Equal(t, "public-2:6648", manager.clusterConfig.Servers[1].Public)
+	assert.Equal(t, "internal-2:6649", manager.clusterConfig.Servers[1].Internal)
+	assert.Equal(t, "a", manager.clusterConfig.ServerMetadata[newName].Labels["rack"])
+}
+
+func TestAdminServerCreateDataServerRejectsDuplicateIdentifier(t *testing.T) {
+	existingName := "server-1"
+	manager := &inMemoryClusterConfigManager{
+		clusterConfig: model.ClusterConfig{
+			Namespaces: []model.NamespaceConfig{{
+				Name:              "default",
+				ReplicationFactor: 1,
+				InitialShardCount: 1,
+			}},
+			Servers: []model.Server{
+				{Name: &existingName, Public: "public-1:6648", Internal: "internal-1:6649"},
+			},
+		},
+	}
+
+	admin := newAdminServer(nil, newWritableTestClusterConfigResource(t, manager, nil, nil), nil)
+
+	_, err := admin.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{
+		DataServerInfo: &proto.DataServerInfo{
+			DataServer: &proto.DataServer{
+				Name:            &existingName,
+				PublicAddress:   "public-2:6648",
+				InternalAddress: "internal-2:6649",
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, grpcstatus.Code(err))
+}
+
+func TestAdminServerCreateDataServerNotifiesClusterConfigResource(t *testing.T) {
+	clusterConfigNotificationsCh := make(chan any, 1)
+	manager := &inMemoryClusterConfigManager{
+		clusterConfig: model.ClusterConfig{
+			Namespaces: []model.NamespaceConfig{{
+				Name:              "default",
+				ReplicationFactor: 1,
+				InitialShardCount: 1,
+			}},
+			Servers: []model.Server{{
+				Public:   "public-1:6648",
+				Internal: "internal-1:6649",
+			}},
+		},
+		clusterConfigNotificationsCh: clusterConfigNotificationsCh,
+	}
+
+	clusterConfigResource := newWritableTestClusterConfigResource(
+		t,
+		manager,
+		clusterConfigNotificationsCh,
+		noopClusterConfigEventListener{},
+	)
+
+	_, exists := clusterConfigResource.Node("internal-1:6649")
+	require.True(t, exists)
+
+	admin := newAdminServer(nil, clusterConfigResource, nil)
+	_, err := admin.CreateDataServer(context.Background(), &proto.CreateDataServerRequest{
+		DataServerInfo: &proto.DataServerInfo{
+			DataServer: &proto.DataServer{
+				PublicAddress:   "public-2:6648",
+				InternalAddress: "internal-2:6649",
+			},
+			Metadata: map[string]string{
+				"rack": "b",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		server, ok := clusterConfigResource.Node("internal-2:6649")
+		return ok && server.Public == "public-2:6648"
+	}, 5*time.Second, 50*time.Millisecond)
 }
 
 func TestAdminServerGetDataServerByIdentifierFallback(t *testing.T) {

--- a/oxiad/coordinator/balancer/scheduler_test.go
+++ b/oxiad/coordinator/balancer/scheduler_test.go
@@ -16,6 +16,7 @@ package balancer
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -111,6 +112,10 @@ func (m *mockClusterConfigResource) GetDataServerInfo(id string) (*model.DataSer
 		Server:   n,
 		Metadata: metadata,
 	}, true
+}
+
+func (*mockClusterConfigResource) CreateDataServer(*model.DataServerInfo) (*model.DataServerInfo, error) {
+	return nil, errors.New("not implemented")
 }
 
 // alwaysErrorSelector is a selector that always returns ErrUnsatisfiedAntiAffinity.

--- a/oxiad/coordinator/cluster_config_manager.go
+++ b/oxiad/coordinator/cluster_config_manager.go
@@ -37,7 +37,11 @@ type ClusterConfigManager interface {
 	Update(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error)
 }
 
-const clusterConfigConfigMapKey = "config.yaml"
+const (
+	clusterConfigConfigMapKey = "config.yaml"
+	defaultClusterConfigMode  = 0o644
+	defaultClusterConfigDir   = 0o755
+)
 
 type clusterConfigManager struct {
 	sync.Mutex
@@ -113,14 +117,14 @@ func (c *clusterConfigManager) storeFile(clusterConfig model.ClusterConfig) erro
 		return errors.Wrap(err, "failed to marshal cluster config")
 	}
 
-	mode := os.FileMode(0o644)
+	mode := os.FileMode(defaultClusterConfigMode)
 	if info, err := os.Stat(path); err == nil {
 		mode = info.Mode().Perm()
 	} else if !os.IsNotExist(err) {
 		return errors.Wrap(err, "failed to inspect cluster config file")
 	}
 
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), defaultClusterConfigDir); err != nil {
 		return errors.Wrap(err, "failed to create cluster config directory")
 	}
 

--- a/oxiad/coordinator/cluster_config_manager.go
+++ b/oxiad/coordinator/cluster_config_manager.go
@@ -1,0 +1,205 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/model"
+	"github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+type ClusterConfigManager interface {
+	Load() (model.ClusterConfig, error)
+	Update(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error)
+}
+
+const clusterConfigConfigMapKey = "config.yaml"
+
+type clusterConfigManager struct {
+	sync.Mutex
+
+	clusterConfigChangeNotifications chan any
+	clusterOptions                   *option.ClusterOptions
+	viper                            *viper.Viper
+}
+
+func newClusterConfigManager(
+	clusterOptions *option.ClusterOptions,
+	v *viper.Viper,
+	clusterConfigChangeNotifications chan any,
+) ClusterConfigManager {
+	return &clusterConfigManager{
+		clusterConfigChangeNotifications: clusterConfigChangeNotifications,
+		clusterOptions:                   clusterOptions,
+		viper:                            v,
+	}
+}
+
+func (c *clusterConfigManager) Load() (model.ClusterConfig, error) {
+	return loadClusterConfig(c.clusterOptions, c.viper)
+}
+
+func (c *clusterConfigManager) Update(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	clusterConfig, err := c.Load()
+	if err != nil {
+		return model.ClusterConfig{}, err
+	}
+
+	if err := mutator(&clusterConfig); err != nil {
+		return model.ClusterConfig{}, err
+	}
+
+	if err := clusterConfig.Validate(); err != nil {
+		return model.ClusterConfig{}, err
+	}
+
+	if err := c.store(clusterConfig); err != nil {
+		return model.ClusterConfig{}, err
+	}
+
+	if c.clusterConfigChangeNotifications != nil {
+		c.clusterConfigChangeNotifications <- struct{}{}
+	}
+
+	return clusterConfig, nil
+}
+
+func (c *clusterConfigManager) store(clusterConfig model.ClusterConfig) error {
+	if strings.HasPrefix(c.clusterOptions.ConfigPath, "configmap:") {
+		return c.storeConfigMap(clusterConfig)
+	}
+
+	return c.storeFile(clusterConfig)
+}
+
+func (c *clusterConfigManager) storeFile(clusterConfig model.ClusterConfig) error {
+	path := c.clusterOptions.ConfigPath
+	if path == "" {
+		path = c.viper.ConfigFileUsed()
+	}
+	if path == "" {
+		return errors.New("cluster config file path is not configured")
+	}
+
+	data, err := yaml.Marshal(clusterConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal cluster config")
+	}
+
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	} else if !os.IsNotExist(err) {
+		return errors.Wrap(err, "failed to inspect cluster config file")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return errors.Wrap(err, "failed to create cluster config directory")
+	}
+
+	tmpFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return errors.Wrap(err, "failed to create temporary cluster config file")
+	}
+
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	if err := tmpFile.Chmod(mode); err != nil {
+		_ = tmpFile.Close()
+		return errors.Wrap(err, "failed to set cluster config permissions")
+	}
+
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		return errors.Wrap(err, "failed to write cluster config")
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return errors.Wrap(err, "failed to close temporary cluster config file")
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return errors.Wrap(err, "failed to atomically replace cluster config file")
+	}
+
+	return nil
+}
+
+func (c *clusterConfigManager) storeConfigMap(clusterConfig model.ClusterConfig) error {
+	namespace, configMapName, err := parseConfigMapPath(c.clusterOptions.ConfigPath)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(clusterConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal cluster config")
+	}
+
+	kubernetes := metadata.NewK8SClientset(metadata.NewK8SClientConfig())
+	configMaps := metadata.K8SConfigMaps(kubernetes)
+
+	cm, err := configMaps.Get(namespace, configMapName)
+	switch {
+	case err == nil:
+	case k8serrors.IsNotFound(err):
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      configMapName,
+				Namespace: namespace,
+			},
+		}
+	default:
+		return errors.Wrap(err, "failed to load cluster config configmap")
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	cm.Data[clusterConfigConfigMapKey] = string(data)
+
+	if _, err := configMaps.Upsert(namespace, configMapName, cm); err != nil {
+		return errors.Wrap(err, "failed to store cluster config configmap")
+	}
+
+	return nil
+}
+
+func parseConfigMapPath(path string) (namespace, configMapName string, err error) {
+	parts := strings.Split(strings.TrimPrefix(path, "configmap:"), "/")
+	if len(parts) != 2 {
+		return "", "", errors.New("invalid configmap configuration")
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -731,7 +731,9 @@ func (c *coordinator) restartInProgressSplits(clusterStatus *model.ClusterStatus
 func NewCoordinator(meta metadata.Provider,
 	clusterConfigProvider func() (model.ClusterConfig, error),
 	clusterConfigNotificationsCh chan any,
-	rpcProvider rpc.Provider) (Coordinator, error) {
+	rpcProvider rpc.Provider,
+	configResourceOptions ...resource.ClusterConfigResourceOption,
+) (Coordinator, error) {
 	c := &coordinator{
 		Logger: slog.With(
 			slog.String("component", "coordinator"),
@@ -759,7 +761,13 @@ func NewCoordinator(meta metadata.Provider,
 	c.assignmentsChanged = concurrent.NewConditionContext(c)
 	c.statusResource = resource.NewStatusResource(meta)
 
-	c.configResource = resource.NewClusterConfigResource(c.ctx, clusterConfigProvider, clusterConfigNotificationsCh, c)
+	c.configResource = resource.NewClusterConfigResource(
+		c.ctx,
+		clusterConfigProvider,
+		clusterConfigNotificationsCh,
+		c,
+		configResourceOptions...,
+	)
 
 	c.loadBalancer = balancer.NewLoadBalancer(balancer.Options{
 		Context:               c.ctx,

--- a/oxiad/coordinator/resource/cluster_config_resource.go
+++ b/oxiad/coordinator/resource/cluster_config_resource.go
@@ -16,6 +16,7 @@ package resource
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"reflect"
@@ -25,6 +26,8 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/emirpasic/gods/v2/trees/redblacktree"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
@@ -56,6 +59,18 @@ type ClusterConfigResource interface {
 	Node(id string) (*model.Server, bool)
 
 	GetDataServerInfo(name string) (*model.DataServerInfo, bool)
+
+	CreateDataServer(dataServerInfo *model.DataServerInfo) (*model.DataServerInfo, error)
+}
+
+type ClusterConfigUpdater func(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error)
+
+type ClusterConfigResourceOption func(*clusterConfig)
+
+func WithClusterConfigUpdater(clusterConfigUpdater ClusterConfigUpdater) ClusterConfigResourceOption {
+	return func(cc *clusterConfig) {
+		cc.clusterConfigUpdater = clusterConfigUpdater
+	}
 }
 
 var _ ClusterConfigResource = &clusterConfig{}
@@ -68,6 +83,7 @@ type clusterConfig struct {
 	cancel context.CancelFunc
 
 	clusterConfigProvider        func() (model.ClusterConfig, error)
+	clusterConfigUpdater         ClusterConfigUpdater
 	clusterConfigNotificationsCh chan any
 	clusterConfigEventListener   ClusterConfigEventListener
 
@@ -216,6 +232,74 @@ func (ccf *clusterConfig) GetDataServerInfo(id string) (*model.DataServerInfo, b
 	return info, true
 }
 
+func (ccf *clusterConfig) CreateDataServer(dataServerInfo *model.DataServerInfo) (*model.DataServerInfo, error) {
+	if ccf.clusterConfigUpdater == nil {
+		return nil, errors.New("cluster config updates are not supported")
+	}
+	if dataServerInfo == nil || dataServerInfo.Server == nil {
+		return nil, grpcstatus.Error(codes.InvalidArgument, "data server is required")
+	}
+
+	dataServerID := dataServerInfo.Server.GetIdentifier()
+	clusterConfig, err := ccf.clusterConfigUpdater(func(clusterConfig *model.ClusterConfig) error {
+		for _, existing := range clusterConfig.Servers {
+			switch {
+			case existing.GetIdentifier() == dataServerID:
+				return grpcstatus.Errorf(codes.AlreadyExists, "data server %q already exists", dataServerID)
+			case existing.Public == dataServerInfo.Server.Public:
+				return grpcstatus.Errorf(codes.AlreadyExists, "public address %q already exists", dataServerInfo.Server.Public)
+			case existing.Internal == dataServerInfo.Server.Internal:
+				return grpcstatus.Errorf(codes.AlreadyExists, "internal address %q already exists", dataServerInfo.Server.Internal)
+			}
+		}
+
+		clusterConfig.Servers = append(clusterConfig.Servers, *dataServerInfo.Server)
+		if len(dataServerInfo.Metadata.Labels) == 0 {
+			return nil
+		}
+
+		if clusterConfig.ServerMetadata == nil {
+			clusterConfig.ServerMetadata = map[string]model.ServerMetadata{}
+		}
+		clusterConfig.ServerMetadata[dataServerID] = model.ServerMetadata{
+			Labels: cloneStringMap(dataServerInfo.Metadata.Labels),
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	createdDataServerInfo := &model.DataServerInfo{
+		Metadata: model.ServerMetadata{},
+	}
+	for idx := range clusterConfig.Servers {
+		server := &clusterConfig.Servers[idx]
+		if server.GetIdentifier() != dataServerID {
+			continue
+		}
+		createdDataServerInfo.Server = server
+		if metadata, found := clusterConfig.ServerMetadata[dataServerID]; found {
+			createdDataServerInfo.Metadata = metadata
+		}
+		return createdDataServerInfo, nil
+	}
+
+	return nil, errors.New("created data server not found in cluster config")
+}
+
+func cloneStringMap(source map[string]string) map[string]string {
+	if len(source) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(source))
+	for key, value := range source {
+		cloned[key] = value
+	}
+	return cloned
+}
+
 func (ccf *clusterConfig) waitForUpdates() {
 	defer ccf.Done()
 	for {
@@ -249,6 +333,7 @@ func NewClusterConfigResource(ctx context.Context,
 	clusterConfigProvider func() (model.ClusterConfig, error),
 	clusterConfigNotificationsCh chan any,
 	clusterConfigEventListener ClusterConfigEventListener,
+	options ...ClusterConfigResourceOption,
 ) ClusterConfigResource {
 	ctx, cancelFunc := context.WithCancel(ctx)
 
@@ -260,6 +345,9 @@ func NewClusterConfigResource(ctx context.Context,
 		clusterConfigProvider:        clusterConfigProvider,
 		clusterConfigNotificationsCh: clusterConfigNotificationsCh,
 		clusterConfigEventListener:   clusterConfigEventListener,
+	}
+	for _, option := range options {
+		option(cc)
 	}
 
 	if clusterConfigNotificationsCh != nil {

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/resource"
 	coordinatorrpc "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
 	"github.com/oxia-db/oxia/common/rpc"
@@ -130,10 +131,8 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	v := viper.New()
 
 	clusterConfigChangeNotifications := make(chan any)
-
-	clusterConfigProvider := func() (model.ClusterConfig, error) {
-		return loadClusterConfig(&options.Cluster, v)
-	}
+	clusterConfigManager := newClusterConfigManager(&options.Cluster, v, clusterConfigChangeNotifications)
+	clusterConfigProvider := clusterConfigManager.Load
 
 	if err := watchClusterConfigProvider(&options.Cluster, v, clusterConfigChangeNotifications); err != nil {
 		return nil, err
@@ -188,7 +187,13 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	clientPool := rpc.NewClientPool(controllerTLS, nil)
 	rpcClient := coordinatorrpc.NewRpcProvider(clientPool)
 
-	coordinatorInstance, err := NewCoordinator(metadataProvider, clusterConfigProvider, clusterConfigChangeNotifications, rpcClient) //nolint:contextcheck
+	coordinatorInstance, err := NewCoordinator(
+		metadataProvider,
+		clusterConfigProvider,
+		clusterConfigChangeNotifications,
+		rpcClient,
+		resource.WithClusterConfigUpdater(clusterConfigManager.Update),
+	) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -193,7 +193,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 		clusterConfigChangeNotifications,
 		rpcClient,
 		resource.WithClusterConfigUpdater(clusterConfigManager.Update),
-	) //nolint:contextcheck
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -187,6 +187,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	clientPool := rpc.NewClientPool(controllerTLS, nil)
 	rpcClient := coordinatorrpc.NewRpcProvider(clientPool)
 
+	//nolint:contextcheck
 	coordinatorInstance, err := NewCoordinator(
 		metadataProvider,
 		clusterConfigProvider,


### PR DESCRIPTION
## Motivation
- start the management endpoint work from discussion #983 with the first config mutation: `CreateDataServer`
- persist new data servers in the cluster config and trigger `ClusterConfigResource` reloads so coordinators observe the change
- expose the endpoint through the Go admin client and CLI so it is usable without raw gRPC calls

## Modifications
- add `CreateDataServer` to the admin proto and extend `DataServer` with metadata labels
- introduce a cluster config manager that writes file/configmap backed cluster configs and notifies config resource watchers after updates
- implement coordinator-side validation, duplicate detection, persistence, and `ListDataServers` metadata mapping
- add Go admin client support and a new `admin create-data-server` command with metadata flag parsing
- add unit/integration coverage for persistence, config resource reloads, client behavior, and CLI wiring

## Testing
- `go test ./common/...`
- `go test ./oxia/...`
- `go test ./cmd/admin/...`
- `go test ./oxiad/...`
