### PR TITLE
fix: rebuild Docker runtime stage on every build

### DIFF
--- a/.github/workflows/candidate-release.yml
+++ b/.github/workflows/candidate-release.yml
@@ -125,6 +125,9 @@ jobs:
           tags: oxia/oxia:${{ needs.prepare.outputs.rc_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Always rebuild the runtime stage so `apk upgrade` picks up the
+          # latest Alpine security patches instead of a cached layer.
+          no-cache-filters: runtime
 
       - name: Summary
         run: |

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -72,3 +72,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Always rebuild the runtime stage so `apk upgrade` picks up the
+          # latest Alpine security patches instead of a cached layer.
+          no-cache-filters: runtime

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,6 +160,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Always rebuild the runtime stage so `apk upgrade` picks up the
+          # latest Alpine security patches instead of a cached layer.
+          no-cache-filters: runtime
 
   # Create GitHub release with binaries and notes
   create-release:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -41,6 +41,9 @@ jobs:
           tags: oxia:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Always rebuild the runtime stage so `apk upgrade` picks up the
+          # latest Alpine security patches instead of a cached layer.
+          no-cache-filters: runtime
 
 
       - name: Run Trivy vulnerability scanner

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     make
 
-FROM alpine:3.22.3
+FROM alpine:3.22.3 AS runtime
 
 RUN apk add --no-cache bash bash-completion jq
 RUN apk upgrade --no-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     make
 
-FROM alpine:3.22.3 AS runtime
+FROM alpine:3.22 AS runtime
 
 RUN apk add --no-cache bash bash-completion jq
 RUN apk upgrade --no-cache


### PR DESCRIPTION
## Summary

- Docker build cache was reusing `apk upgrade --no-cache` layers across CI runs, so CI-built images kept shipping stale OpenSSL packages even after #1023 pinned `alpine:3.22.3`. On the latest Trivy run the build log showed `#16 [stage-1 3/8] RUN apk upgrade --no-cache` as `CACHED`, which is why libssl3 3.5.5-r0 kept showing up in scans and 14 code-scanning alerts (CVE-2026-28390 and friends) stayed `open`.
- Named the final Dockerfile stage `runtime` and added `no-cache-filters: runtime` to every `docker/build-push-action` step (`trivy.yml`, `release.yaml`, `docker-build.yaml`, `candidate-release.yml`).
- Buildkit now excludes only the runtime stage from cache lookups, so `apk upgrade` runs against Alpine's current index on every build. The Go compile stage (`AS build`) still benefits from `cache-from: type=gha`, so release build time is only a few seconds slower.
- Applies to all published images: tag-push releases, nightly cron, candidate-release RCs, and manual docker-build — every image now ships the latest Alpine security patches at build time.

## Test plan

- [ ] Merge and verify the next Trivy push run shows the `runtime` stage steps *without* `CACHED` in the build log
- [ ] Confirm code-scanning alerts 21–34 transition from `open` → `fixed` after that scan
- [ ] Local sanity check: `docker buildx build --no-cache-filter=runtime --load -t oxia:verify . && docker run --rm oxia:verify apk info libssl3` → should report `libssl3-3.5.6-r0` or newer