### PR TITLE
feat: add PatchDataServer admin endpoint

### DIFF
--- a/cmd/admin/commons/mock_admin_client.go
+++ b/cmd/admin/commons/mock_admin_client.go
@@ -63,6 +63,14 @@ func (m *MockAdminClient) GetDataServer(dataServer string) (*proto.DataServer, e
 	return nil, errors.New("data server not found")
 }
 
+func (m *MockAdminClient) PatchDataServer(req *proto.PatchDataServerRequest) (*proto.DataServer, error) {
+	args := m.MethodCalled("PatchDataServer", req)
+	if v, ok := args.Get(0).(*proto.DataServer); ok {
+		return v, args.Error(1)
+	}
+	return nil, errors.New("data server patch failed")
+}
+
 func (m *MockAdminClient) ListNodes() *oxia.ListNodesResult {
 	args := m.MethodCalled("ListNodes")
 	if v, ok := args.Get(0).(*oxia.ListNodesResult); ok {

--- a/common/proto/admin.pb.go
+++ b/common/proto/admin.pb.go
@@ -238,6 +238,118 @@ func (x *GetDataServerRequest) GetDataServer() string {
 	return ""
 }
 
+type DataServerMetadata struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Labels        map[string]string      `protobuf:"bytes,1,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DataServerMetadata) Reset() {
+	*x = DataServerMetadata{}
+	mi := &file_admin_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DataServerMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DataServerMetadata) ProtoMessage() {}
+
+func (x *DataServerMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DataServerMetadata.ProtoReflect.Descriptor instead.
+func (*DataServerMetadata) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *DataServerMetadata) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
+}
+
+type PatchDataServerRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	DataServer      string                 `protobuf:"bytes,1,opt,name=data_server,json=dataServer,proto3" json:"data_server,omitempty"`
+	PublicAddress   *string                `protobuf:"bytes,2,opt,name=public_address,json=publicAddress,proto3,oneof" json:"public_address,omitempty"`
+	InternalAddress *string                `protobuf:"bytes,3,opt,name=internal_address,json=internalAddress,proto3,oneof" json:"internal_address,omitempty"`
+	Metadata        *DataServerMetadata    `protobuf:"bytes,4,opt,name=metadata,proto3,oneof" json:"metadata,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *PatchDataServerRequest) Reset() {
+	*x = PatchDataServerRequest{}
+	mi := &file_admin_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PatchDataServerRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PatchDataServerRequest) ProtoMessage() {}
+
+func (x *PatchDataServerRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_admin_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PatchDataServerRequest.ProtoReflect.Descriptor instead.
+func (*PatchDataServerRequest) Descriptor() ([]byte, []int) {
+	return file_admin_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PatchDataServerRequest) GetDataServer() string {
+	if x != nil {
+		return x.DataServer
+	}
+	return ""
+}
+
+func (x *PatchDataServerRequest) GetPublicAddress() string {
+	if x != nil && x.PublicAddress != nil {
+		return *x.PublicAddress
+	}
+	return ""
+}
+
+func (x *PatchDataServerRequest) GetInternalAddress() string {
+	if x != nil && x.InternalAddress != nil {
+		return *x.InternalAddress
+	}
+	return ""
+}
+
+func (x *PatchDataServerRequest) GetMetadata() *DataServerMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type ListNamespacesRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -246,7 +358,7 @@ type ListNamespacesRequest struct {
 
 func (x *ListNamespacesRequest) Reset() {
 	*x = ListNamespacesRequest{}
-	mi := &file_admin_proto_msgTypes[4]
+	mi := &file_admin_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -258,7 +370,7 @@ func (x *ListNamespacesRequest) String() string {
 func (*ListNamespacesRequest) ProtoMessage() {}
 
 func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[4]
+	mi := &file_admin_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -271,7 +383,7 @@ func (x *ListNamespacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesRequest.ProtoReflect.Descriptor instead.
 func (*ListNamespacesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{4}
+	return file_admin_proto_rawDescGZIP(), []int{6}
 }
 
 type ListNamespacesResponse struct {
@@ -283,7 +395,7 @@ type ListNamespacesResponse struct {
 
 func (x *ListNamespacesResponse) Reset() {
 	*x = ListNamespacesResponse{}
-	mi := &file_admin_proto_msgTypes[5]
+	mi := &file_admin_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -295,7 +407,7 @@ func (x *ListNamespacesResponse) String() string {
 func (*ListNamespacesResponse) ProtoMessage() {}
 
 func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[5]
+	mi := &file_admin_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -308,7 +420,7 @@ func (x *ListNamespacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNamespacesResponse.ProtoReflect.Descriptor instead.
 func (*ListNamespacesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{5}
+	return file_admin_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ListNamespacesResponse) GetNamespaces() []string {
@@ -326,7 +438,7 @@ type ListNodesRequest struct {
 
 func (x *ListNodesRequest) Reset() {
 	*x = ListNodesRequest{}
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -338,7 +450,7 @@ func (x *ListNodesRequest) String() string {
 func (*ListNodesRequest) ProtoMessage() {}
 
 func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[6]
+	mi := &file_admin_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -351,7 +463,7 @@ func (x *ListNodesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesRequest.ProtoReflect.Descriptor instead.
 func (*ListNodesRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{6}
+	return file_admin_proto_rawDescGZIP(), []int{8}
 }
 
 type Node struct {
@@ -366,7 +478,7 @@ type Node struct {
 
 func (x *Node) Reset() {
 	*x = Node{}
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -378,7 +490,7 @@ func (x *Node) String() string {
 func (*Node) ProtoMessage() {}
 
 func (x *Node) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[7]
+	mi := &file_admin_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -391,7 +503,7 @@ func (x *Node) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Node.ProtoReflect.Descriptor instead.
 func (*Node) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{7}
+	return file_admin_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Node) GetName() string {
@@ -431,7 +543,7 @@ type ListNodesResponse struct {
 
 func (x *ListNodesResponse) Reset() {
 	*x = ListNodesResponse{}
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -443,7 +555,7 @@ func (x *ListNodesResponse) String() string {
 func (*ListNodesResponse) ProtoMessage() {}
 
 func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[8]
+	mi := &file_admin_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -456,7 +568,7 @@ func (x *ListNodesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListNodesResponse.ProtoReflect.Descriptor instead.
 func (*ListNodesResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{8}
+	return file_admin_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ListNodesResponse) GetNodes() []*Node {
@@ -478,7 +590,7 @@ type SplitShardRequest struct {
 
 func (x *SplitShardRequest) Reset() {
 	*x = SplitShardRequest{}
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -490,7 +602,7 @@ func (x *SplitShardRequest) String() string {
 func (*SplitShardRequest) ProtoMessage() {}
 
 func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[9]
+	mi := &file_admin_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -503,7 +615,7 @@ func (x *SplitShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardRequest.ProtoReflect.Descriptor instead.
 func (*SplitShardRequest) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{9}
+	return file_admin_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *SplitShardRequest) GetNamespace() string {
@@ -537,7 +649,7 @@ type SplitShardResponse struct {
 
 func (x *SplitShardResponse) Reset() {
 	*x = SplitShardResponse{}
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -549,7 +661,7 @@ func (x *SplitShardResponse) String() string {
 func (*SplitShardResponse) ProtoMessage() {}
 
 func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_admin_proto_msgTypes[10]
+	mi := &file_admin_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -562,7 +674,7 @@ func (x *SplitShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SplitShardResponse.ProtoReflect.Descriptor instead.
 func (*SplitShardResponse) Descriptor() ([]byte, []int) {
-	return file_admin_proto_rawDescGZIP(), []int{10}
+	return file_admin_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SplitShardResponse) GetLeftChildShard() int64 {
@@ -600,7 +712,21 @@ const file_admin_proto_rawDesc = "" +
 	"\fdata_servers\x18\x01 \x03(\v2\x1c.io.oxia.proto.v1.DataServerR\vdataServers\"7\n" +
 	"\x14GetDataServerRequest\x12\x1f\n" +
 	"\vdata_server\x18\x01 \x01(\tR\n" +
-	"dataServer\"\x17\n" +
+	"dataServer\"\x99\x01\n" +
+	"\x12DataServerMetadata\x12H\n" +
+	"\x06labels\x18\x01 \x03(\v20.io.oxia.proto.v1.DataServerMetadata.LabelsEntryR\x06labels\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x91\x02\n" +
+	"\x16PatchDataServerRequest\x12\x1f\n" +
+	"\vdata_server\x18\x01 \x01(\tR\n" +
+	"dataServer\x12*\n" +
+	"\x0epublic_address\x18\x02 \x01(\tH\x00R\rpublicAddress\x88\x01\x01\x12.\n" +
+	"\x10internal_address\x18\x03 \x01(\tH\x01R\x0finternalAddress\x88\x01\x01\x12E\n" +
+	"\bmetadata\x18\x04 \x01(\v2$.io.oxia.proto.v1.DataServerMetadataH\x02R\bmetadata\x88\x01\x01B\x11\n" +
+	"\x0f_public_addressB\x13\n" +
+	"\x11_internal_addressB\v\n" +
+	"\t_metadata\"\x17\n" +
 	"\x15ListNamespacesRequest\"8\n" +
 	"\x16ListNamespacesResponse\x12\x1e\n" +
 	"\n" +
@@ -626,10 +752,11 @@ const file_admin_proto_rawDesc = "" +
 	"\f_split_point\"j\n" +
 	"\x12SplitShardResponse\x12(\n" +
 	"\x10left_child_shard\x18\x01 \x01(\x03R\x0eleftChildShard\x12*\n" +
-	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xde\x03\n" +
+	"\x11right_child_shard\x18\x02 \x01(\x03R\x0frightChildShard2\xb9\x04\n" +
 	"\tOxiaAdmin\x12f\n" +
 	"\x0fListDataServers\x12(.io.oxia.proto.v1.ListDataServersRequest\x1a).io.oxia.proto.v1.ListDataServersResponse\x12U\n" +
-	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a\x1c.io.oxia.proto.v1.DataServer\x12c\n" +
+	"\rGetDataServer\x12&.io.oxia.proto.v1.GetDataServerRequest\x1a\x1c.io.oxia.proto.v1.DataServer\x12Y\n" +
+	"\x0fPatchDataServer\x12(.io.oxia.proto.v1.PatchDataServerRequest\x1a\x1c.io.oxia.proto.v1.DataServer\x12c\n" +
 	"\x0eListNamespaces\x12'.io.oxia.proto.v1.ListNamespacesRequest\x1a(.io.oxia.proto.v1.ListNamespacesResponse\x12T\n" +
 	"\tListNodes\x12\".io.oxia.proto.v1.ListNodesRequest\x1a#.io.oxia.proto.v1.ListNodesResponse\x12W\n" +
 	"\n" +
@@ -647,44 +774,51 @@ func file_admin_proto_rawDescGZIP() []byte {
 	return file_admin_proto_rawDescData
 }
 
-var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_admin_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_admin_proto_goTypes = []any{
 	(*ListDataServersRequest)(nil),  // 0: io.oxia.proto.v1.ListDataServersRequest
 	(*DataServer)(nil),              // 1: io.oxia.proto.v1.DataServer
 	(*ListDataServersResponse)(nil), // 2: io.oxia.proto.v1.ListDataServersResponse
 	(*GetDataServerRequest)(nil),    // 3: io.oxia.proto.v1.GetDataServerRequest
-	(*ListNamespacesRequest)(nil),   // 4: io.oxia.proto.v1.ListNamespacesRequest
-	(*ListNamespacesResponse)(nil),  // 5: io.oxia.proto.v1.ListNamespacesResponse
-	(*ListNodesRequest)(nil),        // 6: io.oxia.proto.v1.ListNodesRequest
-	(*Node)(nil),                    // 7: io.oxia.proto.v1.Node
-	(*ListNodesResponse)(nil),       // 8: io.oxia.proto.v1.ListNodesResponse
-	(*SplitShardRequest)(nil),       // 9: io.oxia.proto.v1.SplitShardRequest
-	(*SplitShardResponse)(nil),      // 10: io.oxia.proto.v1.SplitShardResponse
-	nil,                             // 11: io.oxia.proto.v1.DataServer.MetadataEntry
-	nil,                             // 12: io.oxia.proto.v1.Node.MetadataEntry
-	(Feature)(0),                    // 13: replication.Feature
+	(*DataServerMetadata)(nil),      // 4: io.oxia.proto.v1.DataServerMetadata
+	(*PatchDataServerRequest)(nil),  // 5: io.oxia.proto.v1.PatchDataServerRequest
+	(*ListNamespacesRequest)(nil),   // 6: io.oxia.proto.v1.ListNamespacesRequest
+	(*ListNamespacesResponse)(nil),  // 7: io.oxia.proto.v1.ListNamespacesResponse
+	(*ListNodesRequest)(nil),        // 8: io.oxia.proto.v1.ListNodesRequest
+	(*Node)(nil),                    // 9: io.oxia.proto.v1.Node
+	(*ListNodesResponse)(nil),       // 10: io.oxia.proto.v1.ListNodesResponse
+	(*SplitShardRequest)(nil),       // 11: io.oxia.proto.v1.SplitShardRequest
+	(*SplitShardResponse)(nil),      // 12: io.oxia.proto.v1.SplitShardResponse
+	nil,                             // 13: io.oxia.proto.v1.DataServer.MetadataEntry
+	nil,                             // 14: io.oxia.proto.v1.DataServerMetadata.LabelsEntry
+	nil,                             // 15: io.oxia.proto.v1.Node.MetadataEntry
+	(Feature)(0),                    // 16: replication.Feature
 }
 var file_admin_proto_depIdxs = []int32{
-	11, // 0: io.oxia.proto.v1.DataServer.metadata:type_name -> io.oxia.proto.v1.DataServer.MetadataEntry
-	13, // 1: io.oxia.proto.v1.DataServer.supported_features:type_name -> replication.Feature
+	13, // 0: io.oxia.proto.v1.DataServer.metadata:type_name -> io.oxia.proto.v1.DataServer.MetadataEntry
+	16, // 1: io.oxia.proto.v1.DataServer.supported_features:type_name -> replication.Feature
 	1,  // 2: io.oxia.proto.v1.ListDataServersResponse.data_servers:type_name -> io.oxia.proto.v1.DataServer
-	12, // 3: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
-	7,  // 4: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
-	0,  // 5: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
-	3,  // 6: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
-	4,  // 7: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
-	6,  // 8: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
-	9,  // 9: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
-	2,  // 10: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
-	1,  // 11: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.DataServer
-	5,  // 12: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
-	8,  // 13: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
-	10, // 14: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
-	10, // [10:15] is the sub-list for method output_type
-	5,  // [5:10] is the sub-list for method input_type
-	5,  // [5:5] is the sub-list for extension type_name
-	5,  // [5:5] is the sub-list for extension extendee
-	0,  // [0:5] is the sub-list for field type_name
+	14, // 3: io.oxia.proto.v1.DataServerMetadata.labels:type_name -> io.oxia.proto.v1.DataServerMetadata.LabelsEntry
+	4,  // 4: io.oxia.proto.v1.PatchDataServerRequest.metadata:type_name -> io.oxia.proto.v1.DataServerMetadata
+	15, // 5: io.oxia.proto.v1.Node.metadata:type_name -> io.oxia.proto.v1.Node.MetadataEntry
+	9,  // 6: io.oxia.proto.v1.ListNodesResponse.nodes:type_name -> io.oxia.proto.v1.Node
+	0,  // 7: io.oxia.proto.v1.OxiaAdmin.ListDataServers:input_type -> io.oxia.proto.v1.ListDataServersRequest
+	3,  // 8: io.oxia.proto.v1.OxiaAdmin.GetDataServer:input_type -> io.oxia.proto.v1.GetDataServerRequest
+	5,  // 9: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:input_type -> io.oxia.proto.v1.PatchDataServerRequest
+	6,  // 10: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:input_type -> io.oxia.proto.v1.ListNamespacesRequest
+	8,  // 11: io.oxia.proto.v1.OxiaAdmin.ListNodes:input_type -> io.oxia.proto.v1.ListNodesRequest
+	11, // 12: io.oxia.proto.v1.OxiaAdmin.SplitShard:input_type -> io.oxia.proto.v1.SplitShardRequest
+	2,  // 13: io.oxia.proto.v1.OxiaAdmin.ListDataServers:output_type -> io.oxia.proto.v1.ListDataServersResponse
+	1,  // 14: io.oxia.proto.v1.OxiaAdmin.GetDataServer:output_type -> io.oxia.proto.v1.DataServer
+	1,  // 15: io.oxia.proto.v1.OxiaAdmin.PatchDataServer:output_type -> io.oxia.proto.v1.DataServer
+	7,  // 16: io.oxia.proto.v1.OxiaAdmin.ListNamespaces:output_type -> io.oxia.proto.v1.ListNamespacesResponse
+	10, // 17: io.oxia.proto.v1.OxiaAdmin.ListNodes:output_type -> io.oxia.proto.v1.ListNodesResponse
+	12, // 18: io.oxia.proto.v1.OxiaAdmin.SplitShard:output_type -> io.oxia.proto.v1.SplitShardResponse
+	13, // [13:19] is the sub-list for method output_type
+	7,  // [7:13] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_admin_proto_init() }
@@ -694,15 +828,16 @@ func file_admin_proto_init() {
 	}
 	file_replication_proto_init()
 	file_admin_proto_msgTypes[1].OneofWrappers = []any{}
-	file_admin_proto_msgTypes[7].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[5].OneofWrappers = []any{}
 	file_admin_proto_msgTypes[9].OneofWrappers = []any{}
+	file_admin_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_admin_proto_rawDesc), len(file_admin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/common/proto/admin.proto
+++ b/common/proto/admin.proto
@@ -28,6 +28,7 @@ service OxiaAdmin {
 
   rpc ListDataServers(ListDataServersRequest) returns (ListDataServersResponse);
   rpc GetDataServer(GetDataServerRequest) returns (DataServer);
+  rpc PatchDataServer(PatchDataServerRequest) returns (DataServer);
 
   rpc ListNamespaces(ListNamespacesRequest) returns (ListNamespacesResponse);
 
@@ -59,6 +60,17 @@ message ListDataServersResponse {
 
 message GetDataServerRequest {
   string data_server = 1;
+}
+
+message DataServerMetadata {
+  map<string, string> labels = 1;
+}
+
+message PatchDataServerRequest {
+  string data_server = 1;
+  optional string public_address = 2;
+  optional string internal_address = 3;
+  optional DataServerMetadata metadata = 4;
 }
 
 message ListNamespacesRequest {

--- a/common/proto/admin_grpc.pb.go
+++ b/common/proto/admin_grpc.pb.go
@@ -38,6 +38,7 @@ const _ = grpc.SupportPackageIsVersion9
 const (
 	OxiaAdmin_ListDataServers_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/ListDataServers"
 	OxiaAdmin_GetDataServer_FullMethodName   = "/io.oxia.proto.v1.OxiaAdmin/GetDataServer"
+	OxiaAdmin_PatchDataServer_FullMethodName = "/io.oxia.proto.v1.OxiaAdmin/PatchDataServer"
 	OxiaAdmin_ListNamespaces_FullMethodName  = "/io.oxia.proto.v1.OxiaAdmin/ListNamespaces"
 	OxiaAdmin_ListNodes_FullMethodName       = "/io.oxia.proto.v1.OxiaAdmin/ListNodes"
 	OxiaAdmin_SplitShard_FullMethodName      = "/io.oxia.proto.v1.OxiaAdmin/SplitShard"
@@ -49,6 +50,7 @@ const (
 type OxiaAdminClient interface {
 	ListDataServers(ctx context.Context, in *ListDataServersRequest, opts ...grpc.CallOption) (*ListDataServersResponse, error)
 	GetDataServer(ctx context.Context, in *GetDataServerRequest, opts ...grpc.CallOption) (*DataServer, error)
+	PatchDataServer(ctx context.Context, in *PatchDataServerRequest, opts ...grpc.CallOption) (*DataServer, error)
 	ListNamespaces(ctx context.Context, in *ListNamespacesRequest, opts ...grpc.CallOption) (*ListNamespacesResponse, error)
 	// Deprecated: Use ListDataServers instead.
 	ListNodes(ctx context.Context, in *ListNodesRequest, opts ...grpc.CallOption) (*ListNodesResponse, error)
@@ -80,6 +82,16 @@ func (c *oxiaAdminClient) GetDataServer(ctx context.Context, in *GetDataServerRe
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DataServer)
 	err := c.cc.Invoke(ctx, OxiaAdmin_GetDataServer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *oxiaAdminClient) PatchDataServer(ctx context.Context, in *PatchDataServerRequest, opts ...grpc.CallOption) (*DataServer, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DataServer)
+	err := c.cc.Invoke(ctx, OxiaAdmin_PatchDataServer_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -122,6 +134,7 @@ func (c *oxiaAdminClient) SplitShard(ctx context.Context, in *SplitShardRequest,
 type OxiaAdminServer interface {
 	ListDataServers(context.Context, *ListDataServersRequest) (*ListDataServersResponse, error)
 	GetDataServer(context.Context, *GetDataServerRequest) (*DataServer, error)
+	PatchDataServer(context.Context, *PatchDataServerRequest) (*DataServer, error)
 	ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error)
 	// Deprecated: Use ListDataServers instead.
 	ListNodes(context.Context, *ListNodesRequest) (*ListNodesResponse, error)
@@ -144,6 +157,9 @@ func (UnimplementedOxiaAdminServer) ListDataServers(context.Context, *ListDataSe
 }
 func (UnimplementedOxiaAdminServer) GetDataServer(context.Context, *GetDataServerRequest) (*DataServer, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetDataServer not implemented")
+}
+func (UnimplementedOxiaAdminServer) PatchDataServer(context.Context, *PatchDataServerRequest) (*DataServer, error) {
+	return nil, status.Error(codes.Unimplemented, "method PatchDataServer not implemented")
 }
 func (UnimplementedOxiaAdminServer) ListNamespaces(context.Context, *ListNamespacesRequest) (*ListNamespacesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListNamespaces not implemented")
@@ -207,6 +223,24 @@ func _OxiaAdmin_GetDataServer_Handler(srv interface{}, ctx context.Context, dec 
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(OxiaAdminServer).GetDataServer(ctx, req.(*GetDataServerRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _OxiaAdmin_PatchDataServer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PatchDataServerRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaAdminServer).PatchDataServer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaAdmin_PatchDataServer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaAdminServer).PatchDataServer(ctx, req.(*PatchDataServerRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -279,6 +313,10 @@ var OxiaAdmin_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetDataServer",
 			Handler:    _OxiaAdmin_GetDataServer_Handler,
+		},
+		{
+			MethodName: "PatchDataServer",
+			Handler:    _OxiaAdmin_PatchDataServer_Handler,
 		},
 		{
 			MethodName: "ListNamespaces",

--- a/common/proto/admin_vtproto.pb.go
+++ b/common/proto/admin_vtproto.pb.go
@@ -110,6 +110,55 @@ func (m *GetDataServerRequest) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *DataServerMetadata) CloneVT() *DataServerMetadata {
+	if m == nil {
+		return (*DataServerMetadata)(nil)
+	}
+	r := new(DataServerMetadata)
+	if rhs := m.Labels; rhs != nil {
+		tmpContainer := make(map[string]string, len(rhs))
+		for k, v := range rhs {
+			tmpContainer[k] = v
+		}
+		r.Labels = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *DataServerMetadata) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *PatchDataServerRequest) CloneVT() *PatchDataServerRequest {
+	if m == nil {
+		return (*PatchDataServerRequest)(nil)
+	}
+	r := new(PatchDataServerRequest)
+	r.DataServer = m.DataServer
+	r.Metadata = m.Metadata.CloneVT()
+	if rhs := m.PublicAddress; rhs != nil {
+		tmpVal := *rhs
+		r.PublicAddress = &tmpVal
+	}
+	if rhs := m.InternalAddress; rhs != nil {
+		tmpVal := *rhs
+		r.InternalAddress = &tmpVal
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *PatchDataServerRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *ListNamespacesRequest) CloneVT() *ListNamespacesRequest {
 	if m == nil {
 		return (*ListNamespacesRequest)(nil)
@@ -364,6 +413,62 @@ func (this *GetDataServerRequest) EqualVT(that *GetDataServerRequest) bool {
 
 func (this *GetDataServerRequest) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*GetDataServerRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *DataServerMetadata) EqualVT(that *DataServerMetadata) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if len(this.Labels) != len(that.Labels) {
+		return false
+	}
+	for i, vx := range this.Labels {
+		vy, ok := that.Labels[i]
+		if !ok {
+			return false
+		}
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *DataServerMetadata) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*DataServerMetadata)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *PatchDataServerRequest) EqualVT(that *PatchDataServerRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.DataServer != that.DataServer {
+		return false
+	}
+	if p, q := this.PublicAddress, that.PublicAddress; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
+	}
+	if p, q := this.InternalAddress, that.InternalAddress; (p == nil && q != nil) || (p != nil && (q == nil || *p != *q)) {
+		return false
+	}
+	if !this.Metadata.EqualVT(that.Metadata) {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *PatchDataServerRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*PatchDataServerRequest)
 	if !ok {
 		return false
 	}
@@ -744,6 +849,122 @@ func (m *GetDataServerRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.DataServer) > 0 {
+		i -= len(m.DataServer)
+		copy(dAtA[i:], m.DataServer)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.DataServer)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *DataServerMetadata) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *DataServerMetadata) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *DataServerMetadata) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.Labels) > 0 {
+		for k := range m.Labels {
+			v := m.Labels[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *PatchDataServerRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *PatchDataServerRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *PatchDataServerRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.Metadata != nil {
+		size, err := m.Metadata.MarshalToSizedBufferVT(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(size))
+		i--
+		dAtA[i] = 0x22
+	}
+	if m.InternalAddress != nil {
+		i -= len(*m.InternalAddress)
+		copy(dAtA[i:], *m.InternalAddress)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.InternalAddress)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if m.PublicAddress != nil {
+		i -= len(*m.PublicAddress)
+		copy(dAtA[i:], *m.PublicAddress)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(*m.PublicAddress)))
+		i--
+		dAtA[i] = 0x12
 	}
 	if len(m.DataServer) > 0 {
 		i -= len(m.DataServer)
@@ -1145,6 +1366,50 @@ func (m *GetDataServerRequest) SizeVT() (n int) {
 	_ = l
 	l = len(m.DataServer)
 	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *DataServerMetadata) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if len(m.Labels) > 0 {
+		for k, v := range m.Labels {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
+			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *PatchDataServerRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.DataServer)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.PublicAddress != nil {
+		l = len(*m.PublicAddress)
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.InternalAddress != nil {
+		l = len(*m.InternalAddress)
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.Metadata != nil {
+		l = m.Metadata.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	n += len(m.unknownFields)
@@ -1809,6 +2074,369 @@ func (m *GetDataServerRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.DataServer = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DataServerMetadata) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DataServerMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DataServerMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Labels == nil {
+				m.Labels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Labels[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PatchDataServerRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PatchDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PatchDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.DataServer = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PublicAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(dAtA[iNdEx:postIndex])
+			m.PublicAddress = &s
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InternalAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			s := string(dAtA[iNdEx:postIndex])
+			m.InternalAddress = &s
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &DataServerMetadata{}
+			}
+			if err := m.Metadata.UnmarshalVT(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
@@ -3152,6 +3780,389 @@ func (m *GetDataServerRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
 			}
 			m.DataServer = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *DataServerMetadata) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: DataServerMetadata: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: DataServerMetadata: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Labels", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Labels == nil {
+				m.Labels = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapkey == 0 {
+						mapkey = ""
+					} else {
+						mapkey = unsafe.String(&dAtA[iNdEx], intStringLenmapkey)
+					}
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					if intStringLenmapvalue == 0 {
+						mapvalue = ""
+					} else {
+						mapvalue = unsafe.String(&dAtA[iNdEx], intStringLenmapvalue)
+					}
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if (skippy < 0) || (iNdEx+skippy) < 0 {
+						return protohelpers.ErrInvalidLength
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Labels[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *PatchDataServerRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: PatchDataServerRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: PatchDataServerRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field DataServer", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.DataServer = stringValue
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field PublicAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			s := stringValue
+			m.PublicAddress = &s
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InternalAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			s := stringValue
+			m.InternalAddress = &s
+			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Metadata", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Metadata == nil {
+				m.Metadata = &DataServerMetadata{}
+			}
+			if err := m.Metadata.UnmarshalVTUnsafe(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/oxia/admin.go
+++ b/oxia/admin.go
@@ -25,6 +25,7 @@ type AdminClient interface {
 
 	ListDataServers() ([]*proto.DataServer, error)
 	GetDataServer(dataServer string) (*proto.DataServer, error)
+	PatchDataServer(req *proto.PatchDataServerRequest) (*proto.DataServer, error)
 
 	ListNamespaces() *ListNamespacesResult
 

--- a/oxia/admin_client_impl.go
+++ b/oxia/admin_client_impl.go
@@ -67,6 +67,23 @@ func (admin *adminClientImpl) GetDataServer(dataServer string) (*proto.DataServe
 	return response, nil
 }
 
+func (admin *adminClientImpl) PatchDataServer(req *proto.PatchDataServerRequest) (*proto.DataServer, error) {
+	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+
+	if client == nil {
+		return nil, wrapAdminError(ErrUnknown, errors.New("unable to connect to admin server"))
+	}
+
+	response, err := client.PatchDataServer(context.Background(), req)
+	if err != nil {
+		return nil, mapAdminError(err)
+	}
+	return response, nil
+}
+
 func (admin *adminClientImpl) ListNodes() *ListNodesResult {
 	client, err := admin.clientPool.GetAminRpc(admin.adminAddr)
 	if err != nil {

--- a/oxia/admin_client_impl_test.go
+++ b/oxia/admin_client_impl_test.go
@@ -36,6 +36,8 @@ type mockAdminRpcClient struct {
 	listDataServersErr      error
 	getDataServerResponse   *proto.DataServer
 	getDataServerErr        error
+	patchDataServerResponse *proto.DataServer
+	patchDataServerErr      error
 }
 
 func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataServersRequest, ...grpc.CallOption) (*proto.ListDataServersResponse, error) {
@@ -44,6 +46,10 @@ func (m *mockAdminRpcClient) ListDataServers(context.Context, *proto.ListDataSer
 
 func (m *mockAdminRpcClient) GetDataServer(context.Context, *proto.GetDataServerRequest, ...grpc.CallOption) (*proto.DataServer, error) {
 	return m.getDataServerResponse, m.getDataServerErr
+}
+
+func (m *mockAdminRpcClient) PatchDataServer(context.Context, *proto.PatchDataServerRequest, ...grpc.CallOption) (*proto.DataServer, error) {
+	return m.patchDataServerResponse, m.patchDataServerErr
 }
 
 func (*mockAdminRpcClient) ListNamespaces(context.Context, *proto.ListNamespacesRequest, ...grpc.CallOption) (*proto.ListNamespacesResponse, error) {
@@ -202,6 +208,35 @@ func TestAdminClientGetDataServerReturnsResponse(t *testing.T) {
 	assert.Equal(t, "internal-1", dataServer.InternalAddress)
 	assert.Equal(t, map[string]string{"rack": "r1"}, dataServer.Metadata)
 	assert.Equal(t, []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}, dataServer.SupportedFeatures)
+}
+
+func TestAdminClientPatchDataServerReturnsResponse(t *testing.T) {
+	serverName := "server-1"
+	publicAddress := "public-2"
+	admin := &adminClientImpl{
+		adminAddr: "admin-addr",
+		clientPool: &mockAdminClientPool{
+			adminClient: &mockAdminRpcClient{
+				patchDataServerResponse: &proto.DataServer{
+					Name:            &serverName,
+					PublicAddress:   publicAddress,
+					InternalAddress: "internal-1",
+					Metadata:        map[string]string{"rack": "r2"},
+				},
+			},
+		},
+	}
+
+	dataServer, err := admin.PatchDataServer(&proto.PatchDataServerRequest{
+		DataServer:    serverName,
+		PublicAddress: &publicAddress,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, dataServer)
+	require.NotNil(t, dataServer.Name)
+	assert.Equal(t, serverName, *dataServer.Name)
+	assert.Equal(t, publicAddress, dataServer.PublicAddress)
+	assert.Equal(t, map[string]string{"rack": "r2"}, dataServer.Metadata)
 }
 
 func TestWrapAdminErrorPreservesCause(t *testing.T) {

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -43,10 +43,11 @@ var _ proto.OxiaAdminServer = (*adminServer)(nil)
 type adminServer struct {
 	proto.UnimplementedOxiaAdminServer
 
-	statusResource resource.StatusResource
-	clusterConfig  func() (model.ClusterConfig, error)
-	shardSplitter  ShardSplitter
-	featureSource  DataServerFeatureProvider
+	statusResource     resource.StatusResource
+	clusterConfig      func() (model.ClusterConfig, error)
+	clusterConfigStore ClusterConfigStore
+	shardSplitter      ShardSplitter
+	featureSource      DataServerFeatureProvider
 }
 
 func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
@@ -69,14 +70,51 @@ func (admin *adminServer) GetDataServer(_ context.Context, req *proto.GetDataSer
 		return nil, err
 	}
 
-	for _, server := range cnf.Servers {
-		if server.GetIdentifier() != req.DataServer {
-			continue
-		}
+	server, ok := findDataServer(cnf, req.DataServer)
+	if ok {
 		return admin.toProtoDataServer(cnf, server), nil
 	}
 
 	return nil, grpcstatus.Errorf(codes.NotFound, "data server %q not found", req.DataServer)
+}
+
+func (admin *adminServer) PatchDataServer(_ context.Context, req *proto.PatchDataServerRequest) (*proto.DataServer, error) {
+	if admin.clusterConfigStore == nil {
+		return nil, grpcstatus.Error(codes.Unimplemented, "patch data server not supported")
+	}
+
+	patch := model.DataServerPatch{}
+	if req.PublicAddress != nil {
+		patch.PublicAddress = req.PublicAddress
+	}
+	if req.InternalAddress != nil {
+		patch.InternalAddress = req.InternalAddress
+	}
+	if req.Metadata != nil {
+		patch.Metadata = &model.ServerMetadata{Labels: req.Metadata.Labels}
+	}
+
+	cnf, err := admin.clusterConfigStore.Update(func(config *model.ClusterConfig) error {
+		_, err := config.PatchDataServer(req.DataServer, patch)
+		return err
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, model.ErrDataServerNotFound):
+			return nil, grpcstatus.Error(codes.NotFound, err.Error())
+		case errors.Is(err, model.ErrInvalidDataServerPatch):
+			return nil, grpcstatus.Error(codes.InvalidArgument, err.Error())
+		default:
+			return nil, err
+		}
+	}
+
+	server, ok := findDataServer(cnf, req.DataServer)
+	if !ok {
+		return nil, grpcstatus.Errorf(codes.Internal, "patched data server %q not found in updated cluster config", req.DataServer)
+	}
+
+	return admin.toProtoDataServer(cnf, server), nil
 }
 
 func (admin *adminServer) toProtoDataServer(cnf model.ClusterConfig, server model.Server) *proto.DataServer {
@@ -103,6 +141,16 @@ func (admin *adminServer) supportedFeatures(dataServer string) []proto.Feature {
 	}
 
 	return nodeController.SupportedFeatures()
+}
+
+func findDataServer(cnf model.ClusterConfig, dataServer string) (model.Server, bool) {
+	for _, server := range cnf.Servers {
+		if server.GetIdentifier() == dataServer {
+			return server, true
+		}
+	}
+
+	return model.Server{}, false
 }
 
 func (admin *adminServer) ListNamespaces(context.Context, *proto.ListNamespacesRequest) (*proto.ListNamespacesResponse, error) {
@@ -170,13 +218,15 @@ func (admin *adminServer) SplitShard(_ context.Context, req *proto.SplitShardReq
 func newAdminServer(
 	statusResource resource.StatusResource,
 	clusterConfig func() (model.ClusterConfig, error),
+	clusterConfigStore ClusterConfigStore,
 	shardSplitter ShardSplitter,
 	featureSource DataServerFeatureProvider,
 ) *adminServer {
 	return &adminServer{
-		statusResource: statusResource,
-		clusterConfig:  clusterConfig,
-		shardSplitter:  shardSplitter,
-		featureSource:  featureSource,
+		statusResource:     statusResource,
+		clusterConfig:      clusterConfig,
+		clusterConfigStore: clusterConfigStore,
+		shardSplitter:      shardSplitter,
+		featureSource:      featureSource,
 	}
 }

--- a/oxiad/coordinator/admin_server_test.go
+++ b/oxiad/coordinator/admin_server_test.go
@@ -29,11 +29,16 @@ import (
 )
 
 type testDataServerController struct {
-	features []proto.Feature
+	dataServer model.Server
+	features   []proto.Feature
 }
 
 func (*testDataServerController) Close() error {
 	return nil
+}
+
+func (t *testDataServerController) DataServer() model.Server {
+	return t.dataServer
 }
 
 func (*testDataServerController) Status() controller.DataServerStatus {
@@ -51,6 +56,20 @@ type testDataServerFeatureProvider map[string]controller.DataServerController
 
 func (t testDataServerFeatureProvider) NodeControllers() map[string]controller.DataServerController {
 	return t
+}
+
+type testClusterConfigStore struct {
+	config model.ClusterConfig
+}
+
+func (t *testClusterConfigStore) Update(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error) {
+	config := t.config
+	if err := mutator(&config); err != nil {
+		return model.ClusterConfig{}, err
+	}
+
+	t.config = config
+	return config, nil
 }
 
 func TestAdminServerListDataServers(t *testing.T) {
@@ -72,6 +91,7 @@ func TestAdminServerListDataServers(t *testing.T) {
 				},
 			}, nil
 		},
+		nil,
 		nil,
 		testDataServerFeatureProvider{
 			serverName2: &testDataServerController{features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}},
@@ -119,6 +139,7 @@ func TestAdminServerGetDataServer(t *testing.T) {
 			}, nil
 		},
 		nil,
+		nil,
 		testDataServerFeatureProvider{
 			serverName: &testDataServerController{features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}},
 		},
@@ -134,6 +155,113 @@ func TestAdminServerGetDataServer(t *testing.T) {
 	assert.Equal(t, []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}, res.SupportedFeatures)
 }
 
+func TestAdminServerGetDataServerFallsBackToInternalAddressWhenNameIsEmpty(t *testing.T) {
+	emptyName := ""
+	internalAddress := "internal-1"
+
+	admin := newAdminServer(
+		nil,
+		func() (model.ClusterConfig, error) {
+			return model.ClusterConfig{
+				Servers: []model.Server{
+					{Name: &emptyName, Public: "public-1", Internal: internalAddress},
+				},
+				ServerMetadata: map[string]model.ServerMetadata{
+					internalAddress: {Labels: map[string]string{"zone": "z1"}},
+				},
+			}, nil
+		},
+		nil,
+		nil,
+		testDataServerFeatureProvider{
+			internalAddress: &testDataServerController{features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}},
+		},
+	)
+
+	res, err := admin.GetDataServer(context.Background(), &proto.GetDataServerRequest{DataServer: internalAddress})
+	require.NoError(t, err)
+	require.NotNil(t, res.Name)
+	assert.Equal(t, emptyName, *res.Name)
+	assert.Equal(t, "public-1", res.PublicAddress)
+	assert.Equal(t, internalAddress, res.InternalAddress)
+	assert.Equal(t, map[string]string{"zone": "z1"}, res.Metadata)
+	assert.Equal(t, []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}, res.SupportedFeatures)
+}
+
+func TestAdminServerPatchDataServer(t *testing.T) {
+	serverName := "server-1"
+	publicAddress := "public-2"
+	internalAddress := "internal-2"
+
+	store := &testClusterConfigStore{
+		config: model.ClusterConfig{
+			Servers: []model.Server{
+				{Name: &serverName, Public: "public-1", Internal: "internal-1"},
+			},
+			ServerMetadata: map[string]model.ServerMetadata{
+				serverName: {Labels: map[string]string{"rack": "r1"}},
+			},
+		},
+	}
+
+	admin := newAdminServer(
+		nil,
+		func() (model.ClusterConfig, error) {
+			return store.config, nil
+		},
+		store,
+		nil,
+		testDataServerFeatureProvider{
+			serverName: &testDataServerController{features: []proto.Feature{proto.Feature_FEATURE_DB_CHECKSUM}},
+		},
+	)
+
+	res, err := admin.PatchDataServer(context.Background(), &proto.PatchDataServerRequest{
+		DataServer:      serverName,
+		PublicAddress:   &publicAddress,
+		InternalAddress: &internalAddress,
+		Metadata: &proto.DataServerMetadata{
+			Labels: map[string]string{"rack": "r2"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res.Name)
+	assert.Equal(t, serverName, *res.Name)
+	assert.Equal(t, publicAddress, res.PublicAddress)
+	assert.Equal(t, internalAddress, res.InternalAddress)
+	assert.Equal(t, map[string]string{"rack": "r2"}, res.Metadata)
+	assert.Equal(t, publicAddress, store.config.Servers[0].Public)
+	assert.Equal(t, internalAddress, store.config.Servers[0].Internal)
+}
+
+func TestAdminServerPatchDataServerRejectsUnnamedInternalAddress(t *testing.T) {
+	store := &testClusterConfigStore{
+		config: model.ClusterConfig{
+			Servers: []model.Server{
+				{Public: "public-1", Internal: "internal-1"},
+			},
+		},
+	}
+
+	internalAddress := "internal-2"
+	admin := newAdminServer(
+		nil,
+		func() (model.ClusterConfig, error) {
+			return store.config, nil
+		},
+		store,
+		nil,
+		nil,
+	)
+
+	_, err := admin.PatchDataServer(context.Background(), &proto.PatchDataServerRequest{
+		DataServer:      "internal-1",
+		InternalAddress: &internalAddress,
+	})
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, grpcstatus.Code(err))
+}
+
 func TestAdminServerGetDataServerNotFound(t *testing.T) {
 	admin := newAdminServer(
 		nil,
@@ -144,6 +272,7 @@ func TestAdminServerGetDataServerNotFound(t *testing.T) {
 				},
 			}, nil
 		},
+		nil,
 		nil,
 		nil,
 	)

--- a/oxiad/coordinator/cluster_config_store.go
+++ b/oxiad/coordinator/cluster_config_store.go
@@ -1,0 +1,206 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
+	"github.com/oxia-db/oxia/oxiad/coordinator/model"
+	"github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+const clusterConfigConfigMapFilePath = "config.yaml"
+
+type ClusterConfigStore interface {
+	Update(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error)
+}
+
+type persistentClusterConfigStore struct {
+	lock  sync.Mutex
+	load  func() (model.ClusterConfig, error)
+	write func(model.ClusterConfig) error
+}
+
+func (c *persistentClusterConfigStore) Update(mutator func(*model.ClusterConfig) error) (model.ClusterConfig, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	config, err := c.load()
+	if err != nil {
+		return model.ClusterConfig{}, err
+	}
+
+	if err := mutator(&config); err != nil {
+		return model.ClusterConfig{}, err
+	}
+	if err := config.Validate(); err != nil {
+		return model.ClusterConfig{}, err
+	}
+	if err := c.write(config); err != nil {
+		return model.ClusterConfig{}, err
+	}
+	return config, nil
+}
+
+func newClusterConfigStore(
+	cluster *option.ClusterOptions,
+	v *viper.Viper,
+	load func() (model.ClusterConfig, error),
+) (ClusterConfigStore, error) {
+	var clientset kubernetes.Interface
+	if strings.HasPrefix(cluster.ConfigPath, "configmap:") {
+		clientset = metadata.NewK8SClientset(metadata.NewK8SClientConfig())
+	}
+
+	return newClusterConfigStoreWithKubernetes(cluster, v, clientset, load)
+}
+
+func newClusterConfigStoreWithKubernetes(
+	cluster *option.ClusterOptions,
+	v *viper.Viper,
+	clientset kubernetes.Interface,
+	load func() (model.ClusterConfig, error),
+) (ClusterConfigStore, error) {
+	if strings.HasPrefix(cluster.ConfigPath, "configmap:") {
+		namespace, configMapName, err := parseClusterConfigConfigMapPath(cluster.ConfigPath)
+		if err != nil {
+			return nil, err
+		}
+		if clientset == nil {
+			return nil, errors.New("kubernetes client is required for configmap-backed cluster config")
+		}
+
+		return &persistentClusterConfigStore{
+			load: load,
+			write: func(config model.ClusterConfig) error {
+				return writeClusterConfigConfigMap(clientset, namespace, configMapName, config)
+			},
+		}, nil
+	}
+
+	configFile := v.ConfigFileUsed()
+	if configFile == "" {
+		return nil, errors.New("cluster config file path is not available")
+	}
+
+	return &persistentClusterConfigStore{
+		load: load,
+		write: func(config model.ClusterConfig) error {
+			return writeClusterConfigFile(configFile, config)
+		},
+	}, nil
+}
+
+func parseClusterConfigConfigMapPath(path string) (namespace, configMapName string, err error) {
+	parts := strings.Split(strings.TrimPrefix(path, "configmap:"), "/")
+	if len(parts) != 2 {
+		return "", "", errors.New("invalid configmap configuration")
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func writeClusterConfigFile(path string, config model.ClusterConfig) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	permissions := os.FileMode(0o644)
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		permissions = info.Mode().Perm()
+	case !errors.Is(err, os.ErrNotExist):
+		return err
+	}
+
+	return writeFileAtomically(path, data, permissions)
+}
+
+func writeFileAtomically(path string, data []byte, permissions os.FileMode) error {
+	dir := filepath.Dir(path)
+	tempFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+
+	tempName := tempFile.Name()
+	cleanup := func() {
+		_ = os.Remove(tempName)
+	}
+
+	if _, err := tempFile.Write(data); err != nil {
+		_ = tempFile.Close()
+		cleanup()
+		return err
+	}
+	if err := tempFile.Chmod(permissions); err != nil {
+		_ = tempFile.Close()
+		cleanup()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		cleanup()
+		return err
+	}
+	if err := os.Rename(tempName, path); err != nil {
+		cleanup()
+		return err
+	}
+
+	return nil
+}
+
+func writeClusterConfigConfigMap(clientset kubernetes.Interface, namespace, name string, config model.ClusterConfig) error {
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	cm, err := metadata.K8SConfigMaps(clientset).Get(namespace, name)
+	switch {
+	case err == nil:
+	case k8serrors.IsNotFound(err):
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	default:
+		return err
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string)
+	}
+	cm.Data[clusterConfigConfigMapFilePath] = string(data)
+
+	_, err = metadata.K8SConfigMaps(clientset).Upsert(namespace, name, cm)
+	return err
+}

--- a/oxiad/coordinator/cluster_config_store_test.go
+++ b/oxiad/coordinator/cluster_config_store_test.go
@@ -1,0 +1,141 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coordinator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/model"
+	"github.com/oxia-db/oxia/oxiad/coordinator/option"
+)
+
+func TestClusterConfigStoreUpdatesFileBackedConfig(t *testing.T) {
+	name := "server-1"
+	configPath := filepath.Join(t.TempDir(), "cluster.yaml")
+	initialConfig := model.ClusterConfig{
+		Namespaces: []model.NamespaceConfig{{
+			Name:              "default",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+		}},
+		Servers: []model.Server{
+			{Name: &name, Public: "public-1", Internal: "internal-1"},
+		},
+		ServerMetadata: map[string]model.ServerMetadata{
+			name: {Labels: map[string]string{"rack": "r1"}},
+		},
+	}
+
+	initialData, err := yaml.Marshal(initialConfig)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(configPath, initialData, 0o644))
+
+	clusterOptions := &option.ClusterOptions{ConfigPath: configPath}
+	v := viper.New()
+	v.SetConfigFile(configPath)
+	load := func() (model.ClusterConfig, error) {
+		return loadClusterConfig(clusterOptions, v)
+	}
+
+	_, err = load()
+	require.NoError(t, err)
+
+	store, err := newClusterConfigStoreWithKubernetes(clusterOptions, v, nil, load)
+	require.NoError(t, err)
+
+	updatedConfig, err := store.Update(func(config *model.ClusterConfig) error {
+		newPublicAddress := "public-2"
+		_, err := config.PatchDataServer(name, model.DataServerPatch{
+			PublicAddress: &newPublicAddress,
+			Metadata: &model.ServerMetadata{
+				Labels: map[string]string{"rack": "r2"},
+			},
+		})
+		return err
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "public-2", updatedConfig.Servers[0].Public)
+
+	updatedFile, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	var persisted model.ClusterConfig
+	require.NoError(t, yaml.Unmarshal(updatedFile, &persisted))
+	assert.Equal(t, "public-2", persisted.Servers[0].Public)
+	assert.Equal(t, map[string]string{"rack": "r2"}, persisted.ServerMetadata[name].Labels)
+}
+
+func TestClusterConfigStoreUpdatesConfigMapBackedConfig(t *testing.T) {
+	name := "server-1"
+	clusterConfig := model.ClusterConfig{
+		Namespaces: []model.NamespaceConfig{{
+			Name:              "default",
+			InitialShardCount: 1,
+			ReplicationFactor: 1,
+		}},
+		Servers: []model.Server{
+			{Name: &name, Public: "public-1", Internal: "internal-1"},
+		},
+	}
+
+	initialData, err := yaml.Marshal(clusterConfig)
+	require.NoError(t, err)
+
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-config",
+			Namespace: "oxia",
+		},
+		Data: map[string]string{
+			clusterConfigConfigMapFilePath: string(initialData),
+		},
+	})
+
+	store, err := newClusterConfigStoreWithKubernetes(
+		&option.ClusterOptions{ConfigPath: "configmap:oxia/cluster-config"},
+		viper.New(),
+		clientset,
+		func() (model.ClusterConfig, error) {
+			return clusterConfig, nil
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = store.Update(func(config *model.ClusterConfig) error {
+		newInternalAddress := "internal-2"
+		_, err := config.PatchDataServer(name, model.DataServerPatch{
+			InternalAddress: &newInternalAddress,
+		})
+		return err
+	})
+	require.NoError(t, err)
+
+	configMap, err := clientset.CoreV1().ConfigMaps("oxia").Get(t.Context(), "cluster-config", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	var persisted model.ClusterConfig
+	require.NoError(t, yaml.Unmarshal([]byte(configMap.Data[clusterConfigConfigMapFilePath]), &persisted))
+	assert.Equal(t, "internal-2", persisted.Servers[0].Internal)
+}

--- a/oxiad/coordinator/controller/dataserver_controller.go
+++ b/oxiad/coordinator/controller/dataserver_controller.go
@@ -63,6 +63,8 @@ type ShardAssignmentsProvider interface {
 type DataServerController interface {
 	io.Closer
 
+	DataServer() model.Server
+
 	Status() DataServerStatus
 
 	SupportedFeatures() []proto.Feature
@@ -95,6 +97,10 @@ type dataServerController struct {
 
 	dataServerRunningGauge metric.Gauge
 	failedHealthChecks     metric.Counter
+}
+
+func (n *dataServerController) DataServer() model.Server {
+	return n.dataServer
 }
 
 func (n *dataServerController) Status() DataServerStatus {

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -137,7 +137,15 @@ func (c *coordinator) ConfigChanged(newConfig *model.ClusterConfig) {
 
 	// Check for nodes to add
 	for _, sa := range newConfig.Servers {
-		if _, ok := c.nodeControllers[sa.GetIdentifier()]; ok {
+		if nc, ok := c.nodeControllers[sa.GetIdentifier()]; ok {
+			current := nc.DataServer()
+			if current.Public == sa.Public && current.Internal == sa.Internal {
+				continue
+			}
+
+			c.Info("Detected node address update", slog.Any("before", current), slog.Any("after", sa))
+			_ = nc.Close()
+			c.nodeControllers[sa.GetIdentifier()] = controller.NewDataServerController(c.ctx, sa, c, c, c.rpc)
 			continue
 		}
 		// The node is present in the config, though we don't know it yet,

--- a/oxiad/coordinator/model/cluster_common.go
+++ b/oxiad/coordinator/model/cluster_common.go
@@ -14,6 +14,16 @@
 
 package model
 
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrDataServerNotFound     = errors.New("data server not found")
+	ErrInvalidDataServerPatch = errors.New("invalid data server patch")
+)
+
 type Server struct {
 	// Name is the unique identification for clusters
 	Name *string `json:"name" yaml:"name"`
@@ -30,9 +40,76 @@ type ServerMetadata struct {
 	Labels map[string]string `json:"labels" yaml:"labels"`
 }
 
+type DataServerPatch struct {
+	PublicAddress   *string
+	InternalAddress *string
+	Metadata        *ServerMetadata
+}
+
 func (sv *Server) GetIdentifier() string {
-	if sv.Name == nil {
+	if sv.Name == nil || *sv.Name == "" {
 		return sv.Internal
 	}
 	return *sv.Name
+}
+
+func (sm *ServerMetadata) Clone() ServerMetadata {
+	if sm == nil {
+		return ServerMetadata{}
+	}
+
+	labels := make(map[string]string, len(sm.Labels))
+	for key, value := range sm.Labels {
+		labels[key] = value
+	}
+	return ServerMetadata{Labels: labels}
+}
+
+func (cc *ClusterConfig) PatchDataServer(dataServer string, patch DataServerPatch) (*Server, error) {
+	if dataServer == "" {
+		return nil, fmt.Errorf("%w: data server must not be empty", ErrInvalidDataServerPatch)
+	}
+	if patch.PublicAddress == nil && patch.InternalAddress == nil && patch.Metadata == nil {
+		return nil, fmt.Errorf("%w: at least one data server patch field must be provided", ErrInvalidDataServerPatch)
+	}
+
+	for i := range cc.Servers {
+		server := &cc.Servers[i]
+		if server.GetIdentifier() != dataServer {
+			continue
+		}
+
+		if patch.PublicAddress != nil {
+			if *patch.PublicAddress == "" {
+				return nil, fmt.Errorf("%w: public address must not be empty", ErrInvalidDataServerPatch)
+			}
+			server.Public = *patch.PublicAddress
+		}
+
+		if patch.InternalAddress != nil {
+			if *patch.InternalAddress == "" {
+				return nil, fmt.Errorf("%w: internal address must not be empty", ErrInvalidDataServerPatch)
+			}
+			if server.Name == nil || *server.Name == "" {
+				return nil, fmt.Errorf("%w: cannot patch internal address for unnamed data server %q", ErrInvalidDataServerPatch, dataServer)
+			}
+			server.Internal = *patch.InternalAddress
+		}
+
+		if patch.Metadata != nil {
+			identifier := server.GetIdentifier()
+			if len(patch.Metadata.Labels) == 0 {
+				delete(cc.ServerMetadata, identifier)
+			} else {
+				if cc.ServerMetadata == nil {
+					cc.ServerMetadata = make(map[string]ServerMetadata)
+				}
+				cc.ServerMetadata[identifier] = patch.Metadata.Clone()
+			}
+		}
+
+		return server, nil
+	}
+
+	return nil, fmt.Errorf("%w: %q", ErrDataServerNotFound, dataServer)
 }

--- a/oxiad/coordinator/model/cluster_common_test.go
+++ b/oxiad/coordinator/model/cluster_common_test.go
@@ -1,0 +1,118 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerGetIdentifier(t *testing.T) {
+	name := "server-1"
+	emptyName := ""
+
+	assert.Equal(t, "server-1", (&Server{
+		Name:     &name,
+		Internal: "internal-1",
+	}).GetIdentifier())
+
+	assert.Equal(t, "internal-2", (&Server{
+		Internal: "internal-2",
+	}).GetIdentifier())
+
+	assert.Equal(t, "internal-3", (&Server{
+		Name:     &emptyName,
+		Internal: "internal-3",
+	}).GetIdentifier())
+}
+
+func TestClusterConfigPatchDataServerUpdatesNamedServer(t *testing.T) {
+	name := "server-1"
+	publicAddress := "public-2"
+	internalAddress := "internal-2"
+
+	config := ClusterConfig{
+		Servers: []Server{
+			{Name: &name, Public: "public-1", Internal: "internal-1"},
+		},
+		ServerMetadata: map[string]ServerMetadata{
+			name: {Labels: map[string]string{"rack": "r1"}},
+		},
+	}
+
+	server, err := config.PatchDataServer(name, DataServerPatch{
+		PublicAddress:   &publicAddress,
+		InternalAddress: &internalAddress,
+		Metadata: &ServerMetadata{
+			Labels: map[string]string{"rack": "r2", "zone": "z1"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(t, publicAddress, server.Public)
+	assert.Equal(t, internalAddress, server.Internal)
+	assert.Equal(t, map[string]string{"rack": "r2", "zone": "z1"}, config.ServerMetadata[name].Labels)
+}
+
+func TestClusterConfigPatchDataServerClearsMetadata(t *testing.T) {
+	name := "server-1"
+
+	config := ClusterConfig{
+		Servers: []Server{
+			{Name: &name, Public: "public-1", Internal: "internal-1"},
+		},
+		ServerMetadata: map[string]ServerMetadata{
+			name: {Labels: map[string]string{"rack": "r1"}},
+		},
+	}
+
+	_, err := config.PatchDataServer(name, DataServerPatch{
+		Metadata: &ServerMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, config.ServerMetadata)
+}
+
+func TestClusterConfigPatchDataServerRejectsInternalAddressForUnnamedServer(t *testing.T) {
+	internalAddress := "internal-2"
+
+	config := ClusterConfig{
+		Servers: []Server{
+			{Public: "public-1", Internal: "internal-1"},
+		},
+	}
+
+	_, err := config.PatchDataServer("internal-1", DataServerPatch{
+		InternalAddress: &internalAddress,
+	})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cannot patch internal address for unnamed data server")
+}
+
+func TestClusterConfigPatchDataServerRejectsEmptyPatch(t *testing.T) {
+	name := "server-1"
+
+	config := ClusterConfig{
+		Servers: []Server{
+			{Name: &name, Public: "public-1", Internal: "internal-1"},
+		},
+	}
+
+	_, err := config.PatchDataServer(name, DataServerPatch{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "at least one data server patch field must be provided")
+}

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -143,6 +143,11 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 		return nil, err
 	}
 
+	clusterConfigStore, err := newClusterConfigStore(&options.Cluster, v, clusterConfigProvider)
+	if err != nil {
+		return nil, err
+	}
+
 	meta := &options.Metadata
 
 	var metadataProvider metadata.Provider
@@ -201,6 +206,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	admin := newAdminServer(
 		coordinatorInstance.StatusResource(),
 		clusterConfigProvider,
+		clusterConfigStore,
 		coordinatorInstance,
 		coordinatorInstance,
 	)

--- a/oxiad/coordinator/util/cluster_updates_test.go
+++ b/oxiad/coordinator/util/cluster_updates_test.go
@@ -123,7 +123,9 @@ func TestClientUpdates_ClusterInit(t *testing.T) {
 		return SimpleEnsembleSupplier(servers, namespaceConfig, status), nil
 	})
 
+	assert.NotEmpty(t, status.ClusterId)
 	assert.Equal(t, &model.ClusterStatus{
+		ClusterId: status.ClusterId,
 		Namespaces: map[string]model.NamespaceStatus{
 			"ns-1": {
 				ReplicationFactor: 3,


### PR DESCRIPTION
## Motivation
- add the `PatchDataServer` management endpoint proposed in discussion #983
- allow updating data-server public/internal addresses and metadata through the admin API while persisting the backing cluster config

## Modifications
- add `PatchDataServer` to the admin protobufs and admin client surface
- add cluster-config persistence for file-backed and configmap-backed coordinator configs so admin mutations are durable
- validate mutable data-server fields, including rejecting internal-address changes for unnamed servers, and refresh node controllers when a named server address changes
- add coverage for the new patch flow and align a coordinator util expectation with the branch's current cluster-id behavior

## Testing
- `go test ./cmd/... ./common/... ./oxia/... ./oxiad/...`