### PR TITLE
fix: expose fallback server names in admin responses

### DIFF
--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -41,6 +41,15 @@ type adminServer struct {
 	shardSplitter  ShardSplitter
 }
 
+func effectiveServerName(server model.Server) *string {
+	if server.Name != nil {
+		return server.Name
+	}
+
+	identifier := server.GetIdentifier()
+	return &identifier
+}
+
 func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
 	cnf, err := admin.clusterConfig()
 	if err != nil {
@@ -50,7 +59,7 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 	dataServers := make([]*proto.DataServer, len(cnf.Servers))
 	for i, server := range cnf.Servers {
 		dataServers[i] = &proto.DataServer{
-			Name:            server.Name,
+			Name:            effectiveServerName(server),
 			PublicAddress:   server.Public,
 			InternalAddress: server.Internal,
 		}
@@ -90,7 +99,7 @@ func (admin *adminServer) ListNodes(context.Context, *proto.ListNodesRequest) (*
 			nodeMeta = model.ServerMetadata{}
 		}
 		nodes[i] = &proto.Node{
-			Name:            node.Name,
+			Name:            effectiveServerName(node),
 			PublicAddress:   node.Public,
 			InternalAddress: node.Internal,
 			Metadata:        nodeMeta.Labels,

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -49,7 +49,7 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 
 	dataServers := make([]*proto.DataServer, len(cnf.Servers))
 	for i, server := range cnf.Servers {
-		name := server.GetName()
+		name := server.GetIdentifier()
 		dataServers[i] = &proto.DataServer{
 			Name:            &name,
 			PublicAddress:   server.Public,
@@ -90,7 +90,7 @@ func (admin *adminServer) ListNodes(context.Context, *proto.ListNodesRequest) (*
 		if !found {
 			nodeMeta = model.ServerMetadata{}
 		}
-		name := node.GetName()
+		name := node.GetIdentifier()
 		nodes[i] = &proto.Node{
 			Name:            &name,
 			PublicAddress:   node.Public,

--- a/oxiad/coordinator/admin_server.go
+++ b/oxiad/coordinator/admin_server.go
@@ -41,15 +41,6 @@ type adminServer struct {
 	shardSplitter  ShardSplitter
 }
 
-func effectiveServerName(server model.Server) *string {
-	if server.Name != nil {
-		return server.Name
-	}
-
-	identifier := server.GetIdentifier()
-	return &identifier
-}
-
 func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServersRequest) (*proto.ListDataServersResponse, error) {
 	cnf, err := admin.clusterConfig()
 	if err != nil {
@@ -58,8 +49,9 @@ func (admin *adminServer) ListDataServers(context.Context, *proto.ListDataServer
 
 	dataServers := make([]*proto.DataServer, len(cnf.Servers))
 	for i, server := range cnf.Servers {
+		name := server.GetName()
 		dataServers[i] = &proto.DataServer{
-			Name:            effectiveServerName(server),
+			Name:            &name,
 			PublicAddress:   server.Public,
 			InternalAddress: server.Internal,
 		}
@@ -98,8 +90,9 @@ func (admin *adminServer) ListNodes(context.Context, *proto.ListNodesRequest) (*
 		if !found {
 			nodeMeta = model.ServerMetadata{}
 		}
+		name := node.GetName()
 		nodes[i] = &proto.Node{
-			Name:            effectiveServerName(node),
+			Name:            &name,
 			PublicAddress:   node.Public,
 			InternalAddress: node.Internal,
 			Metadata:        nodeMeta.Labels,

--- a/oxiad/coordinator/admin_server_test.go
+++ b/oxiad/coordinator/admin_server_test.go
@@ -28,7 +28,6 @@ import (
 func TestAdminServerListDataServers(t *testing.T) {
 	serverName1 := "server-1"
 	serverName2 := "server-2"
-	serverName3 := "server-3"
 
 	admin := newAdminServer(
 		nil,
@@ -37,7 +36,7 @@ func TestAdminServerListDataServers(t *testing.T) {
 				Servers: []model.Server{
 					{Name: &serverName1, Public: "public-1", Internal: "internal-1"},
 					{Name: &serverName2, Public: "public-2", Internal: "internal-2"},
-					{Name: &serverName3, Public: "public-3", Internal: "internal-3"},
+					{Public: "public-3", Internal: "internal-3"},
 				},
 			}, nil
 		},
@@ -59,7 +58,42 @@ func TestAdminServerListDataServers(t *testing.T) {
 	assert.Equal(t, "internal-2", res.DataServers[1].InternalAddress)
 
 	require.NotNil(t, res.DataServers[2].Name)
-	assert.Equal(t, serverName3, *res.DataServers[2].Name)
+	assert.Equal(t, "internal-3", *res.DataServers[2].Name)
 	assert.Equal(t, "public-3", res.DataServers[2].PublicAddress)
 	assert.Equal(t, "internal-3", res.DataServers[2].InternalAddress)
+}
+
+func TestAdminServerListNodesUsesInternalAddressWhenNameIsUnset(t *testing.T) {
+	serverName1 := "server-1"
+
+	admin := newAdminServer(
+		nil,
+		func() (model.ClusterConfig, error) {
+			return model.ClusterConfig{
+				Servers: []model.Server{
+					{Name: &serverName1, Public: "public-1", Internal: "internal-1"},
+					{Public: "public-2", Internal: "internal-2"},
+				},
+				ServerMetadata: map[string]model.ServerMetadata{
+					serverName1:  {Labels: map[string]string{"role": "named"}},
+					"internal-2": {Labels: map[string]string{"role": "fallback"}},
+				},
+			}, nil
+		},
+		nil,
+	)
+
+	res, err := admin.ListNodes(context.Background(), &proto.ListNodesRequest{})
+	require.NoError(t, err)
+	require.Len(t, res.Nodes, 2)
+
+	require.NotNil(t, res.Nodes[0].Name)
+	assert.Equal(t, serverName1, *res.Nodes[0].Name)
+	assert.Equal(t, map[string]string{"role": "named"}, res.Nodes[0].Metadata)
+
+	require.NotNil(t, res.Nodes[1].Name)
+	assert.Equal(t, "internal-2", *res.Nodes[1].Name)
+	assert.Equal(t, "public-2", res.Nodes[1].PublicAddress)
+	assert.Equal(t, "internal-2", res.Nodes[1].InternalAddress)
+	assert.Equal(t, map[string]string{"role": "fallback"}, res.Nodes[1].Metadata)
 }

--- a/oxiad/coordinator/model/cluster_common.go
+++ b/oxiad/coordinator/model/cluster_common.go
@@ -30,9 +30,13 @@ type ServerMetadata struct {
 	Labels map[string]string `json:"labels" yaml:"labels"`
 }
 
-func (sv *Server) GetIdentifier() string {
+func (sv *Server) GetName() string {
 	if sv.Name == nil {
 		return sv.Internal
 	}
 	return *sv.Name
+}
+
+func (sv *Server) GetIdentifier() string {
+	return sv.GetName()
 }

--- a/oxiad/coordinator/model/cluster_common.go
+++ b/oxiad/coordinator/model/cluster_common.go
@@ -30,13 +30,9 @@ type ServerMetadata struct {
 	Labels map[string]string `json:"labels" yaml:"labels"`
 }
 
-func (sv *Server) GetName() string {
+func (sv *Server) GetIdentifier() string {
 	if sv.Name == nil {
 		return sv.Internal
 	}
 	return *sv.Name
-}
-
-func (sv *Server) GetIdentifier() string {
-	return sv.GetName()
 }


### PR DESCRIPTION
## Motivation
- surface a stable effective server name in admin responses when cluster config omits `name`
- keep the admin output aligned with the coordinator's existing identifier fallback to `internal`

## Modifications
- add an admin-server helper that returns the configured server name or falls back to `GetIdentifier()`
- use that effective name for both `ListDataServers` and `ListNodes`
- extend coordinator admin tests to cover unnamed servers in both RPCs

## Testing
- `go test ./oxiad/coordinator -run TestAdminServer`
- `go test ./cmd/admin/...`
- broad `go test ./oxiad/coordinator/... ./cmd/admin/...` was blocked by an unrelated untracked file already present in the worktree: `oxiad/coordinator/model/cluster_common_test.go`