### PR TITLE
fix: expose data server listing under dataserver list

### DIFF
--- a/cmd/admin/cmd.go
+++ b/cmd/admin/cmd.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
-	"github.com/oxia-db/oxia/cmd/admin/listdataservers"
+	"github.com/oxia-db/oxia/cmd/admin/dataserver"
 	"github.com/oxia-db/oxia/cmd/admin/listnodes"
 	"github.com/oxia-db/oxia/cmd/admin/splitshard"
 
@@ -41,7 +41,7 @@ func init() {
 	defaultAdminClientAddress := fmt.Sprintf("localhost:%d", oxiacommon.DefaultAdminPort)
 	Cmd.PersistentFlags().StringVar(&commons.AdminConfig.AdminAddress, "admin-address", defaultAdminClientAddress, "Admin client address")
 
-	Cmd.AddCommand(listdataservers.Cmd)
+	Cmd.AddCommand(dataserver.Cmd)
 	Cmd.AddCommand(listnamespaces.Cmd)
 	Cmd.AddCommand(listnodes.Cmd)
 	Cmd.AddCommand(splitshard.Cmd)

--- a/cmd/admin/dataserver/cmd.go
+++ b/cmd/admin/dataserver/cmd.go
@@ -1,0 +1,33 @@
+// Copyright 2023-2026 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataserver
+
+import (
+	listcmd "github.com/oxia-db/oxia/cmd/admin/dataserver/list"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	Cmd = &cobra.Command{
+		Use:   "dataserver",
+		Short: "Oxia admin operations on data servers",
+		Long:  `Oxia admin operations on data servers`,
+	}
+)
+
+func init() {
+	Cmd.AddCommand(listcmd.Cmd)
+}

--- a/cmd/admin/dataserver/cmd_test.go
+++ b/cmd/admin/dataserver/cmd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Oxia Authors
+// Copyright 2023-2026 The Oxia Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package listdataservers
+package dataserver
 
 import (
 	"bytes"
@@ -20,23 +20,22 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oxia-db/oxia/cmd/admin/commons"
 	"github.com/oxia-db/oxia/common/proto"
 )
 
-func runCmd(cmd *cobra.Command) (string, error) {
+func runCmd(args ...string) (string, error) {
 	actual := new(bytes.Buffer)
-	cmd.SetOut(actual)
-	cmd.SetErr(actual)
-	cmd.SetArgs([]string{})
-	err := cmd.Execute()
+	Cmd.SetOut(actual)
+	Cmd.SetErr(actual)
+	Cmd.SetArgs(args)
+	err := Cmd.Execute()
 	return strings.TrimSpace(actual.String()), err
 }
 
-func Test_cmd_listDataServers(t *testing.T) {
+func Test_cmd_dataServerList(t *testing.T) {
 	commons.MockedAdminClient = commons.NewMockAdminClient()
 
 	commons.MockedAdminClient.On("Close").Return(nil)
@@ -53,7 +52,7 @@ func Test_cmd_listDataServers(t *testing.T) {
 		},
 	}, nil)
 
-	out, err := runCmd(Cmd)
+	out, err := runCmd("list")
 
 	assert.NoError(t, err)
 	var dataServers []proto.DataServer

--- a/cmd/admin/dataserver/list/cmd.go
+++ b/cmd/admin/dataserver/list/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 The Oxia Authors
+// Copyright 2023-2026 The Oxia Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package listdataservers
+package list
 
 import (
 	"github.com/spf13/cobra"
@@ -23,7 +23,7 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:          "list-data-servers",
+	Use:          "list",
 	Short:        "List data servers",
 	Long:         `List data servers`,
 	Args:         cobra.ExactArgs(0),

--- a/cmd/admin/listnodes/cmd.go
+++ b/cmd/admin/listnodes/cmd.go
@@ -28,8 +28,8 @@ func init() {
 
 var Cmd = &cobra.Command{
 	Use:          "list-nodes",
-	Short:        "List nodes (deprecated: use list-data-servers)",
-	Long:         `List nodes (deprecated: use list-data-servers)`,
+	Short:        "List nodes (deprecated: use 'dataserver list')",
+	Long:         `List nodes (deprecated: use 'dataserver list')`,
 	Args:         cobra.ExactArgs(0),
 	RunE:         exec,
 	SilenceUsage: true,


### PR DESCRIPTION
## Motivation
- use the new `oxia admin dataserver list` command shape directly because the top-level `list-data-servers` command has not been released
- keep the admin CLI hierarchy consistent for data-server operations

## Modifications
- add `oxia admin dataserver` as the parent admin command for data server operations
- move the list implementation to `oxia admin dataserver list`
- remove the unreleased `oxia admin list-data-servers` command and point `list-nodes` deprecation text at the nested command

## Testing
- `go test ./cmd/admin/...`
- `go run ./cmd admin --help`
- `go run ./cmd admin dataserver --help`