### PR TITLE
feat: add dataserver instance-id handshake and internal RPC validation

### DIFF
--- a/cmd/health/cmd_test.go
+++ b/cmd/health/cmd_test.go
@@ -34,7 +34,7 @@ func TestHealthCmd(t *testing.T) {
 	_health := health.NewServer()
 	server, err := rpc.Default.StartGrpcServer("health", "localhost:0", func(registrar grpc.ServiceRegistrar) {
 		grpc_health_v1.RegisterHealthServer(registrar, _health)
-	}, nil, &auth.Options{})
+	}, nil, &auth.Options{}, nil)
 	assert.NoError(t, err)
 	defer func() {
 		_ = server.Close()

--- a/common/commonio/json_file.go
+++ b/common/commonio/json_file.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io
+package commonio
 
 import (
 	"encoding/json"
@@ -35,7 +35,7 @@ func ReadJSONFromFile(path string, value any) (bool, error) {
 
 func WriteJSONToFile(path string, value any) error {
 	parentDir := filepath.Dir(path)
-	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+	if err := os.MkdirAll(parentDir, 0755); err != nil {
 		return err
 	}
 

--- a/common/commonio/json_file_test.go
+++ b/common/commonio/json_file_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io
+package commonio
 
 import (
 	"os"

--- a/common/commonio/nop_closer.go
+++ b/common/commonio/nop_closer.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package io
+package commonio
 
 import "io"
 

--- a/common/io/json_file.go
+++ b/common/io/json_file.go
@@ -57,9 +57,23 @@ func WriteJSONToFile(path string, value any) error {
 		_ = tmp.Close()
 		return err
 	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
 	if err = tmp.Close(); err != nil {
 		return err
 	}
 
-	return os.Rename(tmpName, path)
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+
+	dir, err := os.Open(parentDir)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+
+	return dir.Sync()
 }

--- a/common/io/json_file.go
+++ b/common/io/json_file.go
@@ -20,6 +20,19 @@ import (
 	"path/filepath"
 )
 
+func ReadJSONFromFile(path string, value any) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	if len(data) == 0 {
+		return false, nil
+	}
+
+	return true, json.Unmarshal(data, value)
+}
+
 func WriteJSONToFile(path string, value any) error {
 	parentDir := filepath.Dir(path)
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {

--- a/common/io/json_file.go
+++ b/common/io/json_file.go
@@ -1,0 +1,52 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+func WriteJSONToFile(path string, value any) error {
+	parentDir := filepath.Dir(path)
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(parentDir, "."+filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpName)
+	}()
+
+	if _, err = tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpName, path)
+}

--- a/common/io/json_file_test.go
+++ b/common/io/json_file_test.go
@@ -12,27 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package constant
+package io
 
-import "time"
+import (
+	"os"
+	"path/filepath"
+	"testing"
 
-const I64NegativeOne int64 = -1
-const I64Zero int64 = 0
-const U32Zero uint32 = 0
-
-const (
-	MetadataTerm              = "term"
-	MetadataNamespace         = "namespace"
-	MetadataShardId           = "shard-id"
-	MetadataSplitHashRangeMin = "split-hash-range-min"
-	MetadataSplitHashRangeMax = "split-hash-range-max"
-	MetadataInstanceId        = "instance-id"
-	DefaultNamespace          = "default"
-
-	DefaultPublicPort   = 6648
-	DefaultInternalPort = 6649
-	DefaultAdminPort    = 6651
-
-	MaxSessionTimeout = 5 * time.Minute
-	MinSessionTimeout = 2 * time.Second
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestWriteJSONAtomicallyCreatesParentDirectoryAndFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "state.json")
+
+	err := WriteJSONToFile(path, map[string]string{
+		"hello": "world",
+	})
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"hello":"world"}`, string(content))
+}

--- a/common/io/json_file_test.go
+++ b/common/io/json_file_test.go
@@ -23,6 +23,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestReadJSONFromFile(t *testing.T) {
+	t.Run("read existing json", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		require.NoError(t, os.WriteFile(path, []byte(`{"hello":"world"}`), 0o600))
+
+		value := map[string]string{}
+		hasContent, err := ReadJSONFromFile(path, &value)
+		require.NoError(t, err)
+		assert.True(t, hasContent)
+		assert.Equal(t, map[string]string{"hello": "world"}, value)
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "state.json")
+		require.NoError(t, os.WriteFile(path, nil, 0o600))
+
+		value := map[string]string{"existing": "value"}
+		hasContent, err := ReadJSONFromFile(path, &value)
+		require.NoError(t, err)
+		assert.False(t, hasContent)
+		assert.Equal(t, map[string]string{"existing": "value"}, value)
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "missing.json")
+
+		value := map[string]string{}
+		hasContent, err := ReadJSONFromFile(path, &value)
+		require.Error(t, err)
+		assert.True(t, os.IsNotExist(err))
+		assert.False(t, hasContent)
+	})
+}
+
 func TestWriteJSONAtomicallyCreatesParentDirectoryAndFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "state.json")
 

--- a/common/proto/replication.pb.go
+++ b/common/proto/replication.pb.go
@@ -83,6 +83,58 @@ func (Feature) EnumDescriptor() ([]byte, []int) {
 	return file_replication_proto_rawDescGZIP(), []int{0}
 }
 
+type HandshakeStatus int32
+
+const (
+	HandshakeStatus_HANDSHAKE_STATUS_UNKNOWN       HandshakeStatus = 0
+	HandshakeStatus_HANDSHAKE_STATUS_BOUND         HandshakeStatus = 1
+	HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND HandshakeStatus = 2
+	HandshakeStatus_HANDSHAKE_STATUS_MISMATCH      HandshakeStatus = 3
+)
+
+// Enum value maps for HandshakeStatus.
+var (
+	HandshakeStatus_name = map[int32]string{
+		0: "HANDSHAKE_STATUS_UNKNOWN",
+		1: "HANDSHAKE_STATUS_BOUND",
+		2: "HANDSHAKE_STATUS_ALREADY_BOUND",
+		3: "HANDSHAKE_STATUS_MISMATCH",
+	}
+	HandshakeStatus_value = map[string]int32{
+		"HANDSHAKE_STATUS_UNKNOWN":       0,
+		"HANDSHAKE_STATUS_BOUND":         1,
+		"HANDSHAKE_STATUS_ALREADY_BOUND": 2,
+		"HANDSHAKE_STATUS_MISMATCH":      3,
+	}
+)
+
+func (x HandshakeStatus) Enum() *HandshakeStatus {
+	p := new(HandshakeStatus)
+	*p = x
+	return p
+}
+
+func (x HandshakeStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (HandshakeStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_replication_proto_enumTypes[1].Descriptor()
+}
+
+func (HandshakeStatus) Type() protoreflect.EnumType {
+	return &file_replication_proto_enumTypes[1]
+}
+
+func (x HandshakeStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use HandshakeStatus.Descriptor instead.
+func (HandshakeStatus) EnumDescriptor() ([]byte, []int) {
+	return file_replication_proto_rawDescGZIP(), []int{1}
+}
+
 type KeySortingType int32
 
 const (
@@ -116,11 +168,11 @@ func (x KeySortingType) String() string {
 }
 
 func (KeySortingType) Descriptor() protoreflect.EnumDescriptor {
-	return file_replication_proto_enumTypes[1].Descriptor()
+	return file_replication_proto_enumTypes[2].Descriptor()
 }
 
 func (KeySortingType) Type() protoreflect.EnumType {
-	return &file_replication_proto_enumTypes[1]
+	return &file_replication_proto_enumTypes[2]
 }
 
 func (x KeySortingType) Number() protoreflect.EnumNumber {
@@ -129,7 +181,7 @@ func (x KeySortingType) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use KeySortingType.Descriptor instead.
 func (KeySortingType) EnumDescriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{1}
+	return file_replication_proto_rawDescGZIP(), []int{2}
 }
 
 type ServingStatus int32
@@ -168,11 +220,11 @@ func (x ServingStatus) String() string {
 }
 
 func (ServingStatus) Descriptor() protoreflect.EnumDescriptor {
-	return file_replication_proto_enumTypes[2].Descriptor()
+	return file_replication_proto_enumTypes[3].Descriptor()
 }
 
 func (ServingStatus) Type() protoreflect.EnumType {
-	return &file_replication_proto_enumTypes[2]
+	return &file_replication_proto_enumTypes[3]
 }
 
 func (x ServingStatus) Number() protoreflect.EnumNumber {
@@ -181,7 +233,7 @@ func (x ServingStatus) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ServingStatus.Descriptor instead.
 func (ServingStatus) EnumDescriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{2}
+	return file_replication_proto_rawDescGZIP(), []int{3}
 }
 
 type GetInfoRequest struct {
@@ -264,6 +316,102 @@ func (x *GetInfoResponse) GetFeaturesSupported() []Feature {
 	return nil
 }
 
+type HandshakeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	InstanceId    string                 `protobuf:"bytes,1,opt,name=instance_id,json=instanceId,proto3" json:"instance_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HandshakeRequest) Reset() {
+	*x = HandshakeRequest{}
+	mi := &file_replication_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HandshakeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HandshakeRequest) ProtoMessage() {}
+
+func (x *HandshakeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_replication_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HandshakeRequest.ProtoReflect.Descriptor instead.
+func (*HandshakeRequest) Descriptor() ([]byte, []int) {
+	return file_replication_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *HandshakeRequest) GetInstanceId() string {
+	if x != nil {
+		return x.InstanceId
+	}
+	return ""
+}
+
+type HandshakeResponse struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	Status            HandshakeStatus        `protobuf:"varint,1,opt,name=status,proto3,enum=replication.HandshakeStatus" json:"status,omitempty"`
+	FeaturesSupported []Feature              `protobuf:"varint,2,rep,packed,name=features_supported,json=featuresSupported,proto3,enum=replication.Feature" json:"features_supported,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *HandshakeResponse) Reset() {
+	*x = HandshakeResponse{}
+	mi := &file_replication_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HandshakeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HandshakeResponse) ProtoMessage() {}
+
+func (x *HandshakeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_replication_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HandshakeResponse.ProtoReflect.Descriptor instead.
+func (*HandshakeResponse) Descriptor() ([]byte, []int) {
+	return file_replication_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *HandshakeResponse) GetStatus() HandshakeStatus {
+	if x != nil {
+		return x.Status
+	}
+	return HandshakeStatus_HANDSHAKE_STATUS_UNKNOWN
+}
+
+func (x *HandshakeResponse) GetFeaturesSupported() []Feature {
+	if x != nil {
+		return x.FeaturesSupported
+	}
+	return nil
+}
+
 type CoordinationShardAssignmentsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -272,7 +420,7 @@ type CoordinationShardAssignmentsResponse struct {
 
 func (x *CoordinationShardAssignmentsResponse) Reset() {
 	*x = CoordinationShardAssignmentsResponse{}
-	mi := &file_replication_proto_msgTypes[2]
+	mi := &file_replication_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -284,7 +432,7 @@ func (x *CoordinationShardAssignmentsResponse) String() string {
 func (*CoordinationShardAssignmentsResponse) ProtoMessage() {}
 
 func (x *CoordinationShardAssignmentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[2]
+	mi := &file_replication_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -297,7 +445,7 @@ func (x *CoordinationShardAssignmentsResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use CoordinationShardAssignmentsResponse.ProtoReflect.Descriptor instead.
 func (*CoordinationShardAssignmentsResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{2}
+	return file_replication_proto_rawDescGZIP(), []int{4}
 }
 
 type EntryId struct {
@@ -310,7 +458,7 @@ type EntryId struct {
 
 func (x *EntryId) Reset() {
 	*x = EntryId{}
-	mi := &file_replication_proto_msgTypes[3]
+	mi := &file_replication_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -322,7 +470,7 @@ func (x *EntryId) String() string {
 func (*EntryId) ProtoMessage() {}
 
 func (x *EntryId) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[3]
+	mi := &file_replication_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -335,7 +483,7 @@ func (x *EntryId) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EntryId.ProtoReflect.Descriptor instead.
 func (*EntryId) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{3}
+	return file_replication_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *EntryId) GetTerm() int64 {
@@ -364,7 +512,7 @@ type LogEntry struct {
 
 func (x *LogEntry) Reset() {
 	*x = LogEntry{}
-	mi := &file_replication_proto_msgTypes[4]
+	mi := &file_replication_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -376,7 +524,7 @@ func (x *LogEntry) String() string {
 func (*LogEntry) ProtoMessage() {}
 
 func (x *LogEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[4]
+	mi := &file_replication_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -389,7 +537,7 @@ func (x *LogEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogEntry.ProtoReflect.Descriptor instead.
 func (*LogEntry) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{4}
+	return file_replication_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *LogEntry) GetTerm() int64 {
@@ -433,7 +581,7 @@ type SnapshotChunk struct {
 
 func (x *SnapshotChunk) Reset() {
 	*x = SnapshotChunk{}
-	mi := &file_replication_proto_msgTypes[5]
+	mi := &file_replication_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -445,7 +593,7 @@ func (x *SnapshotChunk) String() string {
 func (*SnapshotChunk) ProtoMessage() {}
 
 func (x *SnapshotChunk) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[5]
+	mi := &file_replication_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -458,7 +606,7 @@ func (x *SnapshotChunk) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SnapshotChunk.ProtoReflect.Descriptor instead.
 func (*SnapshotChunk) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{5}
+	return file_replication_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *SnapshotChunk) GetTerm() int64 {
@@ -506,7 +654,7 @@ type NewTermOptions struct {
 
 func (x *NewTermOptions) Reset() {
 	*x = NewTermOptions{}
-	mi := &file_replication_proto_msgTypes[6]
+	mi := &file_replication_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -518,7 +666,7 @@ func (x *NewTermOptions) String() string {
 func (*NewTermOptions) ProtoMessage() {}
 
 func (x *NewTermOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[6]
+	mi := &file_replication_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -531,7 +679,7 @@ func (x *NewTermOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewTermOptions.ProtoReflect.Descriptor instead.
 func (*NewTermOptions) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{6}
+	return file_replication_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *NewTermOptions) GetEnableNotifications() bool {
@@ -560,7 +708,7 @@ type NewTermRequest struct {
 
 func (x *NewTermRequest) Reset() {
 	*x = NewTermRequest{}
-	mi := &file_replication_proto_msgTypes[7]
+	mi := &file_replication_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -572,7 +720,7 @@ func (x *NewTermRequest) String() string {
 func (*NewTermRequest) ProtoMessage() {}
 
 func (x *NewTermRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[7]
+	mi := &file_replication_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -585,7 +733,7 @@ func (x *NewTermRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewTermRequest.ProtoReflect.Descriptor instead.
 func (*NewTermRequest) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{7}
+	return file_replication_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *NewTermRequest) GetNamespace() string {
@@ -625,7 +773,7 @@ type NewTermResponse struct {
 
 func (x *NewTermResponse) Reset() {
 	*x = NewTermResponse{}
-	mi := &file_replication_proto_msgTypes[8]
+	mi := &file_replication_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -637,7 +785,7 @@ func (x *NewTermResponse) String() string {
 func (*NewTermResponse) ProtoMessage() {}
 
 func (x *NewTermResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[8]
+	mi := &file_replication_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -650,7 +798,7 @@ func (x *NewTermResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NewTermResponse.ProtoReflect.Descriptor instead.
 func (*NewTermResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{8}
+	return file_replication_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *NewTermResponse) GetHeadEntryId() *EntryId {
@@ -677,7 +825,7 @@ type BecomeLeaderRequest struct {
 
 func (x *BecomeLeaderRequest) Reset() {
 	*x = BecomeLeaderRequest{}
-	mi := &file_replication_proto_msgTypes[9]
+	mi := &file_replication_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -689,7 +837,7 @@ func (x *BecomeLeaderRequest) String() string {
 func (*BecomeLeaderRequest) ProtoMessage() {}
 
 func (x *BecomeLeaderRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[9]
+	mi := &file_replication_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -702,7 +850,7 @@ func (x *BecomeLeaderRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BecomeLeaderRequest.ProtoReflect.Descriptor instead.
 func (*BecomeLeaderRequest) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{9}
+	return file_replication_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *BecomeLeaderRequest) GetNamespace() string {
@@ -773,7 +921,7 @@ type AddFollowerRequest struct {
 
 func (x *AddFollowerRequest) Reset() {
 	*x = AddFollowerRequest{}
-	mi := &file_replication_proto_msgTypes[10]
+	mi := &file_replication_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -785,7 +933,7 @@ func (x *AddFollowerRequest) String() string {
 func (*AddFollowerRequest) ProtoMessage() {}
 
 func (x *AddFollowerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[10]
+	mi := &file_replication_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -798,7 +946,7 @@ func (x *AddFollowerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFollowerRequest.ProtoReflect.Descriptor instead.
 func (*AddFollowerRequest) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{10}
+	return file_replication_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AddFollowerRequest) GetNamespace() string {
@@ -865,7 +1013,7 @@ type BecomeLeaderResponse struct {
 
 func (x *BecomeLeaderResponse) Reset() {
 	*x = BecomeLeaderResponse{}
-	mi := &file_replication_proto_msgTypes[11]
+	mi := &file_replication_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -877,7 +1025,7 @@ func (x *BecomeLeaderResponse) String() string {
 func (*BecomeLeaderResponse) ProtoMessage() {}
 
 func (x *BecomeLeaderResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[11]
+	mi := &file_replication_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -890,7 +1038,7 @@ func (x *BecomeLeaderResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BecomeLeaderResponse.ProtoReflect.Descriptor instead.
 func (*BecomeLeaderResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{11}
+	return file_replication_proto_rawDescGZIP(), []int{13}
 }
 
 type AddFollowerResponse struct {
@@ -901,7 +1049,7 @@ type AddFollowerResponse struct {
 
 func (x *AddFollowerResponse) Reset() {
 	*x = AddFollowerResponse{}
-	mi := &file_replication_proto_msgTypes[12]
+	mi := &file_replication_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -913,7 +1061,7 @@ func (x *AddFollowerResponse) String() string {
 func (*AddFollowerResponse) ProtoMessage() {}
 
 func (x *AddFollowerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[12]
+	mi := &file_replication_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -926,7 +1074,7 @@ func (x *AddFollowerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddFollowerResponse.ProtoReflect.Descriptor instead.
 func (*AddFollowerResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{12}
+	return file_replication_proto_rawDescGZIP(), []int{14}
 }
 
 type TruncateRequest struct {
@@ -941,7 +1089,7 @@ type TruncateRequest struct {
 
 func (x *TruncateRequest) Reset() {
 	*x = TruncateRequest{}
-	mi := &file_replication_proto_msgTypes[13]
+	mi := &file_replication_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -953,7 +1101,7 @@ func (x *TruncateRequest) String() string {
 func (*TruncateRequest) ProtoMessage() {}
 
 func (x *TruncateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[13]
+	mi := &file_replication_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -966,7 +1114,7 @@ func (x *TruncateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TruncateRequest.ProtoReflect.Descriptor instead.
 func (*TruncateRequest) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{13}
+	return file_replication_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *TruncateRequest) GetNamespace() string {
@@ -1006,7 +1154,7 @@ type TruncateResponse struct {
 
 func (x *TruncateResponse) Reset() {
 	*x = TruncateResponse{}
-	mi := &file_replication_proto_msgTypes[14]
+	mi := &file_replication_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1018,7 +1166,7 @@ func (x *TruncateResponse) String() string {
 func (*TruncateResponse) ProtoMessage() {}
 
 func (x *TruncateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[14]
+	mi := &file_replication_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1031,7 +1179,7 @@ func (x *TruncateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TruncateResponse.ProtoReflect.Descriptor instead.
 func (*TruncateResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{14}
+	return file_replication_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *TruncateResponse) GetHeadEntryId() *EntryId {
@@ -1053,7 +1201,7 @@ type Append struct {
 
 func (x *Append) Reset() {
 	*x = Append{}
-	mi := &file_replication_proto_msgTypes[15]
+	mi := &file_replication_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1065,7 +1213,7 @@ func (x *Append) String() string {
 func (*Append) ProtoMessage() {}
 
 func (x *Append) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[15]
+	mi := &file_replication_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1078,7 +1226,7 @@ func (x *Append) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Append.ProtoReflect.Descriptor instead.
 func (*Append) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{15}
+	return file_replication_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *Append) GetTerm() int64 {
@@ -1118,7 +1266,7 @@ type Ack struct {
 
 func (x *Ack) Reset() {
 	*x = Ack{}
-	mi := &file_replication_proto_msgTypes[16]
+	mi := &file_replication_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1130,7 +1278,7 @@ func (x *Ack) String() string {
 func (*Ack) ProtoMessage() {}
 
 func (x *Ack) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[16]
+	mi := &file_replication_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1143,7 +1291,7 @@ func (x *Ack) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Ack.ProtoReflect.Descriptor instead.
 func (*Ack) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{16}
+	return file_replication_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *Ack) GetOffset() int64 {
@@ -1162,7 +1310,7 @@ type SnapshotResponse struct {
 
 func (x *SnapshotResponse) Reset() {
 	*x = SnapshotResponse{}
-	mi := &file_replication_proto_msgTypes[17]
+	mi := &file_replication_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1174,7 +1322,7 @@ func (x *SnapshotResponse) String() string {
 func (*SnapshotResponse) ProtoMessage() {}
 
 func (x *SnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[17]
+	mi := &file_replication_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1187,7 +1335,7 @@ func (x *SnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SnapshotResponse.ProtoReflect.Descriptor instead.
 func (*SnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{17}
+	return file_replication_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *SnapshotResponse) GetAckOffset() int64 {
@@ -1208,7 +1356,7 @@ type DeleteShardRequest struct {
 
 func (x *DeleteShardRequest) Reset() {
 	*x = DeleteShardRequest{}
-	mi := &file_replication_proto_msgTypes[18]
+	mi := &file_replication_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1220,7 +1368,7 @@ func (x *DeleteShardRequest) String() string {
 func (*DeleteShardRequest) ProtoMessage() {}
 
 func (x *DeleteShardRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[18]
+	mi := &file_replication_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1233,7 +1381,7 @@ func (x *DeleteShardRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteShardRequest.ProtoReflect.Descriptor instead.
 func (*DeleteShardRequest) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{18}
+	return file_replication_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DeleteShardRequest) GetNamespace() string {
@@ -1265,7 +1413,7 @@ type DeleteShardResponse struct {
 
 func (x *DeleteShardResponse) Reset() {
 	*x = DeleteShardResponse{}
-	mi := &file_replication_proto_msgTypes[19]
+	mi := &file_replication_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1277,7 +1425,7 @@ func (x *DeleteShardResponse) String() string {
 func (*DeleteShardResponse) ProtoMessage() {}
 
 func (x *DeleteShardResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[19]
+	mi := &file_replication_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1290,7 +1438,7 @@ func (x *DeleteShardResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteShardResponse.ProtoReflect.Descriptor instead.
 func (*DeleteShardResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{19}
+	return file_replication_proto_rawDescGZIP(), []int{21}
 }
 
 type RemoveObserverRequest struct {
@@ -1306,7 +1454,7 @@ type RemoveObserverRequest struct {
 
 func (x *RemoveObserverRequest) Reset() {
 	*x = RemoveObserverRequest{}
-	mi := &file_replication_proto_msgTypes[20]
+	mi := &file_replication_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1318,7 +1466,7 @@ func (x *RemoveObserverRequest) String() string {
 func (*RemoveObserverRequest) ProtoMessage() {}
 
 func (x *RemoveObserverRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[20]
+	mi := &file_replication_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1331,7 +1479,7 @@ func (x *RemoveObserverRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveObserverRequest.ProtoReflect.Descriptor instead.
 func (*RemoveObserverRequest) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{20}
+	return file_replication_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *RemoveObserverRequest) GetNamespace() string {
@@ -1377,7 +1525,7 @@ type RemoveObserverResponse struct {
 
 func (x *RemoveObserverResponse) Reset() {
 	*x = RemoveObserverResponse{}
-	mi := &file_replication_proto_msgTypes[21]
+	mi := &file_replication_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1389,7 +1537,7 @@ func (x *RemoveObserverResponse) String() string {
 func (*RemoveObserverResponse) ProtoMessage() {}
 
 func (x *RemoveObserverResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[21]
+	mi := &file_replication_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1402,7 +1550,7 @@ func (x *RemoveObserverResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveObserverResponse.ProtoReflect.Descriptor instead.
 func (*RemoveObserverResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{21}
+	return file_replication_proto_rawDescGZIP(), []int{23}
 }
 
 type GetStatusRequest struct {
@@ -1414,7 +1562,7 @@ type GetStatusRequest struct {
 
 func (x *GetStatusRequest) Reset() {
 	*x = GetStatusRequest{}
-	mi := &file_replication_proto_msgTypes[22]
+	mi := &file_replication_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1426,7 +1574,7 @@ func (x *GetStatusRequest) String() string {
 func (*GetStatusRequest) ProtoMessage() {}
 
 func (x *GetStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[22]
+	mi := &file_replication_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1439,7 +1587,7 @@ func (x *GetStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetStatusRequest) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{22}
+	return file_replication_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *GetStatusRequest) GetShard() int64 {
@@ -1461,7 +1609,7 @@ type GetStatusResponse struct {
 
 func (x *GetStatusResponse) Reset() {
 	*x = GetStatusResponse{}
-	mi := &file_replication_proto_msgTypes[23]
+	mi := &file_replication_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1473,7 +1621,7 @@ func (x *GetStatusResponse) String() string {
 func (*GetStatusResponse) ProtoMessage() {}
 
 func (x *GetStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_replication_proto_msgTypes[23]
+	mi := &file_replication_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1486,7 +1634,7 @@ func (x *GetStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetStatusResponse) Descriptor() ([]byte, []int) {
-	return file_replication_proto_rawDescGZIP(), []int{23}
+	return file_replication_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *GetStatusResponse) GetTerm() int64 {
@@ -1524,7 +1672,13 @@ const file_replication_proto_rawDesc = "" +
 	"\x11replication.proto\x12\vreplication\x1a\fclient.proto\"\x10\n" +
 	"\x0eGetInfoRequest\"V\n" +
 	"\x0fGetInfoResponse\x12C\n" +
-	"\x12features_supported\x18\x01 \x03(\x0e2\x14.replication.FeatureR\x11featuresSupported\"&\n" +
+	"\x12features_supported\x18\x01 \x03(\x0e2\x14.replication.FeatureR\x11featuresSupported\"3\n" +
+	"\x10HandshakeRequest\x12\x1f\n" +
+	"\vinstance_id\x18\x01 \x01(\tR\n" +
+	"instanceId\"\x8e\x01\n" +
+	"\x11HandshakeResponse\x124\n" +
+	"\x06status\x18\x01 \x01(\x0e2\x1c.replication.HandshakeStatusR\x06status\x12C\n" +
+	"\x12features_supported\x18\x02 \x03(\x0e2\x14.replication.FeatureR\x11featuresSupported\"&\n" +
 	"$CoordinationShardAssignmentsResponse\"5\n" +
 	"\aEntryId\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x03R\x04term\x12\x16\n" +
@@ -1616,7 +1770,12 @@ const file_replication_proto_rawDesc = "" +
 	"\rcommit_offset\x18\x04 \x01(\x03R\fcommitOffset*7\n" +
 	"\aFeature\x12\x13\n" +
 	"\x0fFEATURE_UNKNOWN\x10\x00\x12\x17\n" +
-	"\x13FEATURE_DB_CHECKSUM\x10\x01*<\n" +
+	"\x13FEATURE_DB_CHECKSUM\x10\x01*\x8e\x01\n" +
+	"\x0fHandshakeStatus\x12\x1c\n" +
+	"\x18HANDSHAKE_STATUS_UNKNOWN\x10\x00\x12\x1a\n" +
+	"\x16HANDSHAKE_STATUS_BOUND\x10\x01\x12\"\n" +
+	"\x1eHANDSHAKE_STATUS_ALREADY_BOUND\x10\x02\x12\x1d\n" +
+	"\x19HANDSHAKE_STATUS_MISMATCH\x10\x03*<\n" +
 	"\x0eKeySortingType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\v\n" +
 	"\aNATURAL\x10\x01\x12\x10\n" +
@@ -1628,14 +1787,15 @@ const file_replication_proto_rawDesc = "" +
 	"\x06FENCED\x10\x01\x12\f\n" +
 	"\bFOLLOWER\x10\x02\x12\n" +
 	"\n" +
-	"\x06LEADER\x10\x032\xaf\x05\n" +
+	"\x06LEADER\x10\x032\xfb\x05\n" +
 	"\x10OxiaCoordination\x12o\n" +
 	"\x14PushShardAssignments\x12\".io.oxia.proto.v1.ShardAssignments\x1a1.replication.CoordinationShardAssignmentsResponse(\x01\x12D\n" +
 	"\aNewTerm\x12\x1b.replication.NewTermRequest\x1a\x1c.replication.NewTermResponse\x12S\n" +
 	"\fBecomeLeader\x12 .replication.BecomeLeaderRequest\x1a!.replication.BecomeLeaderResponse\x12P\n" +
 	"\vAddFollower\x12\x1f.replication.AddFollowerRequest\x1a .replication.AddFollowerResponse\x12J\n" +
 	"\tGetStatus\x12\x1d.replication.GetStatusRequest\x1a\x1e.replication.GetStatusResponse\x12P\n" +
-	"\vDeleteShard\x12\x1f.replication.DeleteShardRequest\x1a .replication.DeleteShardResponse\x12D\n" +
+	"\vDeleteShard\x12\x1f.replication.DeleteShardRequest\x1a .replication.DeleteShardResponse\x12J\n" +
+	"\tHandshake\x12\x1d.replication.HandshakeRequest\x1a\x1e.replication.HandshakeResponse\x12D\n" +
 	"\aGetInfo\x12\x1b.replication.GetInfoRequest\x1a\x1c.replication.GetInfoResponse\x12Y\n" +
 	"\x0eRemoveObserver\x12\".replication.RemoveObserverRequest\x1a#.replication.RemoveObserverResponse2\xe2\x01\n" +
 	"\x12OxiaLogReplication\x12G\n" +
@@ -1655,81 +1815,88 @@ func file_replication_proto_rawDescGZIP() []byte {
 	return file_replication_proto_rawDescData
 }
 
-var file_replication_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_replication_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_replication_proto_goTypes = []any{
 	(Feature)(0),                                 // 0: replication.Feature
-	(KeySortingType)(0),                          // 1: replication.KeySortingType
-	(ServingStatus)(0),                           // 2: replication.ServingStatus
-	(*GetInfoRequest)(nil),                       // 3: replication.GetInfoRequest
-	(*GetInfoResponse)(nil),                      // 4: replication.GetInfoResponse
-	(*CoordinationShardAssignmentsResponse)(nil), // 5: replication.CoordinationShardAssignmentsResponse
-	(*EntryId)(nil),                              // 6: replication.EntryId
-	(*LogEntry)(nil),                             // 7: replication.LogEntry
-	(*SnapshotChunk)(nil),                        // 8: replication.SnapshotChunk
-	(*NewTermOptions)(nil),                       // 9: replication.NewTermOptions
-	(*NewTermRequest)(nil),                       // 10: replication.NewTermRequest
-	(*NewTermResponse)(nil),                      // 11: replication.NewTermResponse
-	(*BecomeLeaderRequest)(nil),                  // 12: replication.BecomeLeaderRequest
-	(*AddFollowerRequest)(nil),                   // 13: replication.AddFollowerRequest
-	(*BecomeLeaderResponse)(nil),                 // 14: replication.BecomeLeaderResponse
-	(*AddFollowerResponse)(nil),                  // 15: replication.AddFollowerResponse
-	(*TruncateRequest)(nil),                      // 16: replication.TruncateRequest
-	(*TruncateResponse)(nil),                     // 17: replication.TruncateResponse
-	(*Append)(nil),                               // 18: replication.Append
-	(*Ack)(nil),                                  // 19: replication.Ack
-	(*SnapshotResponse)(nil),                     // 20: replication.SnapshotResponse
-	(*DeleteShardRequest)(nil),                   // 21: replication.DeleteShardRequest
-	(*DeleteShardResponse)(nil),                  // 22: replication.DeleteShardResponse
-	(*RemoveObserverRequest)(nil),                // 23: replication.RemoveObserverRequest
-	(*RemoveObserverResponse)(nil),               // 24: replication.RemoveObserverResponse
-	(*GetStatusRequest)(nil),                     // 25: replication.GetStatusRequest
-	(*GetStatusResponse)(nil),                    // 26: replication.GetStatusResponse
-	nil,                                          // 27: replication.BecomeLeaderRequest.FollowerMapsEntry
-	(*Int32HashRange)(nil),                       // 28: io.oxia.proto.v1.Int32HashRange
-	(*ShardAssignments)(nil),                     // 29: io.oxia.proto.v1.ShardAssignments
+	(HandshakeStatus)(0),                         // 1: replication.HandshakeStatus
+	(KeySortingType)(0),                          // 2: replication.KeySortingType
+	(ServingStatus)(0),                           // 3: replication.ServingStatus
+	(*GetInfoRequest)(nil),                       // 4: replication.GetInfoRequest
+	(*GetInfoResponse)(nil),                      // 5: replication.GetInfoResponse
+	(*HandshakeRequest)(nil),                     // 6: replication.HandshakeRequest
+	(*HandshakeResponse)(nil),                    // 7: replication.HandshakeResponse
+	(*CoordinationShardAssignmentsResponse)(nil), // 8: replication.CoordinationShardAssignmentsResponse
+	(*EntryId)(nil),                              // 9: replication.EntryId
+	(*LogEntry)(nil),                             // 10: replication.LogEntry
+	(*SnapshotChunk)(nil),                        // 11: replication.SnapshotChunk
+	(*NewTermOptions)(nil),                       // 12: replication.NewTermOptions
+	(*NewTermRequest)(nil),                       // 13: replication.NewTermRequest
+	(*NewTermResponse)(nil),                      // 14: replication.NewTermResponse
+	(*BecomeLeaderRequest)(nil),                  // 15: replication.BecomeLeaderRequest
+	(*AddFollowerRequest)(nil),                   // 16: replication.AddFollowerRequest
+	(*BecomeLeaderResponse)(nil),                 // 17: replication.BecomeLeaderResponse
+	(*AddFollowerResponse)(nil),                  // 18: replication.AddFollowerResponse
+	(*TruncateRequest)(nil),                      // 19: replication.TruncateRequest
+	(*TruncateResponse)(nil),                     // 20: replication.TruncateResponse
+	(*Append)(nil),                               // 21: replication.Append
+	(*Ack)(nil),                                  // 22: replication.Ack
+	(*SnapshotResponse)(nil),                     // 23: replication.SnapshotResponse
+	(*DeleteShardRequest)(nil),                   // 24: replication.DeleteShardRequest
+	(*DeleteShardResponse)(nil),                  // 25: replication.DeleteShardResponse
+	(*RemoveObserverRequest)(nil),                // 26: replication.RemoveObserverRequest
+	(*RemoveObserverResponse)(nil),               // 27: replication.RemoveObserverResponse
+	(*GetStatusRequest)(nil),                     // 28: replication.GetStatusRequest
+	(*GetStatusResponse)(nil),                    // 29: replication.GetStatusResponse
+	nil,                                          // 30: replication.BecomeLeaderRequest.FollowerMapsEntry
+	(*Int32HashRange)(nil),                       // 31: io.oxia.proto.v1.Int32HashRange
+	(*ShardAssignments)(nil),                     // 32: io.oxia.proto.v1.ShardAssignments
 }
 var file_replication_proto_depIdxs = []int32{
 	0,  // 0: replication.GetInfoResponse.features_supported:type_name -> replication.Feature
-	1,  // 1: replication.NewTermOptions.key_sorting:type_name -> replication.KeySortingType
-	9,  // 2: replication.NewTermRequest.options:type_name -> replication.NewTermOptions
-	6,  // 3: replication.NewTermResponse.head_entry_id:type_name -> replication.EntryId
-	27, // 4: replication.BecomeLeaderRequest.follower_maps:type_name -> replication.BecomeLeaderRequest.FollowerMapsEntry
-	0,  // 5: replication.BecomeLeaderRequest.features_supported:type_name -> replication.Feature
-	6,  // 6: replication.AddFollowerRequest.follower_head_entry_id:type_name -> replication.EntryId
-	28, // 7: replication.AddFollowerRequest.split_hash_range:type_name -> io.oxia.proto.v1.Int32HashRange
-	6,  // 8: replication.TruncateRequest.head_entry_id:type_name -> replication.EntryId
-	6,  // 9: replication.TruncateResponse.head_entry_id:type_name -> replication.EntryId
-	7,  // 10: replication.Append.entry:type_name -> replication.LogEntry
-	2,  // 11: replication.GetStatusResponse.status:type_name -> replication.ServingStatus
-	6,  // 12: replication.BecomeLeaderRequest.FollowerMapsEntry.value:type_name -> replication.EntryId
-	29, // 13: replication.OxiaCoordination.PushShardAssignments:input_type -> io.oxia.proto.v1.ShardAssignments
-	10, // 14: replication.OxiaCoordination.NewTerm:input_type -> replication.NewTermRequest
-	12, // 15: replication.OxiaCoordination.BecomeLeader:input_type -> replication.BecomeLeaderRequest
-	13, // 16: replication.OxiaCoordination.AddFollower:input_type -> replication.AddFollowerRequest
-	25, // 17: replication.OxiaCoordination.GetStatus:input_type -> replication.GetStatusRequest
-	21, // 18: replication.OxiaCoordination.DeleteShard:input_type -> replication.DeleteShardRequest
-	3,  // 19: replication.OxiaCoordination.GetInfo:input_type -> replication.GetInfoRequest
-	23, // 20: replication.OxiaCoordination.RemoveObserver:input_type -> replication.RemoveObserverRequest
-	16, // 21: replication.OxiaLogReplication.Truncate:input_type -> replication.TruncateRequest
-	18, // 22: replication.OxiaLogReplication.Replicate:input_type -> replication.Append
-	8,  // 23: replication.OxiaLogReplication.SendSnapshot:input_type -> replication.SnapshotChunk
-	5,  // 24: replication.OxiaCoordination.PushShardAssignments:output_type -> replication.CoordinationShardAssignmentsResponse
-	11, // 25: replication.OxiaCoordination.NewTerm:output_type -> replication.NewTermResponse
-	14, // 26: replication.OxiaCoordination.BecomeLeader:output_type -> replication.BecomeLeaderResponse
-	15, // 27: replication.OxiaCoordination.AddFollower:output_type -> replication.AddFollowerResponse
-	26, // 28: replication.OxiaCoordination.GetStatus:output_type -> replication.GetStatusResponse
-	22, // 29: replication.OxiaCoordination.DeleteShard:output_type -> replication.DeleteShardResponse
-	4,  // 30: replication.OxiaCoordination.GetInfo:output_type -> replication.GetInfoResponse
-	24, // 31: replication.OxiaCoordination.RemoveObserver:output_type -> replication.RemoveObserverResponse
-	17, // 32: replication.OxiaLogReplication.Truncate:output_type -> replication.TruncateResponse
-	19, // 33: replication.OxiaLogReplication.Replicate:output_type -> replication.Ack
-	20, // 34: replication.OxiaLogReplication.SendSnapshot:output_type -> replication.SnapshotResponse
-	24, // [24:35] is the sub-list for method output_type
-	13, // [13:24] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	1,  // 1: replication.HandshakeResponse.status:type_name -> replication.HandshakeStatus
+	0,  // 2: replication.HandshakeResponse.features_supported:type_name -> replication.Feature
+	2,  // 3: replication.NewTermOptions.key_sorting:type_name -> replication.KeySortingType
+	12, // 4: replication.NewTermRequest.options:type_name -> replication.NewTermOptions
+	9,  // 5: replication.NewTermResponse.head_entry_id:type_name -> replication.EntryId
+	30, // 6: replication.BecomeLeaderRequest.follower_maps:type_name -> replication.BecomeLeaderRequest.FollowerMapsEntry
+	0,  // 7: replication.BecomeLeaderRequest.features_supported:type_name -> replication.Feature
+	9,  // 8: replication.AddFollowerRequest.follower_head_entry_id:type_name -> replication.EntryId
+	31, // 9: replication.AddFollowerRequest.split_hash_range:type_name -> io.oxia.proto.v1.Int32HashRange
+	9,  // 10: replication.TruncateRequest.head_entry_id:type_name -> replication.EntryId
+	9,  // 11: replication.TruncateResponse.head_entry_id:type_name -> replication.EntryId
+	10, // 12: replication.Append.entry:type_name -> replication.LogEntry
+	3,  // 13: replication.GetStatusResponse.status:type_name -> replication.ServingStatus
+	9,  // 14: replication.BecomeLeaderRequest.FollowerMapsEntry.value:type_name -> replication.EntryId
+	32, // 15: replication.OxiaCoordination.PushShardAssignments:input_type -> io.oxia.proto.v1.ShardAssignments
+	13, // 16: replication.OxiaCoordination.NewTerm:input_type -> replication.NewTermRequest
+	15, // 17: replication.OxiaCoordination.BecomeLeader:input_type -> replication.BecomeLeaderRequest
+	16, // 18: replication.OxiaCoordination.AddFollower:input_type -> replication.AddFollowerRequest
+	28, // 19: replication.OxiaCoordination.GetStatus:input_type -> replication.GetStatusRequest
+	24, // 20: replication.OxiaCoordination.DeleteShard:input_type -> replication.DeleteShardRequest
+	6,  // 21: replication.OxiaCoordination.Handshake:input_type -> replication.HandshakeRequest
+	4,  // 22: replication.OxiaCoordination.GetInfo:input_type -> replication.GetInfoRequest
+	26, // 23: replication.OxiaCoordination.RemoveObserver:input_type -> replication.RemoveObserverRequest
+	19, // 24: replication.OxiaLogReplication.Truncate:input_type -> replication.TruncateRequest
+	21, // 25: replication.OxiaLogReplication.Replicate:input_type -> replication.Append
+	11, // 26: replication.OxiaLogReplication.SendSnapshot:input_type -> replication.SnapshotChunk
+	8,  // 27: replication.OxiaCoordination.PushShardAssignments:output_type -> replication.CoordinationShardAssignmentsResponse
+	14, // 28: replication.OxiaCoordination.NewTerm:output_type -> replication.NewTermResponse
+	17, // 29: replication.OxiaCoordination.BecomeLeader:output_type -> replication.BecomeLeaderResponse
+	18, // 30: replication.OxiaCoordination.AddFollower:output_type -> replication.AddFollowerResponse
+	29, // 31: replication.OxiaCoordination.GetStatus:output_type -> replication.GetStatusResponse
+	25, // 32: replication.OxiaCoordination.DeleteShard:output_type -> replication.DeleteShardResponse
+	7,  // 33: replication.OxiaCoordination.Handshake:output_type -> replication.HandshakeResponse
+	5,  // 34: replication.OxiaCoordination.GetInfo:output_type -> replication.GetInfoResponse
+	27, // 35: replication.OxiaCoordination.RemoveObserver:output_type -> replication.RemoveObserverResponse
+	20, // 36: replication.OxiaLogReplication.Truncate:output_type -> replication.TruncateResponse
+	22, // 37: replication.OxiaLogReplication.Replicate:output_type -> replication.Ack
+	23, // 38: replication.OxiaLogReplication.SendSnapshot:output_type -> replication.SnapshotResponse
+	27, // [27:39] is the sub-list for method output_type
+	15, // [15:27] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_replication_proto_init() }
@@ -1738,15 +1905,15 @@ func file_replication_proto_init() {
 		return
 	}
 	file_client_proto_init()
-	file_replication_proto_msgTypes[10].OneofWrappers = []any{}
-	file_replication_proto_msgTypes[15].OneofWrappers = []any{}
+	file_replication_proto_msgTypes[12].OneofWrappers = []any{}
+	file_replication_proto_msgTypes[17].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_replication_proto_rawDesc), len(file_replication_proto_rawDesc)),
-			NumEnums:      3,
-			NumMessages:   25,
+			NumEnums:      4,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/common/proto/replication.proto
+++ b/common/proto/replication.proto
@@ -31,6 +31,10 @@ service OxiaCoordination {
 
   rpc GetStatus(GetStatusRequest) returns (GetStatusResponse);
   rpc DeleteShard(DeleteShardRequest) returns (DeleteShardResponse);
+  rpc Handshake(HandshakeRequest) returns (HandshakeResponse);
+  // Deprecated: use Handshake for node initialization and feature discovery.
+  // Keep GetInfo only for rolling-upgrade compatibility and remove it in the
+  // next major version.
   rpc GetInfo(GetInfoRequest) returns (GetInfoResponse);
 
   // Removes an observer follower from the parent leader without fencing.
@@ -59,6 +63,22 @@ message GetInfoRequest {
 
 message GetInfoResponse {
     repeated Feature features_supported = 1;
+}
+
+enum HandshakeStatus {
+  HANDSHAKE_STATUS_UNKNOWN = 0;
+  HANDSHAKE_STATUS_BOUND = 1;
+  HANDSHAKE_STATUS_ALREADY_BOUND = 2;
+  HANDSHAKE_STATUS_MISMATCH = 3;
+}
+
+message HandshakeRequest {
+  string instance_id = 1;
+}
+
+message HandshakeResponse {
+  HandshakeStatus status = 1;
+  repeated Feature features_supported = 2;
 }
 
 message CoordinationShardAssignmentsResponse {}

--- a/common/proto/replication.proto
+++ b/common/proto/replication.proto
@@ -33,8 +33,8 @@ service OxiaCoordination {
   rpc DeleteShard(DeleteShardRequest) returns (DeleteShardResponse);
   rpc Handshake(HandshakeRequest) returns (HandshakeResponse);
   // Deprecated: use Handshake for node initialization and feature discovery.
-  // Keep GetInfo only for rolling-upgrade compatibility and remove it in the
-  // next major version.
+  // Keep GetInfo only so new coordinators can fall back to older dataservers
+  // during rolling upgrades, and remove it in the next major version.
   rpc GetInfo(GetInfoRequest) returns (GetInfoResponse);
 
   // Removes an observer follower from the parent leader without fencing.

--- a/common/proto/replication_grpc.pb.go
+++ b/common/proto/replication_grpc.pb.go
@@ -39,6 +39,7 @@ const (
 	OxiaCoordination_AddFollower_FullMethodName          = "/replication.OxiaCoordination/AddFollower"
 	OxiaCoordination_GetStatus_FullMethodName            = "/replication.OxiaCoordination/GetStatus"
 	OxiaCoordination_DeleteShard_FullMethodName          = "/replication.OxiaCoordination/DeleteShard"
+	OxiaCoordination_Handshake_FullMethodName            = "/replication.OxiaCoordination/Handshake"
 	OxiaCoordination_GetInfo_FullMethodName              = "/replication.OxiaCoordination/GetInfo"
 	OxiaCoordination_RemoveObserver_FullMethodName       = "/replication.OxiaCoordination/RemoveObserver"
 )
@@ -55,6 +56,10 @@ type OxiaCoordinationClient interface {
 	AddFollower(ctx context.Context, in *AddFollowerRequest, opts ...grpc.CallOption) (*AddFollowerResponse, error)
 	GetStatus(ctx context.Context, in *GetStatusRequest, opts ...grpc.CallOption) (*GetStatusResponse, error)
 	DeleteShard(ctx context.Context, in *DeleteShardRequest, opts ...grpc.CallOption) (*DeleteShardResponse, error)
+	Handshake(ctx context.Context, in *HandshakeRequest, opts ...grpc.CallOption) (*HandshakeResponse, error)
+	// Deprecated: use Handshake for node initialization and feature discovery.
+	// Keep GetInfo only for rolling-upgrade compatibility and remove it in the
+	// next major version.
 	GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error)
 	// Removes an observer follower from the parent leader without fencing.
 	// Used during split abort to cleanly stop data streaming to children.
@@ -132,6 +137,16 @@ func (c *oxiaCoordinationClient) DeleteShard(ctx context.Context, in *DeleteShar
 	return out, nil
 }
 
+func (c *oxiaCoordinationClient) Handshake(ctx context.Context, in *HandshakeRequest, opts ...grpc.CallOption) (*HandshakeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(HandshakeResponse)
+	err := c.cc.Invoke(ctx, OxiaCoordination_Handshake_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *oxiaCoordinationClient) GetInfo(ctx context.Context, in *GetInfoRequest, opts ...grpc.CallOption) (*GetInfoResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetInfoResponse)
@@ -164,6 +179,10 @@ type OxiaCoordinationServer interface {
 	AddFollower(context.Context, *AddFollowerRequest) (*AddFollowerResponse, error)
 	GetStatus(context.Context, *GetStatusRequest) (*GetStatusResponse, error)
 	DeleteShard(context.Context, *DeleteShardRequest) (*DeleteShardResponse, error)
+	Handshake(context.Context, *HandshakeRequest) (*HandshakeResponse, error)
+	// Deprecated: use Handshake for node initialization and feature discovery.
+	// Keep GetInfo only for rolling-upgrade compatibility and remove it in the
+	// next major version.
 	GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error)
 	// Removes an observer follower from the parent leader without fencing.
 	// Used during split abort to cleanly stop data streaming to children.
@@ -195,6 +214,9 @@ func (UnimplementedOxiaCoordinationServer) GetStatus(context.Context, *GetStatus
 }
 func (UnimplementedOxiaCoordinationServer) DeleteShard(context.Context, *DeleteShardRequest) (*DeleteShardResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteShard not implemented")
+}
+func (UnimplementedOxiaCoordinationServer) Handshake(context.Context, *HandshakeRequest) (*HandshakeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Handshake not implemented")
 }
 func (UnimplementedOxiaCoordinationServer) GetInfo(context.Context, *GetInfoRequest) (*GetInfoResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetInfo not implemented")
@@ -320,6 +342,24 @@ func _OxiaCoordination_DeleteShard_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _OxiaCoordination_Handshake_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(HandshakeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(OxiaCoordinationServer).Handshake(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: OxiaCoordination_Handshake_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(OxiaCoordinationServer).Handshake(ctx, req.(*HandshakeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _OxiaCoordination_GetInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetInfoRequest)
 	if err := dec(in); err != nil {
@@ -382,6 +422,10 @@ var OxiaCoordination_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteShard",
 			Handler:    _OxiaCoordination_DeleteShard_Handler,
+		},
+		{
+			MethodName: "Handshake",
+			Handler:    _OxiaCoordination_Handshake_Handler,
 		},
 		{
 			MethodName: "GetInfo",

--- a/common/proto/replication_vtproto.pb.go
+++ b/common/proto/replication_vtproto.pb.go
@@ -3058,10 +3058,6 @@ func (m *GetInfoResponse) UnmarshalVT(dAtA []byte) error {
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
-				var elementCount int
-				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
-					m.FeaturesSupported = make([]Feature, 0, elementCount)
-				}
 				for iNdEx < postIndex {
 					var v Feature
 					for shift := uint(0); ; shift += 7 {
@@ -3279,10 +3275,6 @@ func (m *HandshakeResponse) UnmarshalVT(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
-					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature
@@ -4398,10 +4390,6 @@ func (m *BecomeLeaderRequest) UnmarshalVT(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
-					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature
@@ -6058,10 +6046,6 @@ func (m *GetInfoResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
-				var elementCount int
-				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
-					m.FeaturesSupported = make([]Feature, 0, elementCount)
-				}
 				for iNdEx < postIndex {
 					var v Feature
 					for shift := uint(0); ; shift += 7 {
@@ -6283,10 +6267,6 @@ func (m *HandshakeResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
-					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature
@@ -7412,10 +7392,6 @@ func (m *BecomeLeaderRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
-				}
-				var elementCount int
-				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
-					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature

--- a/common/proto/replication_vtproto.pb.go
+++ b/common/proto/replication_vtproto.pb.go
@@ -3058,6 +3058,10 @@ func (m *GetInfoResponse) UnmarshalVT(dAtA []byte) error {
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
+				}
 				for iNdEx < postIndex {
 					var v Feature
 					for shift := uint(0); ; shift += 7 {
@@ -3275,6 +3279,10 @@ func (m *HandshakeResponse) UnmarshalVT(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature
@@ -4390,6 +4398,10 @@ func (m *BecomeLeaderRequest) UnmarshalVT(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature
@@ -6046,6 +6058,10 @@ func (m *GetInfoResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
+				}
 				for iNdEx < postIndex {
 					var v Feature
 					for shift := uint(0); ; shift += 7 {
@@ -6267,6 +6283,10 @@ func (m *HandshakeResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature
@@ -7392,6 +7412,10 @@ func (m *BecomeLeaderRequest) UnmarshalVTUnsafe(dAtA []byte) error {
 				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
 				}
 				for iNdEx < postIndex {
 					var v Feature

--- a/common/proto/replication_vtproto.pb.go
+++ b/common/proto/replication_vtproto.pb.go
@@ -58,6 +58,45 @@ func (m *GetInfoResponse) CloneMessageVT() proto.Message {
 	return m.CloneVT()
 }
 
+func (m *HandshakeRequest) CloneVT() *HandshakeRequest {
+	if m == nil {
+		return (*HandshakeRequest)(nil)
+	}
+	r := new(HandshakeRequest)
+	r.InstanceId = m.InstanceId
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *HandshakeRequest) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
+func (m *HandshakeResponse) CloneVT() *HandshakeResponse {
+	if m == nil {
+		return (*HandshakeResponse)(nil)
+	}
+	r := new(HandshakeResponse)
+	r.Status = m.Status
+	if rhs := m.FeaturesSupported; rhs != nil {
+		tmpContainer := make([]Feature, len(rhs))
+		copy(tmpContainer, rhs)
+		r.FeaturesSupported = tmpContainer
+	}
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = make([]byte, len(m.unknownFields))
+		copy(r.unknownFields, m.unknownFields)
+	}
+	return r
+}
+
+func (m *HandshakeResponse) CloneMessageVT() proto.Message {
+	return m.CloneVT()
+}
+
 func (m *CoordinationShardAssignmentsResponse) CloneVT() *CoordinationShardAssignmentsResponse {
 	if m == nil {
 		return (*CoordinationShardAssignmentsResponse)(nil)
@@ -526,6 +565,53 @@ func (this *GetInfoResponse) EqualVT(that *GetInfoResponse) bool {
 
 func (this *GetInfoResponse) EqualMessageVT(thatMsg proto.Message) bool {
 	that, ok := thatMsg.(*GetInfoResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *HandshakeRequest) EqualVT(that *HandshakeRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.InstanceId != that.InstanceId {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *HandshakeRequest) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*HandshakeRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+func (this *HandshakeResponse) EqualVT(that *HandshakeResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.Status != that.Status {
+		return false
+	}
+	if len(this.FeaturesSupported) != len(that.FeaturesSupported) {
+		return false
+	}
+	for i, vx := range this.FeaturesSupported {
+		vy := that.FeaturesSupported[i]
+		if vx != vy {
+			return false
+		}
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *HandshakeResponse) EqualMessageVT(thatMsg proto.Message) bool {
+	that, ok := thatMsg.(*HandshakeResponse)
 	if !ok {
 		return false
 	}
@@ -1157,6 +1243,105 @@ func (m *GetInfoResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
 		i--
 		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *HandshakeRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HandshakeRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *HandshakeRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.InstanceId) > 0 {
+		i -= len(m.InstanceId)
+		copy(dAtA[i:], m.InstanceId)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.InstanceId)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *HandshakeResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HandshakeResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *HandshakeResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.FeaturesSupported) > 0 {
+		var pksize2 int
+		for _, num := range m.FeaturesSupported {
+			pksize2 += protohelpers.SizeOfVarint(uint64(num))
+		}
+		i -= pksize2
+		j1 := i
+		for _, num1 := range m.FeaturesSupported {
+			num := uint64(num1)
+			for num >= 1<<7 {
+				dAtA[j1] = uint8(uint64(num)&0x7f | 0x80)
+				num >>= 7
+				j1++
+			}
+			dAtA[j1] = uint8(num)
+			j1++
+		}
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(pksize2))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Status != 0 {
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(m.Status))
+		i--
+		dAtA[i] = 0x8
 	}
 	return len(dAtA) - i, nil
 }
@@ -2295,6 +2480,40 @@ func (m *GetInfoResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *HandshakeRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.InstanceId)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *HandshakeResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Status != 0 {
+		n += 1 + protohelpers.SizeOfVarint(uint64(m.Status))
+	}
+	if len(m.FeaturesSupported) > 0 {
+		l = 0
+		for _, e := range m.FeaturesSupported {
+			l += protohelpers.SizeOfVarint(uint64(e))
+		}
+		n += 1 + protohelpers.SizeOfVarint(uint64(l)) + l
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *CoordinationShardAssignmentsResponse) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -2796,6 +3015,228 @@ func (m *GetInfoResponse) UnmarshalVT(dAtA []byte) error {
 		}
 		switch fieldNum {
 		case 1:
+			if wireType == 0 {
+				var v Feature
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= Feature(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.FeaturesSupported = append(m.FeaturesSupported, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v Feature
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= Feature(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.FeaturesSupported = append(m.FeaturesSupported, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field FeaturesSupported", wireType)
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HandshakeRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HandshakeRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HandshakeRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InstanceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.InstanceId = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HandshakeResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HandshakeResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HandshakeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			m.Status = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Status |= HandshakeStatus(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
 			if wireType == 0 {
 				var v Feature
 				for shift := uint(0); ; shift += 7 {
@@ -5574,6 +6015,232 @@ func (m *GetInfoResponse) UnmarshalVTUnsafe(dAtA []byte) error {
 		}
 		switch fieldNum {
 		case 1:
+			if wireType == 0 {
+				var v Feature
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					v |= Feature(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				m.FeaturesSupported = append(m.FeaturesSupported, v)
+			} else if wireType == 2 {
+				var packedLen int
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return protohelpers.ErrIntOverflow
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					packedLen |= int(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				if packedLen < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return protohelpers.ErrInvalidLength
+				}
+				if postIndex > l {
+					return io.ErrUnexpectedEOF
+				}
+				var elementCount int
+				if elementCount != 0 && len(m.FeaturesSupported) == 0 {
+					m.FeaturesSupported = make([]Feature, 0, elementCount)
+				}
+				for iNdEx < postIndex {
+					var v Feature
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return protohelpers.ErrIntOverflow
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						v |= Feature(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					m.FeaturesSupported = append(m.FeaturesSupported, v)
+				}
+			} else {
+				return fmt.Errorf("proto: wrong wireType = %d for field FeaturesSupported", wireType)
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HandshakeRequest) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HandshakeRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HandshakeRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field InstanceId", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			var stringValue string
+			if intStringLen > 0 {
+				stringValue = unsafe.String(&dAtA[iNdEx], intStringLen)
+			}
+			m.InstanceId = stringValue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HandshakeResponse) UnmarshalVTUnsafe(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return protohelpers.ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HandshakeResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HandshakeResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Status", wireType)
+			}
+			m.Status = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Status |= HandshakeStatus(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
 			if wireType == 0 {
 				var v Feature
 				for shift := uint(0); ; shift += 7 {

--- a/common/rpc/client_pool.go
+++ b/common/rpc/client_pool.go
@@ -191,8 +191,8 @@ func (cp *clientPool) newConnection(target string) (*grpc.ClientConn, error) {
 
 	options := []grpc.DialOption{
 		grpc.WithTransportCredentials(tcs),
-		grpc.WithStreamInterceptor(grpcprometheus.StreamClientInterceptor),
-		grpc.WithUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
+		grpc.WithChainStreamInterceptor(grpcprometheus.StreamClientInterceptor),
+		grpc.WithChainUnaryInterceptor(grpcprometheus.UnaryClientInterceptor),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
 			PermitWithoutStream: defaultGrpcClientPermitWithoutStream,
 			Time:                defaultGrpcClientKeepAliveTime,

--- a/common/rpc/metadata.go
+++ b/common/rpc/metadata.go
@@ -1,0 +1,48 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func MetadataInjectionDialOptions(values map[string]string) []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithChainUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			return invoker(withOutgoingMetadata(ctx, values), method, req, reply, cc, opts...)
+		}),
+		grpc.WithChainStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+			return streamer(withOutgoingMetadata(ctx, values), desc, cc, method, opts...)
+		}),
+	}
+}
+
+func withOutgoingMetadata(ctx context.Context, values map[string]string) context.Context {
+	existing, _ := metadata.FromOutgoingContext(ctx)
+	merged := metadata.MD{}
+	if existing != nil {
+		merged = existing.Copy()
+	}
+	for key, value := range values {
+		merged.Set(key, value)
+	}
+	if len(merged) == 0 {
+		return ctx
+	}
+	return metadata.NewOutgoingContext(ctx, merged)
+}

--- a/common/rpc/metadata.go
+++ b/common/rpc/metadata.go
@@ -21,23 +21,25 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func MetadataInjectionDialOptions(values map[string]string) []grpc.DialOption {
+type MetadataValueSupplier = func() map[string]string
+
+func MetadataInjectionDialOptions(valuesSupplier MetadataValueSupplier) []grpc.DialOption {
 	return []grpc.DialOption{
 		grpc.WithChainUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-			return invoker(withOutgoingMetadata(ctx, values), method, req, reply, cc, opts...)
+			return invoker(withOutgoingMetadata(ctx, valuesSupplier), method, req, reply, cc, opts...)
 		}),
 		grpc.WithChainStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-			return streamer(withOutgoingMetadata(ctx, values), desc, cc, method, opts...)
+			return streamer(withOutgoingMetadata(ctx, valuesSupplier), desc, cc, method, opts...)
 		}),
 	}
 }
 
-func withOutgoingMetadata(ctx context.Context, values map[string]string) context.Context {
+func withOutgoingMetadata(ctx context.Context, valuesSupplier MetadataValueSupplier) context.Context {
 	merged, _ := metadata.FromOutgoingContext(ctx)
 	if merged == nil {
 		merged = metadata.MD{}
 	}
-	for key, value := range values {
+	for key, value := range valuesSupplier() {
 		merged.Set(key, value)
 	}
 	if len(merged) == 0 {

--- a/common/rpc/metadata.go
+++ b/common/rpc/metadata.go
@@ -33,10 +33,9 @@ func MetadataInjectionDialOptions(values map[string]string) []grpc.DialOption {
 }
 
 func withOutgoingMetadata(ctx context.Context, values map[string]string) context.Context {
-	existing, _ := metadata.FromOutgoingContext(ctx)
-	merged := metadata.MD{}
-	if existing != nil {
-		merged = existing.Copy()
+	merged, _ := metadata.FromOutgoingContext(ctx)
+	if merged == nil {
+		merged = metadata.MD{}
 	}
 	for key, value := range values {
 		merged.Set(key, value)

--- a/common/rpc/rpc_provider.go
+++ b/common/rpc/rpc_provider.go
@@ -55,8 +55,10 @@ func NewReplicationRpcProvider(tlsOptions *security.TLSOptions, manifest *manife
 		return nil, err
 	}
 	return &replicationRpcProvider{
-		pool: NewClientPool(tlsConf, nil, MetadataInjectionDialOptions(map[string]string{
-			constant.MetadataInstanceId: manifest.GetInstanceID(),
+		pool: NewClientPool(tlsConf, nil, MetadataInjectionDialOptions(func() map[string]string {
+			return map[string]string{
+				constant.MetadataInstanceId: manifest.GetInstanceID(),
+			}
 		})...),
 	}, nil
 }

--- a/common/rpc/rpc_provider.go
+++ b/common/rpc/rpc_provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/common/security"
+	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 )
 
 const rpcTimeout = 30 * time.Second
@@ -48,13 +49,15 @@ type replicationRpcProvider struct {
 	pool ClientPool
 }
 
-func NewReplicationRpcProvider(tlsOptions *security.TLSOptions) (ReplicationRpcProvider, error) {
+func NewReplicationRpcProvider(tlsOptions *security.TLSOptions, manifest *manifestpkg.Manifest) (ReplicationRpcProvider, error) {
 	tlsConf, err := tlsOptions.TryIntoClientTLSConf()
 	if err != nil {
 		return nil, err
 	}
 	return &replicationRpcProvider{
-		pool: NewClientPool(tlsConf, nil),
+		pool: NewClientPool(tlsConf, nil, MetadataInjectionDialOptions(map[string]string{
+			constant.MetadataInstanceId: manifest.GetInstanceID(),
+		})...),
 	}, nil
 }
 

--- a/common/rpc/rpc_provider.go
+++ b/common/rpc/rpc_provider.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"time"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/oxia-db/oxia/common/constant"
@@ -56,22 +55,9 @@ func NewReplicationRpcProvider(tlsOptions *security.TLSOptions, manifest *manife
 		return nil, err
 	}
 	return &replicationRpcProvider{
-		pool: NewClientPool(tlsConf, nil,
-			grpc.WithChainUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-				values := map[string]string{}
-				if instanceID := manifest.GetInstanceID(); instanceID != "" {
-					values[constant.MetadataInstanceId] = instanceID
-				}
-				return invoker(withOutgoingMetadata(ctx, values), method, req, reply, cc, opts...)
-			}),
-			grpc.WithChainStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
-				values := map[string]string{}
-				if instanceID := manifest.GetInstanceID(); instanceID != "" {
-					values[constant.MetadataInstanceId] = instanceID
-				}
-				return streamer(withOutgoingMetadata(ctx, values), desc, cc, method, opts...)
-			}),
-		),
+		pool: NewClientPool(tlsConf, nil, MetadataInjectionDialOptions(map[string]string{
+			constant.MetadataInstanceId: manifest.GetInstanceID(),
+		})...),
 	}, nil
 }
 

--- a/common/rpc/rpc_provider.go
+++ b/common/rpc/rpc_provider.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/oxia-db/oxia/common/constant"
@@ -55,9 +56,22 @@ func NewReplicationRpcProvider(tlsOptions *security.TLSOptions, manifest *manife
 		return nil, err
 	}
 	return &replicationRpcProvider{
-		pool: NewClientPool(tlsConf, nil, MetadataInjectionDialOptions(map[string]string{
-			constant.MetadataInstanceId: manifest.GetInstanceID(),
-		})...),
+		pool: NewClientPool(tlsConf, nil,
+			grpc.WithChainUnaryInterceptor(func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+				values := map[string]string{}
+				if instanceID := manifest.GetInstanceID(); instanceID != "" {
+					values[constant.MetadataInstanceId] = instanceID
+				}
+				return invoker(withOutgoingMetadata(ctx, values), method, req, reply, cc, opts...)
+			}),
+			grpc.WithChainStreamInterceptor(func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+				values := map[string]string{}
+				if instanceID := manifest.GetInstanceID(); instanceID != "" {
+					values[constant.MetadataInstanceId] = instanceID
+				}
+				return streamer(withOutgoingMetadata(ctx, values), desc, cc, method, opts...)
+			}),
+		),
 	}, nil
 }
 

--- a/oxiad/common/rpc/grpc_server.go
+++ b/oxiad/common/rpc/grpc_server.go
@@ -47,8 +47,13 @@ type GrpcServer interface {
 	Port() int
 }
 
+type Interceptors struct {
+	Unary  []grpc.UnaryServerInterceptor
+	Stream []grpc.StreamServerInterceptor
+}
+
 type GrpcProvider interface {
-	StartGrpcServer(name, bindAddress string, registerFunc func(grpc.ServiceRegistrar), tlsConf *tls.Config, options *auth.Options) (GrpcServer, error)
+	StartGrpcServer(name, bindAddress string, registerFunc func(grpc.ServiceRegistrar), tlsConf *tls.Config, options *auth.Options, interceptors *Interceptors) (GrpcServer, error)
 }
 
 var Default = &defaultProvider{}
@@ -56,8 +61,8 @@ var Default = &defaultProvider{}
 type defaultProvider struct {
 }
 
-func (*defaultProvider) StartGrpcServer(name, bindAddress string, registerFunc func(grpc.ServiceRegistrar), tlsConf *tls.Config, options *auth.Options) (GrpcServer, error) {
-	return newDefaultGrpcProvider(name, bindAddress, registerFunc, tlsConf, options)
+func (*defaultProvider) StartGrpcServer(name, bindAddress string, registerFunc func(grpc.ServiceRegistrar), tlsConf *tls.Config, options *auth.Options, interceptors *Interceptors) (GrpcServer, error) {
+	return newDefaultGrpcProvider(name, bindAddress, registerFunc, tlsConf, options, interceptors)
 }
 
 type defaultGrpcServer struct {
@@ -68,7 +73,7 @@ type defaultGrpcServer struct {
 }
 
 func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.ServiceRegistrar),
-	tlsConf *tls.Config, authOptions *auth.Options) (GrpcServer, error) {
+	tlsConf *tls.Config, authOptions *auth.Options, extraInterceptors *Interceptors) (GrpcServer, error) {
 	tcs := insecure.NewCredentials()
 	if tlsConf != nil {
 		tcs = credentials.NewTLS(tlsConf)
@@ -96,6 +101,10 @@ func newDefaultGrpcProvider(name, bindAddress string, registerFunc func(grpc.Ser
 		}
 		unaryInterceptors = append(unaryInterceptors, delegator.GetUnaryInterceptor())
 		streamInterceptors = append(streamInterceptors, delegator.GetStreamInterceptor())
+	}
+	if extraInterceptors != nil {
+		unaryInterceptors = append(unaryInterceptors, extraInterceptors.Unary...)
+		streamInterceptors = append(streamInterceptors, extraInterceptors.Stream...)
 	}
 
 	c := &defaultGrpcServer{

--- a/oxiad/common/rpc/instance_id.go
+++ b/oxiad/common/rpc/instance_id.go
@@ -34,7 +34,7 @@ var DefaultOpenInstanceIDMethods = []string{
 	grpc_health_v1.Health_Watch_FullMethodName,
 }
 
-func NewInstanceIDValidationInterceptors(manifest *manifestpkg.Manifest, excludedMethods ...string) *Interceptors {
+func NewGrpcInsIDVerifyInterceptors(manifest *manifestpkg.Manifest, excludedMethods ...string) *Interceptors {
 	validate := func(ctx context.Context, fullMethod string) error {
 		if matchesAnyMethod(fullMethod, excludedMethods) {
 			return nil

--- a/oxiad/common/rpc/instance_id.go
+++ b/oxiad/common/rpc/instance_id.go
@@ -17,6 +17,7 @@ package rpc
 import (
 	"context"
 
+	"github.com/emirpasic/gods/v2/sets/hashset"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -28,15 +29,15 @@ import (
 	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 )
 
-var DefaultOpenInstanceIDMethods = []string{
+var InsIDValidationMethodsWhiteList = hashset.New(
 	proto.OxiaCoordination_Handshake_FullMethodName,
 	grpc_health_v1.Health_Check_FullMethodName,
 	grpc_health_v1.Health_Watch_FullMethodName,
-}
+)
 
-func NewGrpcInsIDVerifyInterceptors(manifest *manifestpkg.Manifest, excludedMethods ...string) *Interceptors {
+func NewGrpcInsIDVerifyInterceptors(manifest *manifestpkg.Manifest) *Interceptors {
 	validate := func(ctx context.Context, fullMethod string) error {
-		if matchesAnyMethod(fullMethod, excludedMethods) {
+		if InsIDValidationMethodsWhiteList.Contains(fullMethod) {
 			return nil
 		}
 
@@ -93,13 +94,4 @@ func getIncomingInstanceID(ctx context.Context) (string, error) {
 	default:
 		return "", status.Errorf(codes.InvalidArgument, "oxia: instance id metadata %q must be provided only once", constant.MetadataInstanceId)
 	}
-}
-
-func matchesAnyMethod(fullMethod string, methods []string) bool {
-	for _, method := range methods {
-		if fullMethod == method {
-			return true
-		}
-	}
-	return false
 }

--- a/oxiad/common/rpc/instance_id.go
+++ b/oxiad/common/rpc/instance_id.go
@@ -1,0 +1,105 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
+)
+
+var DefaultOpenInstanceIDMethods = []string{
+	proto.OxiaCoordination_Handshake_FullMethodName,
+	grpc_health_v1.Health_Check_FullMethodName,
+	grpc_health_v1.Health_Watch_FullMethodName,
+}
+
+func NewInstanceIDValidationInterceptors(manifest *manifestpkg.Manifest, excludedMethods ...string) *Interceptors {
+	validate := func(ctx context.Context, fullMethod string) error {
+		if matchesAnyMethod(fullMethod, excludedMethods) {
+			return nil
+		}
+
+		expected := manifest.GetInstanceID()
+		if expected == "" {
+			return constant.ErrNotInitialized
+		}
+
+		instanceID, err := getIncomingInstanceID(ctx)
+		if err != nil {
+			return err
+		}
+		if instanceID != expected {
+			return status.Errorf(codes.PermissionDenied, "oxia: unexpected instance id %q", instanceID)
+		}
+		return nil
+	}
+
+	return &Interceptors{
+		Unary: []grpc.UnaryServerInterceptor{
+			func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+				if err := validate(ctx, info.FullMethod); err != nil {
+					return nil, err
+				}
+				return handler(ctx, req)
+			},
+		},
+		Stream: []grpc.StreamServerInterceptor{
+			func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+				if err := validate(ss.Context(), info.FullMethod); err != nil {
+					return err
+				}
+				return handler(srv, ss)
+			},
+		},
+	}
+}
+
+func getIncomingInstanceID(ctx context.Context) (string, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", status.Error(codes.Unauthenticated, "oxia: instance id not identified")
+	}
+
+	values := md.Get(constant.MetadataInstanceId)
+	switch len(values) {
+	case 0:
+		return "", status.Error(codes.Unauthenticated, "oxia: instance id not identified")
+	case 1:
+		if values[0] == "" {
+			return "", status.Error(codes.InvalidArgument, "oxia: instance id must not be empty")
+		}
+		return values[0], nil
+	default:
+		return "", status.Errorf(codes.InvalidArgument, "oxia: instance id metadata %q must be provided only once", constant.MetadataInstanceId)
+	}
+}
+
+func matchesAnyMethod(fullMethod string, methods []string) bool {
+	for _, method := range methods {
+		if fullMethod == method {
+			return true
+		}
+	}
+	return false
+}

--- a/oxiad/common/rpc/instance_id.go
+++ b/oxiad/common/rpc/instance_id.go
@@ -29,7 +29,7 @@ import (
 	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 )
 
-var InsIDValidationMethodsWhiteList = hashset.New(
+var insIDValidationMethodsWhiteList = hashset.New(
 	proto.OxiaCoordination_Handshake_FullMethodName,
 	grpc_health_v1.Health_Check_FullMethodName,
 	grpc_health_v1.Health_Watch_FullMethodName,
@@ -37,7 +37,7 @@ var InsIDValidationMethodsWhiteList = hashset.New(
 
 func NewGrpcInsIDVerifyInterceptors(manifest *manifestpkg.Manifest) *Interceptors {
 	validate := func(ctx context.Context, fullMethod string) error {
-		if InsIDValidationMethodsWhiteList.Contains(fullMethod) {
+		if insIDValidationMethodsWhiteList.Contains(fullMethod) {
 			return nil
 		}
 

--- a/oxiad/coordinator/controller/dataserver_controller.go
+++ b/oxiad/coordinator/controller/dataserver_controller.go
@@ -31,7 +31,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
-	commonio "github.com/oxia-db/oxia/common/io"
+	"github.com/oxia-db/oxia/common/commonio"
 
 	"github.com/oxia-db/oxia/common/metric"
 	"github.com/oxia-db/oxia/common/process"

--- a/oxiad/coordinator/controller/dataserver_controller.go
+++ b/oxiad/coordinator/controller/dataserver_controller.go
@@ -50,7 +50,6 @@ const (
 const (
 	healthCheckProbeInterval   = 2 * time.Second
 	healthCheckProbeTimeout    = 2 * time.Second
-	getInfoTimeout             = 10 * time.Second
 	defaultInitialRetryBackoff = 10 * time.Second
 )
 
@@ -80,6 +79,7 @@ type dataServerController struct {
 	cancel     context.CancelFunc
 	dataServer model.Server
 	rpc        rpc.Provider
+	insID      string
 	closed     atomic.Bool
 
 	statusLock        sync.RWMutex
@@ -289,10 +289,7 @@ func (n *dataServerController) becomeUnavailable() {
 }
 
 func (n *dataServerController) becomeAvailable() {
-	n.statusLock.Lock()
-	if n.status != NotRunning {
-		n.status = Running
-		n.statusLock.Unlock()
+	if n.Status() != NotRunning {
 		return
 	}
 
@@ -302,37 +299,39 @@ func (n *dataServerController) becomeAvailable() {
 	// dataServer went down, we interrupt the current stream when the ping on the dataServer fails
 	n.rpc.ClearPooledConnections(n.dataServer)
 	n.healthCheckBackoff.Reset()
-	n.status = Running
-	n.statusLock.Unlock()
 
-	// sync the latest info
+	// Bind the node before it can receive other internal traffic.
 	bo := commontime.NewBackOffWithInitialInterval(n.ctx, defaultInitialRetryBackoff)
-	_ = backoff.RetryNotify(func() error {
-		return n.syncDataServerInfo()
+	if err := backoff.RetryNotify(func() error {
+		handshake, err := n.rpc.Handshake(n.ctx, n.dataServer, &proto.HandshakeRequest{
+			InstanceId: n.insID,
+		})
+		if err != nil {
+			return err
+		}
+		switch handshake.Status {
+		case proto.HandshakeStatus_HANDSHAKE_STATUS_BOUND, proto.HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND:
+			n.supportedFeatures.Store(handshake.FeaturesSupported)
+			return nil
+		case proto.HandshakeStatus_HANDSHAKE_STATUS_MISMATCH:
+			return errors.New("data server instance id mismatch")
+		default:
+			return errors.Errorf("unexpected handshake status: %s", handshake.Status.String())
+		}
 	}, bo, func(err error, duration time.Duration) {
-		n.Warn("Failed to get data server info",
+		n.Warn("Failed to handshake with data server",
 			slog.Any("error", err),
 			slog.Duration("retry-after", duration),
 		)
-		n.becomeUnavailable()
-	})
-}
-
-func (n *dataServerController) syncDataServerInfo() error {
-	ctx, cancelFunc := context.WithTimeout(n.ctx, getInfoTimeout)
-	info, err := n.rpc.GetInfo(ctx, n.dataServer, &proto.GetInfoRequest{})
-	cancelFunc()
-	if err != nil {
-		code := grpcstatus.Code(err)
-		if code == codes.Unimplemented {
-			// The old data server might not have this endpoint, we should treat it as success.
-			n.Warn("the storage data server is too old without info endpoint.")
-			return nil
-		}
-		return err
+	}); err != nil {
+		return
 	}
-	n.supportedFeatures.Store(info.FeaturesSupported)
-	return nil
+
+	n.statusLock.Lock()
+	if n.status == NotRunning {
+		n.status = Running
+	}
+	n.statusLock.Unlock()
 }
 
 func (n *dataServerController) healthCheckHandler(response *grpc_health_v1.HealthCheckResponse, err error) error {
@@ -352,14 +351,16 @@ func (n *dataServerController) healthCheckHandler(response *grpc_health_v1.Healt
 func NewDataServerController(ctx context.Context, dataServer model.Server,
 	shardAssignmentsProvider ShardAssignmentsProvider,
 	dataServerEventListener DataServerEventListener,
-	rpcProvider rpc.Provider) DataServerController {
-	return newDataServerController(ctx, dataServer, shardAssignmentsProvider, dataServerEventListener, rpcProvider, defaultInitialRetryBackoff)
+	rpcProvider rpc.Provider,
+	insID string) DataServerController {
+	return newDataServerController(ctx, dataServer, shardAssignmentsProvider, dataServerEventListener, rpcProvider, insID, defaultInitialRetryBackoff)
 }
 
 func newDataServerController(ctx context.Context, dataServer model.Server,
 	shardAssignmentsProvider ShardAssignmentsProvider,
 	dataServerEventListener DataServerEventListener,
 	rpcProvider rpc.Provider,
+	insID string,
 	initialRetryBackoff time.Duration) DataServerController {
 	dataServerCtx, cancel := context.WithCancel(ctx)
 	dataServerID := dataServer.GetIdentifier()
@@ -375,6 +376,7 @@ func newDataServerController(ctx context.Context, dataServer model.Server,
 		ShardAssignmentsProvider: shardAssignmentsProvider,
 		DataServerEventListener:  dataServerEventListener,
 		rpc:                      rpcProvider,
+		insID:                    insID,
 		statusLock:               sync.RWMutex{},
 		status:                   NotRunning,
 		supportedFeatures:        supportedFeatures,

--- a/oxiad/coordinator/controller/dataserver_controller_test.go
+++ b/oxiad/coordinator/controller/dataserver_controller_test.go
@@ -39,7 +39,7 @@ func TestDataServerController_HealthCheck(t *testing.T) {
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, 1*time.Second)
+	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, "test-instance", 1*time.Second)
 
 	node := rpc.GetNode(addr)
 
@@ -71,7 +71,7 @@ func TestDataServerController_HealthCheck(t *testing.T) {
 	assert.NoError(t, nc.Close())
 }
 
-func TestDataServerController_GetInfoOnlyCalledOnStateTransition(t *testing.T) {
+func TestDataServerController_HandshakeOnlyCalledOnStateTransition(t *testing.T) {
 	addr := model.Server{
 		Public:   "my-server:9190",
 		Internal: "my-server:8190",
@@ -80,27 +80,27 @@ func TestDataServerController_GetInfoOnlyCalledOnStateTransition(t *testing.T) {
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, 1*time.Second)
+	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, "test-instance", 1*time.Second)
 
 	node := rpc.GetNode(addr)
 
-	// Wait for the initial GetInfo call that happens when the controller starts
+	// Wait for the initial Handshake call that happens when the controller starts
 	// (the controller starts in Running state, transitions through health check)
 	assert.Eventually(t, func() bool {
-		return node.getInfoCount.Load() >= 1
+		return node.handshakeCount.Load() >= 1
 	}, 10*time.Second, 100*time.Millisecond)
 
 	// Record the count after initial startup
-	initialCount := node.getInfoCount.Load()
+	initialCount := node.handshakeCount.Load()
 
 	// Wait for several health check cycles (health check runs every 2s)
-	// If GetInfo were called on every health check, we'd see the count increase
+	// If Handshake were called on every health check, we'd see the count increase
 	time.Sleep(5 * time.Second)
 
 	// The count should NOT have increased while the server stayed Running
-	countAfterWait := node.getInfoCount.Load()
+	countAfterWait := node.handshakeCount.Load()
 	assert.Equal(t, initialCount, countAfterWait,
-		"GetInfo should not be called repeatedly while server is already Running")
+		"Handshake should not be called repeatedly while server is already Running")
 
 	// Now simulate the server going down and coming back
 	node.healthClient.SetStatus(grpc_health_v1.HealthCheckResponse_NOT_SERVING)
@@ -112,21 +112,21 @@ func TestDataServerController_GetInfoOnlyCalledOnStateTransition(t *testing.T) {
 	// Bring the server back online
 	node.healthClient.SetStatus(grpc_health_v1.HealthCheckResponse_SERVING)
 
-	// GetInfo should have been called again for the NotRunning -> Running transition
+	// Handshake should have been called again for the NotRunning -> Running transition
 	assert.Eventually(t, func() bool {
-		return node.getInfoCount.Load() > countAfterWait
+		return node.handshakeCount.Load() > countAfterWait
 	}, 10*time.Second, 100*time.Millisecond,
-		"GetInfo should be called on state transition from NotRunning to Running")
+		"Handshake should be called on state transition from NotRunning to Running")
 
 	assert.Equal(t, Running, nc.Status())
-	countAfterRecovery := node.getInfoCount.Load()
+	countAfterRecovery := node.handshakeCount.Load()
 
 	// Wait again to confirm no further redundant calls
 	time.Sleep(5 * time.Second)
 
-	countAfterSecondWait := node.getInfoCount.Load()
+	countAfterSecondWait := node.handshakeCount.Load()
 	assert.Equal(t, countAfterRecovery, countAfterSecondWait,
-		"GetInfo should not be called repeatedly after recovery")
+		"Handshake should not be called repeatedly after recovery")
 
 	assert.NoError(t, nc.Close())
 }
@@ -140,7 +140,7 @@ func TestDataServerController_ShardsAssignments(t *testing.T) {
 	sap := newMockShardAssignmentsProvider()
 	nal := newMockNodeAvailabilityListener()
 	rpc := newMockRpcProvider()
-	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, 1*time.Second)
+	nc := newDataServerController(context.Background(), addr, sap, nal, rpc, "test-instance", 1*time.Second)
 
 	node := rpc.GetNode(addr)
 

--- a/oxiad/coordinator/controller/mock_test.go
+++ b/oxiad/coordinator/controller/mock_test.go
@@ -140,6 +140,9 @@ type mockPerNodeChannels struct {
 
 	// Feature negotiation support
 	supportedFeatures []proto.Feature
+	handshakeStatus   proto.HandshakeStatus
+	handshakeErr      error
+	handshakeCount    atomic.Int64
 	getInfoErr        error
 	getInfoCount      atomic.Int64
 }
@@ -348,6 +351,7 @@ func newMockPerNodeChannels() *mockPerNodeChannels {
 		shardAssignmentsStream: newMockShardAssignmentClient(),
 		healthClient:           newMockHealthClient(),
 		supportedFeatures:      feature.SupportedFeatures(), // Default to current version
+		handshakeStatus:        proto.HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND,
 	}
 }
 
@@ -358,6 +362,7 @@ func (m *mockPerNodeChannels) SetNodeFeatures(features []proto.Feature) {
 
 // SetOldNode simulates an old node that doesn't support the GetInfo RPC.
 func (m *mockPerNodeChannels) SetOldNode() {
+	m.handshakeErr = ErrNotImplement
 	m.getInfoErr = ErrNotImplement
 	m.supportedFeatures = nil
 }
@@ -365,6 +370,10 @@ func (m *mockPerNodeChannels) SetOldNode() {
 type mockRpcProvider struct {
 	sync.Mutex
 	channels map[string]*mockPerNodeChannels
+}
+
+func (r *mockRpcProvider) Close() error {
+	return nil
 }
 
 func (r *mockRpcProvider) ClearPooledConnections(node model.Server) {
@@ -393,6 +402,21 @@ func (r *mockRpcProvider) GetInfo(_ context.Context, node model.Server, _ *proto
 		return nil, n.getInfoErr
 	}
 	return &proto.GetInfoResponse{
+		FeaturesSupported: n.supportedFeatures,
+	}, nil
+}
+
+func (r *mockRpcProvider) Handshake(_ context.Context, node model.Server, _ *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	n := r.getNode(node)
+	n.handshakeCount.Add(1)
+	if n.handshakeErr != nil {
+		return nil, n.handshakeErr
+	}
+	return &proto.HandshakeResponse{
+		Status:            n.handshakeStatus,
 		FeaturesSupported: n.supportedFeatures,
 	}, nil
 }

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"log/slog"
 	"sync"
-	"time"
 
 	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 	"github.com/pkg/errors"
@@ -211,35 +210,6 @@ func (c *coordinator) findDataServerFeatures(dataServers []model.Server) map[str
 		}
 	}
 	return features
-}
-
-func (c *coordinator) waitForAllNodesToBeAvailable() {
-	c.Info("Waiting for all the nodes to be available")
-	for {
-		select {
-		case <-time.After(1 * time.Second):
-			c.Info("Start to check unavailable nodes")
-
-			var unavailableNodes []string
-			for nodeName, nc := range c.nodeControllers {
-				if nc.Status() != controller.Running {
-					unavailableNodes = append(unavailableNodes, nodeName)
-				}
-			}
-			if len(unavailableNodes) == 0 {
-				c.Info("All nodes are now available")
-				return
-			}
-
-			c.Info(
-				"A part of nodes is not available",
-				slog.Any("UnavailableNodeNames", unavailableNodes),
-			)
-		case <-c.ctx.Done():
-			// Give up if we're closing the coordinator
-			return
-		}
-	}
 }
 
 // selectNewEnsemble select a new server ensemble based on namespace policy and current cluster status.

--- a/oxiad/coordinator/coordinator.go
+++ b/oxiad/coordinator/coordinator.go
@@ -71,6 +71,7 @@ type coordinator struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
+	insID  string
 
 	statusResource resource.StatusResource
 	configResource resource.ClusterConfigResource
@@ -149,7 +150,14 @@ func (c *coordinator) ConfigChanged(newConfig *model.ClusterConfig) {
 			_ = nc.Close()
 			delete(c.drainingNodes, sa.GetIdentifier())
 		}
-		c.nodeControllers[sa.GetIdentifier()] = controller.NewDataServerController(c.ctx, sa, c, c, c.rpc)
+		c.nodeControllers[sa.GetIdentifier()] = controller.NewDataServerController(
+			c.ctx,
+			sa,
+			c,
+			c,
+			c.rpc,
+			c.insID,
+		)
 	}
 
 	// Check for nodes to remove
@@ -285,6 +293,7 @@ func (c *coordinator) Close() error {
 	for _, nc := range c.drainingNodes {
 		err = multierr.Append(err, nc.Close())
 	}
+	err = multierr.Append(err, c.rpc.Close())
 	return err
 }
 
@@ -731,7 +740,7 @@ func (c *coordinator) restartInProgressSplits(clusterStatus *model.ClusterStatus
 func NewCoordinator(meta metadata.Provider,
 	clusterConfigProvider func() (model.ClusterConfig, error),
 	clusterConfigNotificationsCh chan any,
-	rpcProvider rpc.Provider) (Coordinator, error) {
+	rpcProvider rpc.ProviderFactory) (Coordinator, error) {
 	c := &coordinator{
 		Logger: slog.With(
 			slog.String("component", "coordinator"),
@@ -744,7 +753,6 @@ func NewCoordinator(meta metadata.Provider,
 		splitControllers:      make(map[int64]*controller.SplitController),
 		nodeControllers:       make(map[string]controller.DataServerController),
 		drainingNodes:         make(map[string]controller.DataServerController),
-		rpc:                   rpcProvider,
 	}
 	c.ccrWg.Add(1)
 
@@ -775,23 +783,22 @@ func NewCoordinator(meta metadata.Provider,
 
 	clusterConfig := c.configResource.Load()
 	clusterStatus := c.statusResource.Load()
+	c.insID = clusterStatus.InstanceId
+
+	c.rpc = rpcProvider(c.insID)
 
 	// init node controller
 	for _, node := range clusterConfig.Servers {
-		c.nodeControllers[node.GetIdentifier()] = controller.NewDataServerController(c.ctx, node, c, c, c.rpc)
+		c.nodeControllers[node.GetIdentifier()] = controller.NewDataServerController(
+			c.ctx,
+			node,
+			c,
+			c,
+			c.rpc,
+			c.insID,
+		)
 	}
-
-	// init status
-	if clusterStatus == nil {
-		// Before initializing the cluster, it's better to make sure we
-		// have all the nodes available, otherwise the coordinator might be
-		// the first component in getting started and will print out a lot
-		// of error logs regarding failed leader elections
-		c.waitForAllNodesToBeAvailable()
-		c.Info("Performing initial assignment", slog.Any("clusterConfig", clusterConfig))
-	} else {
-		c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
-	}
+	c.Info("Checking cluster config", slog.Any("clusterConfig", clusterConfig))
 	clusterStatus, _, _ = c.statusResource.ApplyChanges(clusterConfig, c.selectNewEnsemble)
 
 	// init shard controller

--- a/oxiad/coordinator/metadata/metadata_file.go
+++ b/oxiad/coordinator/metadata/metadata_file.go
@@ -15,6 +15,7 @@
 package metadata
 
 import (
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -102,10 +103,15 @@ func (m *metadataProviderFile) Store(cs *model.ClusterStatus, expectedVersion Ve
 	}
 
 	newVersion = incrVersion(existingVersion)
-	if err := commonio.WriteJSONToFile(m.path, container{
+	newContent, err := json.Marshal(container{
 		ClusterStatus: cs,
 		Version:       newVersion,
-	}); err != nil {
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(m.path, newContent, 0600); err != nil {
 		return NotExists, err
 	}
 

--- a/oxiad/coordinator/metadata/metadata_file.go
+++ b/oxiad/coordinator/metadata/metadata_file.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/fslock"
 	"github.com/pkg/errors"
 
-	commonio "github.com/oxia-db/oxia/common/io"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 )
 
@@ -72,8 +71,7 @@ func (m *metadataProviderFile) WaitToBecomeLeader() error {
 }
 
 func (m *metadataProviderFile) Get() (cs *model.ClusterStatus, version Version, err error) {
-	mc := container{}
-	hasContent, err := commonio.ReadJSONFromFile(m.path, &mc)
+	content, err := os.ReadFile(m.path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, NotExists, nil
@@ -81,8 +79,13 @@ func (m *metadataProviderFile) Get() (cs *model.ClusterStatus, version Version, 
 		return nil, NotExists, err
 	}
 
-	if !hasContent {
+	if len(content) == 0 {
 		return nil, NotExists, nil
+	}
+
+	mc := container{}
+	if err = json.Unmarshal(content, &mc); err != nil {
+		return nil, NotExists, err
 	}
 
 	return mc.ClusterStatus, mc.Version, nil

--- a/oxiad/coordinator/metadata/metadata_file.go
+++ b/oxiad/coordinator/metadata/metadata_file.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/fslock"
 	"github.com/pkg/errors"
 
+	commonio "github.com/oxia-db/oxia/common/io"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 )
 
@@ -71,7 +72,8 @@ func (m *metadataProviderFile) WaitToBecomeLeader() error {
 }
 
 func (m *metadataProviderFile) Get() (cs *model.ClusterStatus, version Version, err error) {
-	content, err := os.ReadFile(m.path)
+	mc := container{}
+	hasContent, err := commonio.ReadJSONFromFile(m.path, &mc)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, NotExists, nil
@@ -79,13 +81,8 @@ func (m *metadataProviderFile) Get() (cs *model.ClusterStatus, version Version, 
 		return nil, NotExists, err
 	}
 
-	if len(content) == 0 {
+	if !hasContent {
 		return nil, NotExists, nil
-	}
-
-	mc := container{}
-	if err = json.Unmarshal(content, &mc); err != nil {
-		return nil, NotExists, err
 	}
 
 	return mc.ClusterStatus, mc.Version, nil

--- a/oxiad/coordinator/metadata/metadata_file.go
+++ b/oxiad/coordinator/metadata/metadata_file.go
@@ -15,7 +15,6 @@
 package metadata
 
 import (
-	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -103,15 +102,10 @@ func (m *metadataProviderFile) Store(cs *model.ClusterStatus, expectedVersion Ve
 	}
 
 	newVersion = incrVersion(existingVersion)
-	newContent, err := json.Marshal(container{
+	if err := commonio.WriteJSONToFile(m.path, container{
 		ClusterStatus: cs,
 		Version:       newVersion,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	if err := os.WriteFile(m.path, newContent, 0600); err != nil {
+	}); err != nil {
 		return NotExists, err
 	}
 

--- a/oxiad/coordinator/model/cluster_status.go
+++ b/oxiad/coordinator/model/cluster_status.go
@@ -112,6 +112,7 @@ type ClusterStatus struct {
 	Namespaces       map[string]NamespaceStatus `json:"namespaces" yaml:"namespaces"`
 	ShardIdGenerator int64                      `json:"shardIdGenerator" yaml:"shardIdGenerator"`
 	ServerIdx        uint32                     `json:"serverIdx" yaml:"serverIdx"`
+	InstanceId       string                     `json:"instanceId,omitempty" yaml:"instanceId,omitempty"`
 }
 
 func NewClusterStatus() *ClusterStatus {
@@ -119,6 +120,7 @@ func NewClusterStatus() *ClusterStatus {
 		Namespaces:       map[string]NamespaceStatus{},
 		ShardIdGenerator: 0,
 		ServerIdx:        0,
+		InstanceId:       "",
 	}
 }
 
@@ -166,6 +168,7 @@ func (c ClusterStatus) Clone() *ClusterStatus {
 		Namespaces:       make(map[string]NamespaceStatus),
 		ShardIdGenerator: c.ShardIdGenerator,
 		ServerIdx:        c.ServerIdx,
+		InstanceId:       c.InstanceId,
 	}
 
 	for name, n := range c.Namespaces {

--- a/oxiad/coordinator/resource/status_resource.go
+++ b/oxiad/coordinator/resource/status_resource.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/google/uuid"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
@@ -105,12 +106,7 @@ func WaitForCondition(ctx context.Context, sr StatusResource, triggerFn func(), 
 	}
 }
 
-// ensureLoaded loads the status from the metadata store if not already loaded.
-// Caller must hold s.lock for writing.
-func (s *status) ensureLoaded() {
-	if s.current != nil {
-		return
-	}
+func (s *status) doRecovery() {
 	_ = backoff.RetryNotify(func() error {
 		clusterStatus, version, err := s.metadata.Get()
 		if err != nil {
@@ -127,28 +123,24 @@ func (s *status) ensureLoaded() {
 		)
 	})
 	if s.current == nil {
-		s.current = &model.ClusterStatus{}
+		s.current = model.NewClusterStatus()
+	}
+	if s.current.InstanceId == "" {
+		clonedStatus := s.current.Clone()
+		clonedStatus.InstanceId = uuid.NewString()
+		s.Update(clonedStatus)
 	}
 }
 
 func (s *status) Load() *model.ClusterStatus {
 	s.lock.RLock()
-	if s.current != nil {
-		defer s.lock.RUnlock()
-		return s.current
-	}
-	s.lock.RUnlock()
-
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	s.ensureLoaded()
+	defer s.lock.RUnlock()
 	return s.current
 }
 
 func (s *status) ApplyChanges(config *model.ClusterConfig, ensembleSupplier EnsembleSupplier) (*model.ClusterStatus, map[int64]string, []int64) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	s.ensureLoaded()
 	newStatus := s.current.Clone()
 	shardsToAdd, shardsToDelete := util.ApplyClusterChanges(config, newStatus, ensembleSupplier)
 	if len(shardsToAdd) == 0 && len(shardsToDelete) == 0 {
@@ -285,6 +277,8 @@ func NewStatusResource(meta metadata.Provider) StatusResource {
 		current:          nil,
 		changeCh:         make(chan struct{}),
 	}
-	s.Load()
+
+	s.doRecovery()
+
 	return &s
 }

--- a/oxiad/coordinator/rpc/factory.go
+++ b/oxiad/coordinator/rpc/factory.go
@@ -1,0 +1,3 @@
+package rpc
+
+type ProviderFactory = func(instanceID string) Provider

--- a/oxiad/coordinator/rpc/factory.go
+++ b/oxiad/coordinator/rpc/factory.go
@@ -1,3 +1,11 @@
 package rpc
 
+import "crypto/tls"
+
 type ProviderFactory = func(instanceID string) Provider
+
+func NewRpcProviderFactory(tlsConf *tls.Config) ProviderFactory {
+	return func(instanceID string) Provider {
+		return NewRpcProvider(tlsConf, instanceID)
+	}
+}

--- a/oxiad/coordinator/rpc/factory.go
+++ b/oxiad/coordinator/rpc/factory.go
@@ -1,3 +1,17 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rpc
 
 import "crypto/tls"

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -16,14 +16,17 @@ package rpc
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"time"
 
+	"github.com/oxia-db/oxia/common/constant"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	grpcstatus "google.golang.org/grpc/status"
 
+	commonrpc "github.com/oxia-db/oxia/common/rpc"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
-
-	"github.com/oxia-db/oxia/common/rpc"
 
 	"github.com/oxia-db/oxia/common/proto"
 )
@@ -31,14 +34,16 @@ import (
 const rpcTimeout = 30 * time.Second
 
 type Provider interface {
+	io.Closer
+
 	PushShardAssignments(ctx context.Context, node model.Server) (proto.OxiaCoordination_PushShardAssignmentsClient, error)
 	NewTerm(ctx context.Context, node model.Server, req *proto.NewTermRequest) (*proto.NewTermResponse, error)
 	BecomeLeader(ctx context.Context, node model.Server, req *proto.BecomeLeaderRequest) (*proto.BecomeLeaderResponse, error)
 	AddFollower(ctx context.Context, node model.Server, req *proto.AddFollowerRequest) (*proto.AddFollowerResponse, error)
 	GetStatus(ctx context.Context, node model.Server, req *proto.GetStatusRequest) (*proto.GetStatusResponse, error)
 	DeleteShard(ctx context.Context, node model.Server, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error)
+	Handshake(ctx context.Context, node model.Server, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error)
 	RemoveObserver(ctx context.Context, node model.Server, req *proto.RemoveObserverRequest) (*proto.RemoveObserverResponse, error)
-	GetInfo(ctx context.Context, node model.Server, req *proto.GetInfoRequest) (*proto.GetInfoResponse, error)
 
 	GetHealthClient(node model.Server) (grpc_health_v1.HealthClient, io.Closer, error)
 
@@ -46,11 +51,19 @@ type Provider interface {
 }
 
 type rpcProvider struct {
-	pool rpc.ClientPool
+	pool commonrpc.ClientPool
 }
 
-func NewRpcProvider(pool rpc.ClientPool) Provider {
-	return &rpcProvider{pool: pool}
+func NewRpcProvider(tlsConf *tls.Config, instanceID string) Provider {
+	return &rpcProvider{
+		pool: commonrpc.NewClientPool(tlsConf, nil, commonrpc.MetadataInjectionDialOptions(map[string]string{
+			constant.MetadataInstanceId: instanceID,
+		})...),
+	}
+}
+
+func (r *rpcProvider) Close() error {
+	return r.pool.Close()
 }
 
 func (r *rpcProvider) PushShardAssignments(ctx context.Context, node model.Server) (proto.OxiaCoordination_PushShardAssignmentsClient, error) {
@@ -110,7 +123,7 @@ func (r *rpcProvider) GetStatus(ctx context.Context, node model.Server, req *pro
 	return client.GetStatus(ctx, req)
 }
 
-func (r *rpcProvider) GetInfo(ctx context.Context, node model.Server, req *proto.GetInfoRequest) (*proto.GetInfoResponse, error) {
+func (r *rpcProvider) Handshake(ctx context.Context, node model.Server, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
 	client, err := r.pool.GetCoordinationRpc(node.Internal)
 	if err != nil {
 		return nil, err
@@ -119,7 +132,23 @@ func (r *rpcProvider) GetInfo(ctx context.Context, node model.Server, req *proto
 	ctx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
 
-	return client.GetInfo(ctx, req)
+	res, err := client.Handshake(ctx, &proto.HandshakeRequest{
+		InstanceId: req.InstanceId,
+	})
+	if grpcstatus.Code(err) != codes.Unimplemented {
+		return res, err
+	}
+
+	// Deprecated GetInfo fallback for pre-handshake data servers. Remove this
+	// branch in the next major version together with the GetInfo RPC.
+	info, legacyErr := client.GetInfo(ctx, &proto.GetInfoRequest{})
+	if legacyErr != nil {
+		return nil, legacyErr
+	}
+	return &proto.HandshakeResponse{
+		Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND,
+		FeaturesSupported: info.FeaturesSupported,
+	}, nil
 }
 
 func (r *rpcProvider) DeleteShard(ctx context.Context, node model.Server, req *proto.DeleteShardRequest) (*proto.DeleteShardResponse, error) {

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -139,8 +139,9 @@ func (r *rpcProvider) Handshake(ctx context.Context, node model.Server, req *pro
 		return res, err
 	}
 
-	// Deprecated GetInfo fallback for pre-handshake data servers. Remove this
-	// branch in the next major version together with the GetInfo RPC.
+	// Deprecated GetInfo fallback for older dataservers that do not implement
+	// Handshake. Remove this branch in the next major version together with the
+	// GetInfo RPC.
 	info, legacyErr := client.GetInfo(ctx, &proto.GetInfoRequest{})
 	if legacyErr != nil {
 		return nil, legacyErr

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -20,10 +20,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/oxia-db/oxia/common/constant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	grpcstatus "google.golang.org/grpc/status"
+
+	"github.com/oxia-db/oxia/common/constant"
 
 	commonrpc "github.com/oxia-db/oxia/common/rpc"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
@@ -142,7 +143,7 @@ func (r *rpcProvider) Handshake(ctx context.Context, node model.Server, req *pro
 	// Deprecated GetInfo fallback for older dataservers that do not implement
 	// Handshake. Remove this branch in the next major version together with the
 	// GetInfo RPC.
-	info, legacyErr := client.GetInfo(ctx, &proto.GetInfoRequest{})
+	info, legacyErr := client.GetInfo(ctx, &proto.GetInfoRequest{}) //nolint:staticcheck // Deprecated rolling-upgrade fallback for older dataservers.
 	if legacyErr != nil {
 		return nil, legacyErr
 	}

--- a/oxiad/coordinator/rpc/rpc_provider.go
+++ b/oxiad/coordinator/rpc/rpc_provider.go
@@ -57,8 +57,10 @@ type rpcProvider struct {
 
 func NewRpcProvider(tlsConf *tls.Config, instanceID string) Provider {
 	return &rpcProvider{
-		pool: commonrpc.NewClientPool(tlsConf, nil, commonrpc.MetadataInjectionDialOptions(map[string]string{
-			constant.MetadataInstanceId: instanceID,
+		pool: commonrpc.NewClientPool(tlsConf, nil, commonrpc.MetadataInjectionDialOptions(func() map[string]string {
+			return map[string]string{
+				constant.MetadataInstanceId: instanceID,
+			}
 		})...),
 	}
 }

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/mitchellh/mapstructure"
+	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"go.uber.org/multierr"
@@ -42,9 +43,6 @@ import (
 
 	"github.com/oxia-db/oxia/common/proto"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
-	coordinatorrpc "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
-
-	"github.com/oxia-db/oxia/common/rpc"
 )
 
 type GrpcServer struct {
@@ -59,7 +57,6 @@ type GrpcServer struct {
 	adminServer  rpc2.GrpcServer
 	healthServer *health.Server
 	coordinator  Coordinator
-	clientPool   rpc.ClientPool
 	metrics      *metric.PrometheusMetrics
 }
 
@@ -175,20 +172,19 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	}
 	grpcServer, err := rpc2.Default.StartGrpcServer("coordinator", internalServer.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		grpc_health_v1.RegisterHealthServer(registrar, healthServer)
-	}, internalServerTLS, &internalServer.Auth)
+	}, internalServerTLS, &internalServer.Auth, nil)
 	if err != nil {
 		return nil, err
 	}
-
 	controller := &options.Controller
 	controllerTLS, err := controller.TLS.TryIntoClientTLSConf()
 	if err != nil {
 		return nil, err
 	}
-	clientPool := rpc.NewClientPool(controllerTLS, nil)
-	rpcClient := coordinatorrpc.NewRpcProvider(clientPool)
 
-	coordinatorInstance, err := NewCoordinator(metadataProvider, clusterConfigProvider, clusterConfigChangeNotifications, rpcClient) //nolint:contextcheck
+	coordinatorInstance, err := NewCoordinator(metadataProvider, clusterConfigProvider, clusterConfigChangeNotifications, func(instanceID string) rpc.Provider {
+		return rpc.NewRpcProvider(controllerTLS, instanceID)
+	}) //nolint:contextcheck
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +201,7 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 	)
 	adminGrpcServer, err := rpc2.Default.StartGrpcServer("admin", adminSv.BindAddress, func(registrar grpc.ServiceRegistrar) { //nolint:contextcheck
 		proto.RegisterOxiaAdminServer(registrar, admin)
-	}, adminSvTLS, &adminSv.Auth)
+	}, adminSvTLS, &adminSv.Auth, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +220,6 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 		grpcServer:       grpcServer,
 		adminServer:      adminGrpcServer,
 		healthServer:     healthServer,
-		clientPool:       clientPool,
 		coordinator:      coordinatorInstance,
 		metrics:          metricsServer,
 	}
@@ -275,7 +270,6 @@ func (s *GrpcServer) Close() error {
 	var err error
 	s.healthServer.Shutdown()
 	err = multierr.Combine(
-		s.clientPool.Close(),
 		s.grpcServer.Close(),
 		s.adminServer.Close(),
 		s.coordinator.Close(),

--- a/oxiad/coordinator/server.go
+++ b/oxiad/coordinator/server.go
@@ -22,13 +22,14 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/mitchellh/mapstructure"
-	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"go.uber.org/multierr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
 	"github.com/oxia-db/oxia/common/process"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
@@ -182,9 +183,9 @@ func NewGrpcServer(parent context.Context, watchableOptions *commonoption.Watch[
 		return nil, err
 	}
 
-	coordinatorInstance, err := NewCoordinator(metadataProvider, clusterConfigProvider, clusterConfigChangeNotifications, func(instanceID string) rpc.Provider {
+	coordinatorInstance, err := NewCoordinator(metadataProvider, clusterConfigProvider, clusterConfigChangeNotifications, func(instanceID string) rpc.Provider { //nolint:contextcheck // Provider factory is configuration-only and does not accept a caller context.
 		return rpc.NewRpcProvider(controllerTLS, instanceID)
-	}) //nolint:contextcheck
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller"
 	dserror "github.com/oxia-db/oxia/oxiad/dataserver/errors"
+	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 
 	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
 
@@ -52,13 +53,15 @@ type internalRpcServer struct {
 
 	shardsDirector       controller.ShardsDirector
 	assignmentDispatcher assignment.ShardAssignmentsDispatcher
+	manifest             *manifestpkg.Manifest
 	grpcServer           rpc2.GrpcServer
 	healthServer         rpc2.HealthServer
 	log                  *slog.Logger
 }
 
 func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector,
-	assignmentDispatcher assignment.ShardAssignmentsDispatcher, healthServer rpc2.HealthServer, tlsConf *tls.Config, authOptions *auth.Options) (*internalRpcServer, error) {
+	assignmentDispatcher assignment.ShardAssignmentsDispatcher, healthServer rpc2.HealthServer,
+	tlsConf *tls.Config, authOptions *auth.Options, manifest *manifestpkg.Manifest) (*internalRpcServer, error) {
 	if authOptions == nil {
 		authOptions = &auth.Disabled
 	}
@@ -66,6 +69,7 @@ func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, sh
 	server := &internalRpcServer{
 		shardsDirector:       shardsDirector,
 		assignmentDispatcher: assignmentDispatcher,
+		manifest:             manifest,
 		healthServer:         healthServer,
 		log: slog.With(
 			slog.String("component", "internal-rpc-server"),
@@ -73,11 +77,15 @@ func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, sh
 	}
 
 	var err error
+	interceptors := rpc2.NewInstanceIDValidationInterceptors(
+		server.manifest,
+		rpc2.DefaultOpenInstanceIDMethods...,
+	)
 	server.grpcServer, err = grpcProvider.StartGrpcServer("internal", bindAddress, func(registrar grpc.ServiceRegistrar) {
 		proto.RegisterOxiaCoordinationServer(registrar, server)
 		proto.RegisterOxiaLogReplicationServer(registrar, server)
 		grpc_health_v1.RegisterHealthServer(registrar, server.healthServer)
-	}, tlsConf, authOptions)
+	}, tlsConf, authOptions, interceptors)
 	if err != nil {
 		return nil, err
 	}
@@ -132,6 +140,48 @@ func (s *internalRpcServer) PushShardAssignments(srv proto.OxiaCoordination_Push
 	}
 
 	return err
+}
+
+func (s *internalRpcServer) Handshake(c context.Context, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+	log := s.log.With(
+		slog.Any("request", req),
+		slog.String("peer", rpc.GetPeer(c)),
+	)
+
+	log.Info("Received Handshake request")
+
+	if req.InstanceId == "" {
+		return nil, status.Error(codes.InvalidArgument, "instance id must not be empty")
+	}
+
+	currentInstanceID := s.manifest.GetInstanceID()
+	switch {
+	case currentInstanceID == "":
+		if err := s.manifest.SetInstanceID(req.InstanceId); err != nil {
+			if errors.Is(err, manifestpkg.ErrInstanceIDMismatch) {
+				return &proto.HandshakeResponse{
+					Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_MISMATCH,
+					FeaturesSupported: feature.SupportedFeatures(),
+				}, nil
+			}
+			log.Warn("Failed to bind instance id", slog.Any("error", err))
+			return nil, err
+		}
+		return &proto.HandshakeResponse{
+			Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_BOUND,
+			FeaturesSupported: feature.SupportedFeatures(),
+		}, nil
+	case currentInstanceID == req.InstanceId:
+		return &proto.HandshakeResponse{
+			Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND,
+			FeaturesSupported: feature.SupportedFeatures(),
+		}, nil
+	default:
+		return &proto.HandshakeResponse{
+			Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_MISMATCH,
+			FeaturesSupported: feature.SupportedFeatures(),
+		}, nil
+	}
 }
 
 func (s *internalRpcServer) NewTerm(c context.Context, req *proto.NewTermRequest) (*proto.NewTermResponse, error) {
@@ -279,6 +329,9 @@ func (s *internalRpcServer) RemoveObserver(c context.Context, req *proto.RemoveO
 	return res, err
 }
 
+// GetInfo is kept only for rolling-upgrade compatibility with older
+// coordinators. New coordinators should use Handshake instead and remove this
+// endpoint in the next major version.
 func (s *internalRpcServer) GetInfo(c context.Context, req *proto.GetInfoRequest) (*proto.GetInfoResponse, error) {
 	log := s.log.With(
 		slog.Any("request", req),

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -153,8 +153,8 @@ func (s *internalRpcServer) Handshake(c context.Context, req *proto.HandshakeReq
 	}
 
 	currentInstanceID := s.manifest.GetInstanceID()
-	switch {
-	case currentInstanceID == "":
+	switch currentInstanceID {
+	case "":
 		if err := s.manifest.SetInstanceID(req.InstanceId); err != nil {
 			if errors.Is(err, manifestpkg.ErrInstanceIDMismatch) {
 				return &proto.HandshakeResponse{
@@ -169,7 +169,7 @@ func (s *internalRpcServer) Handshake(c context.Context, req *proto.HandshakeReq
 			Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_BOUND,
 			FeaturesSupported: feature.SupportedFeatures(),
 		}, nil
-	case currentInstanceID == req.InstanceId:
+	case req.InstanceId:
 		return &proto.HandshakeResponse{
 			Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND,
 			FeaturesSupported: feature.SupportedFeatures(),

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -32,7 +32,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/common/feature"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 
-	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
+	dcommonrpc "github.com/oxia-db/oxia/oxiad/common/rpc"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller"
@@ -54,13 +54,13 @@ type internalRpcServer struct {
 	shardsDirector       controller.ShardsDirector
 	assignmentDispatcher assignment.ShardAssignmentsDispatcher
 	manifest             *manifestpkg.Manifest
-	grpcServer           rpc2.GrpcServer
-	healthServer         rpc2.HealthServer
+	grpcServer           dcommonrpc.GrpcServer
+	healthServer         dcommonrpc.HealthServer
 	log                  *slog.Logger
 }
 
-func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector,
-	assignmentDispatcher assignment.ShardAssignmentsDispatcher, healthServer rpc2.HealthServer,
+func newInternalRpcServer(grpcProvider dcommonrpc.GrpcProvider, bindAddress string, shardsDirector controller.ShardsDirector,
+	assignmentDispatcher assignment.ShardAssignmentsDispatcher, healthServer dcommonrpc.HealthServer,
 	tlsConf *tls.Config, authOptions *auth.Options, manifest *manifestpkg.Manifest) (*internalRpcServer, error) {
 	if authOptions == nil {
 		authOptions = &auth.Disabled
@@ -77,15 +77,13 @@ func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, sh
 	}
 
 	var err error
-	interceptors := rpc2.NewGrpcInsIDVerifyInterceptors(
-		server.manifest,
-		rpc2.DefaultOpenInstanceIDMethods...,
-	)
 	server.grpcServer, err = grpcProvider.StartGrpcServer("internal", bindAddress, func(registrar grpc.ServiceRegistrar) {
 		proto.RegisterOxiaCoordinationServer(registrar, server)
 		proto.RegisterOxiaLogReplicationServer(registrar, server)
 		grpc_health_v1.RegisterHealthServer(registrar, server.healthServer)
-	}, tlsConf, authOptions, interceptors)
+	}, tlsConf, authOptions, dcommonrpc.NewGrpcInsIDVerifyInterceptors(
+		server.manifest,
+	))
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -327,9 +327,10 @@ func (s *internalRpcServer) RemoveObserver(c context.Context, req *proto.RemoveO
 	return res, err
 }
 
-// GetInfo is kept only for rolling-upgrade compatibility with older
-// coordinators. New coordinators should use Handshake instead and remove this
-// endpoint in the next major version.
+// GetInfo is a deprecated legacy endpoint kept for rolling-upgrade
+// compatibility. New coordinators should use Handshake, and this endpoint
+// still follows the normal instance-id validation flow until removal in the
+// next major version.
 func (s *internalRpcServer) GetInfo(c context.Context, req *proto.GetInfoRequest) (*proto.GetInfoResponse, error) {
 	log := s.log.With(
 		slog.Any("request", req),

--- a/oxiad/dataserver/internal_rpc_server.go
+++ b/oxiad/dataserver/internal_rpc_server.go
@@ -77,7 +77,7 @@ func newInternalRpcServer(grpcProvider rpc2.GrpcProvider, bindAddress string, sh
 	}
 
 	var err error
-	interceptors := rpc2.NewInstanceIDValidationInterceptors(
+	interceptors := rpc2.NewGrpcInsIDVerifyInterceptors(
 		server.manifest,
 		rpc2.DefaultOpenInstanceIDMethods...,
 	)

--- a/oxiad/dataserver/internal_rpc_server_test.go
+++ b/oxiad/dataserver/internal_rpc_server_test.go
@@ -129,7 +129,7 @@ func TestInternalGetInfoRejectedWhileUninitialized(t *testing.T) {
 	cnx := newInternalTestConn(t, server, "")
 
 	client := proto.NewOxiaCoordinationClient(cnx)
-	_, err := client.GetInfo(context.Background(), &proto.GetInfoRequest{})
+	_, err := client.GetInfo(context.Background(), &proto.GetInfoRequest{}) //nolint:staticcheck // Deprecated endpoint coverage.
 	require.Error(t, err)
 	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
 }
@@ -197,7 +197,7 @@ func TestInternalGetInfoAcceptsMatchingInstanceID(t *testing.T) {
 	cnx := newInternalTestConn(t, server, "cluster-a")
 
 	client := proto.NewOxiaCoordinationClient(cnx)
-	response, err := client.GetInfo(context.Background(), &proto.GetInfoRequest{})
+	response, err := client.GetInfo(context.Background(), &proto.GetInfoRequest{}) //nolint:staticcheck // Deprecated endpoint coverage.
 	require.NoError(t, err)
 	assert.NotNil(t, response)
 }

--- a/oxiad/dataserver/internal_rpc_server_test.go
+++ b/oxiad/dataserver/internal_rpc_server_test.go
@@ -17,34 +17,197 @@ package dataserver
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
+	grpcstatus "google.golang.org/grpc/status"
 
+	"github.com/oxia-db/oxia/common/constant"
+	"github.com/oxia-db/oxia/common/proto"
+	clientrpc "github.com/oxia-db/oxia/common/rpc"
 	rpc2 "github.com/oxia-db/oxia/oxiad/common/rpc"
 	"github.com/oxia-db/oxia/oxiad/common/rpc/auth"
-
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
+	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 )
 
-func TestInternalHealthCheck(t *testing.T) {
+type internalTestAssignmentDispatcher struct {
+	pushShardAssignments func(proto.OxiaCoordination_PushShardAssignmentsServer) error
+}
+
+func (*internalTestAssignmentDispatcher) Close() error { return nil }
+
+func (*internalTestAssignmentDispatcher) Initialized() bool {
+	return false
+}
+
+func (t *internalTestAssignmentDispatcher) PushShardAssignments(stream proto.OxiaCoordination_PushShardAssignmentsServer) error {
+	if t.pushShardAssignments != nil {
+		return t.pushShardAssignments(stream)
+	}
+	return stream.SendAndClose(&proto.CoordinationShardAssignmentsResponse{})
+}
+
+func (*internalTestAssignmentDispatcher) RegisterForUpdates(*proto.ShardAssignmentsRequest, assignment.Client) error {
+	panic("unexpected call")
+}
+
+func (*internalTestAssignmentDispatcher) GetLeader(int64) string { return "" }
+
+func (*internalTestAssignmentDispatcher) HasAuthority(string) bool { return false }
+
+func newTestManifest(t *testing.T, instanceID string) *manifestpkg.Manifest {
+	t.Helper()
+
+	manifest, err := manifestpkg.NewManifest(t.TempDir())
+	require.NoError(t, err)
+	if instanceID == "" {
+		return manifest
+	}
+
+	require.NoError(t, manifest.SetInstanceID(instanceID))
+	return manifest
+}
+
+func newInternalTestServer(t *testing.T, manifest *manifestpkg.Manifest, dispatcher *internalTestAssignmentDispatcher) *internalRpcServer {
+	t.Helper()
+
 	healthServer := rpc2.NewClosableHealthServer(t.Context())
 	server, err := newInternalRpcServer(rpc2.Default, "localhost:0", nil,
-		assignment.NewShardAssignmentDispatcher(healthServer), healthServer, nil, &auth.Disabled)
-	assert.NoError(t, err)
+		dispatcher, healthServer, nil, &auth.Disabled, manifest)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, server.Close())
+		assert.NoError(t, healthServer.Close())
+	})
+
+	return server
+}
+
+func newInternalTestConn(t *testing.T, server *internalRpcServer, instanceID string) *grpc.ClientConn {
+	t.Helper()
 
 	target := fmt.Sprintf("localhost:%d", server.grpcServer.Port())
-	cnx, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	options := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	if instanceID != "" {
+		options = append(options, clientrpc.MetadataInjectionDialOptions(map[string]string{
+			constant.MetadataInstanceId: instanceID,
+		})...)
+	}
+
+	cnx, err := grpc.NewClient(target, options...)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, cnx.Close())
+	})
+
+	return cnx
+}
+
+func TestInternalHealthCheckRemainsOpenWhileUninitialized(t *testing.T) {
+	server := newInternalTestServer(t, newTestManifest(t, ""), &internalTestAssignmentDispatcher{})
+	cnx := newInternalTestConn(t, server, "")
 
 	client := grpc_health_v1.NewHealthClient(cnx)
-
-	request := &grpc_health_v1.HealthCheckRequest{Service: ""}
-	response, err := client.Check(context.Background(), request)
-	assert.NoError(t, err)
-
+	response, err := client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{Service: ""})
+	require.NoError(t, err)
 	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, response.Status)
+}
+
+func TestInternalGetInfoRejectedWhileUninitialized(t *testing.T) {
+	server := newInternalTestServer(t, newTestManifest(t, ""), &internalTestAssignmentDispatcher{})
+	cnx := newInternalTestConn(t, server, "")
+
+	client := proto.NewOxiaCoordinationClient(cnx)
+	_, err := client.GetInfo(context.Background(), &proto.GetInfoRequest{})
+	require.Error(t, err)
+	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
+}
+
+func TestInternalHandshakeBindsInstanceID(t *testing.T) {
+	manifest := newTestManifest(t, "")
+	server := newInternalTestServer(t, manifest, &internalTestAssignmentDispatcher{})
+	cnx := newInternalTestConn(t, server, "")
+
+	client := proto.NewOxiaCoordinationClient(cnx)
+	response, err := client.Handshake(context.Background(), &proto.HandshakeRequest{InstanceId: "cluster-a"})
+	require.NoError(t, err)
+	assert.Equal(t, proto.HandshakeStatus_HANDSHAKE_STATUS_BOUND, response.Status)
+	assert.Equal(t, "cluster-a", manifest.GetInstanceID())
+}
+
+func TestInternalProtectedRpcRejectedWhileUninitialized(t *testing.T) {
+	server := newInternalTestServer(t, newTestManifest(t, ""), &internalTestAssignmentDispatcher{})
+	cnx := newInternalTestConn(t, server, "")
+
+	client := proto.NewOxiaCoordinationClient(cnx)
+	stream, err := client.PushShardAssignments(context.Background())
+	require.NoError(t, err)
+
+	_, err = stream.CloseAndRecv()
+	require.Error(t, err)
+	assert.Equal(t, constant.CodeNotInitialized, grpcstatus.Code(err))
+}
+
+func TestInternalReplicateRejectsWrongInstanceID(t *testing.T) {
+	server := newInternalTestServer(t, newTestManifest(t, "cluster-a"), &internalTestAssignmentDispatcher{})
+	cnx := newInternalTestConn(t, server, "cluster-b")
+
+	client := proto.NewOxiaLogReplicationClient(cnx)
+	stream, err := client.Replicate(context.Background())
+	require.NoError(t, err)
+
+	_, err = stream.Recv()
+	require.Error(t, err)
+	assert.Equal(t, codes.PermissionDenied, grpcstatus.Code(err))
+}
+
+func TestInternalPushShardAssignmentsAcceptsMatchingInstanceID(t *testing.T) {
+	var called atomic.Bool
+	server := newInternalTestServer(t, newTestManifest(t, "cluster-a"), &internalTestAssignmentDispatcher{
+		pushShardAssignments: func(stream proto.OxiaCoordination_PushShardAssignmentsServer) error {
+			called.Store(true)
+			return stream.SendAndClose(&proto.CoordinationShardAssignmentsResponse{})
+		},
+	})
+	cnx := newInternalTestConn(t, server, "cluster-a")
+
+	client := proto.NewOxiaCoordinationClient(cnx)
+	stream, err := client.PushShardAssignments(context.Background())
+	require.NoError(t, err)
+
+	response, err := stream.CloseAndRecv()
+	require.NoError(t, err)
+	assert.NotNil(t, response)
+	assert.True(t, called.Load())
+}
+
+func TestInternalGetInfoAcceptsMatchingInstanceID(t *testing.T) {
+	server := newInternalTestServer(t, newTestManifest(t, "cluster-a"), &internalTestAssignmentDispatcher{})
+	cnx := newInternalTestConn(t, server, "cluster-a")
+
+	client := proto.NewOxiaCoordinationClient(cnx)
+	response, err := client.GetInfo(context.Background(), &proto.GetInfoRequest{})
+	require.NoError(t, err)
+	assert.NotNil(t, response)
+}
+
+func TestInternalHandshakeReturnsMismatchForDifferentInstanceID(t *testing.T) {
+	server := newInternalTestServer(t, newTestManifest(t, "cluster-a"), &internalTestAssignmentDispatcher{})
+	cnx := newInternalTestConn(t, server, "")
+
+	client := proto.NewOxiaCoordinationClient(cnx)
+	response, err := client.Handshake(context.Background(), &proto.HandshakeRequest{InstanceId: "cluster-b"})
+	require.NoError(t, err)
+	assert.Equal(t, proto.HandshakeStatus_HANDSHAKE_STATUS_MISMATCH, response.Status)
 }

--- a/oxiad/dataserver/internal_rpc_server_test.go
+++ b/oxiad/dataserver/internal_rpc_server_test.go
@@ -99,8 +99,10 @@ func newInternalTestConn(t *testing.T, server *internalRpcServer, instanceID str
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
 	if instanceID != "" {
-		options = append(options, clientrpc.MetadataInjectionDialOptions(map[string]string{
-			constant.MetadataInstanceId: instanceID,
+		options = append(options, clientrpc.MetadataInjectionDialOptions(func() map[string]string {
+			return map[string]string{
+				constant.MetadataInstanceId: instanceID,
+			}
 		})...)
 	}
 

--- a/oxiad/dataserver/manifest/manifest.go
+++ b/oxiad/dataserver/manifest/manifest.go
@@ -1,0 +1,93 @@
+package manifest
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+
+	commonio "github.com/oxia-db/oxia/common/io"
+)
+
+const filename = "MANIFEST"
+
+var ErrInstanceIDMismatch = errors.New("instance id mismatch")
+
+type Document struct {
+	InstanceID string `json:"instance_id,omitempty"`
+}
+
+type Manifest struct {
+	path string
+	mu   sync.Mutex
+
+	document atomic.Pointer[Document]
+}
+
+func NewManifest(dir string) (*Manifest, error) {
+	m := &Manifest{
+		path: filepath.Join(dir, filename),
+	}
+	if err := m.doRecovery(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *Manifest) doRecovery() error {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			doc := &Document{}
+			if err := commonio.WriteJSONToFile(m.path, doc); err != nil {
+				return err
+			}
+			m.document.Store(doc)
+			return nil
+		}
+		return err
+	}
+
+	doc := &Document{}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, doc); err != nil {
+			return err
+		}
+	}
+	m.document.Store(doc)
+	return nil
+}
+
+func (m *Manifest) GetInstanceID() string {
+	doc := m.document.Load()
+	if doc == nil || doc.InstanceID == "" {
+		return ""
+	}
+	return doc.InstanceID
+}
+
+func (m *Manifest) SetInstanceID(id string) error {
+	if id == "" {
+		return errors.New("instance id must not be empty")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	current := m.document.Load()
+	switch {
+	case current == nil || current.InstanceID == "":
+		next := &Document{InstanceID: id}
+		if err := commonio.WriteJSONToFile(m.path, next); err != nil {
+			return err
+		}
+		m.document.Store(next)
+		return nil
+	case current.InstanceID == id:
+		return nil
+	default:
+		return ErrInstanceIDMismatch
+	}
+}

--- a/oxiad/dataserver/manifest/manifest.go
+++ b/oxiad/dataserver/manifest/manifest.go
@@ -1,3 +1,17 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package manifest
 
 import (

--- a/oxiad/dataserver/manifest/manifest.go
+++ b/oxiad/dataserver/manifest/manifest.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	commonio "github.com/oxia-db/oxia/common/io"
+	"github.com/oxia-db/oxia/common/commonio"
 )
 
 const filename = "MANIFEST"

--- a/oxiad/dataserver/manifest/manifest.go
+++ b/oxiad/dataserver/manifest/manifest.go
@@ -1,7 +1,6 @@
 package manifest
 
 import (
-	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -37,10 +36,10 @@ func NewManifest(dir string) (*Manifest, error) {
 }
 
 func (m *Manifest) doRecovery() error {
-	data, err := os.ReadFile(m.path)
+	doc := &Document{}
+	_, err := commonio.ReadJSONFromFile(m.path, doc)
 	if err != nil {
 		if os.IsNotExist(err) {
-			doc := &Document{}
 			if err := commonio.WriteJSONToFile(m.path, doc); err != nil {
 				return err
 			}
@@ -50,12 +49,6 @@ func (m *Manifest) doRecovery() error {
 		return err
 	}
 
-	doc := &Document{}
-	if len(data) > 0 {
-		if err := json.Unmarshal(data, doc); err != nil {
-			return err
-		}
-	}
 	m.document.Store(doc)
 	return nil
 }

--- a/oxiad/dataserver/manifest/manifest_test.go
+++ b/oxiad/dataserver/manifest/manifest_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023-2025 The Oxia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package manifest
 
 import (

--- a/oxiad/dataserver/manifest/manifest_test.go
+++ b/oxiad/dataserver/manifest/manifest_test.go
@@ -1,0 +1,27 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewManifestCreatesDirectoryAndFile(t *testing.T) {
+	baseDir := filepath.Join(t.TempDir(), "db")
+
+	m, err := NewManifest(baseDir)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+
+	_, err = os.Stat(baseDir)
+	assert.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(baseDir, filename))
+	require.NoError(t, err)
+	assert.False(t, info.IsDir())
+
+	assert.Empty(t, m.GetInstanceID())
+}

--- a/oxiad/dataserver/public_rpc_server.go
+++ b/oxiad/dataserver/public_rpc_server.go
@@ -81,7 +81,7 @@ func newPublicRpcServer(provider oxiadcommonrpc.GrpcProvider, bindAddress string
 	server.grpcServer, err = provider.StartGrpcServer("public", bindAddress, func(registrar grpc.ServiceRegistrar) {
 		proto.RegisterOxiaClientServer(registrar, server)
 		compat.RegisterOxiaClientServer(registrar, &compatPublicRpcServer{impl: server})
-	}, tlsConf, options)
+	}, tlsConf, options, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -127,7 +127,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 	if err != nil {
 		return nil, err
 	}
-	s.internalRpcServer, err = newInternalRpcServer(provider, internalServer.BindAddress,
+	s.internalRpcServer, err = newInternalRpcServer(provider, internalServer.BindAddress, //nolint:contextcheck // Server construction wires interceptors and does not take a request-scoped context.
 		s.shardsDirector, s.shardAssignmentDispatcher, s.healthServer, internalServerTLS, &internalServer.Auth, manifest)
 	if err != nil {
 		return nil, err

--- a/oxiad/dataserver/server.go
+++ b/oxiad/dataserver/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver/assignment"
 	"github.com/oxia-db/oxia/oxiad/dataserver/controller"
 	"github.com/oxia-db/oxia/oxiad/dataserver/database/kvstore"
+	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 
 	"github.com/oxia-db/oxia/oxiad/dataserver/wal"
 
@@ -62,16 +63,20 @@ type Server struct {
 
 func New(parent context.Context, watchableOption *commonoption.Watch[*option.Options]) (*Server, error) {
 	options, _ := watchableOption.Load()
-	provider, err := rpc.NewReplicationRpcProvider(&options.Replication.TLS)
+	manifest, err := manifestpkg.NewManifest(options.Storage.Database.Dir)
 	if err != nil {
 		return nil, err
 	}
-	grpcProvider, err := NewWithGrpcProvider(parent, watchableOption, rpc2.Default, provider, false)
+	provider, err := rpc.NewReplicationRpcProvider(&options.Replication.TLS, manifest)
+	if err != nil {
+		return nil, err
+	}
+	grpcProvider, err := NewWithGrpcProvider(parent, watchableOption, rpc2.Default, provider, manifest, false)
 	return grpcProvider, err
 }
 
 func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.Watch[*option.Options], provider rpc2.GrpcProvider,
-	replicationRpcProvider rpc.ReplicationRpcProvider, disableAuthorityValidation bool) (*Server, error) {
+	replicationRpcProvider rpc.ReplicationRpcProvider, manifest *manifestpkg.Manifest, disableAuthorityValidation bool) (*Server, error) {
 	options, _ := watchableOption.Load()
 	slog.Info("Starting Oxia dataServer", slog.Any("options", options))
 
@@ -123,7 +128,7 @@ func NewWithGrpcProvider(parent context.Context, watchableOption *commonoption.W
 		return nil, err
 	}
 	s.internalRpcServer, err = newInternalRpcServer(provider, internalServer.BindAddress,
-		s.shardsDirector, s.shardAssignmentDispatcher, s.healthServer, internalServerTLS, &internalServer.Auth)
+		s.shardsDirector, s.shardAssignmentDispatcher, s.healthServer, internalServerTLS, &internalServer.Auth, manifest)
 	if err != nil {
 		return nil, err
 	}

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -108,8 +108,9 @@ func (m *maelstromCoordinatorRpcProvider) RemoveObserver(ctx context.Context, no
 	return &proto.RemoveObserverResponse{}, nil
 }
 
-func (m *maelstromCoordinatorRpcProvider) GetInfo(ctx context.Context, node model.Server, req *proto.GetInfoRequest) (*proto.GetInfoResponse, error) {
-	return &proto.GetInfoResponse{
+func (m *maelstromCoordinatorRpcProvider) Handshake(ctx context.Context, node model.Server, req *proto.HandshakeRequest) (*proto.HandshakeResponse, error) {
+	return &proto.HandshakeResponse{
+		Status:            proto.HandshakeStatus_HANDSHAKE_STATUS_ALREADY_BOUND,
 		FeaturesSupported: make([]proto.Feature, 0),
 	}, nil
 }

--- a/oxiad/maelstrom/coordinator_rpc_client.go
+++ b/oxiad/maelstrom/coordinator_rpc_client.go
@@ -46,6 +46,10 @@ type maelstromCoordinatorRpcProvider struct {
 	assignmentStreams map[int64]*maelstromShardAssignmentClient
 }
 
+func (m *maelstromCoordinatorRpcProvider) Close() error {
+	return nil
+}
+
 func (m *maelstromCoordinatorRpcProvider) ClearPooledConnections(node model.Server) {
 }
 

--- a/oxiad/maelstrom/grpc_provider.go
+++ b/oxiad/maelstrom/grpc_provider.go
@@ -55,7 +55,7 @@ func newMaelstromGrpcProvider() *maelstromGrpcProvider {
 }
 
 func (m *maelstromGrpcProvider) StartGrpcServer(name, _ string, registerFunc func(grpc.ServiceRegistrar),
-	_ *tls.Config, _ *auth.Options) (rpc.GrpcServer, error) {
+	_ *tls.Config, _ *auth.Options, _ *rpc.Interceptors) (rpc.GrpcServer, error) {
 	slog.Info(
 		"Start Grpc server",
 		slog.String("name", name),

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	"github.com/oxia-db/oxia/oxiad/dataserver"
+	manifestpkg "github.com/oxia-db/oxia/oxiad/dataserver/manifest"
 
 	"github.com/oxia-db/oxia/common/constant"
 	"github.com/oxia-db/oxia/oxiad/common/logging"
@@ -182,7 +184,9 @@ func main() {
 		_, err := coordinator.NewCoordinator(
 			metadata.NewMetadataProviderFile(filepath.Join(dataDir, "cluster-status.json")),
 			func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil,
-			newRpcProvider(dispatcher))
+			func(instanceID string) rpc.Provider {
+				return newRpcProvider(dispatcher)
+			})
 		if err != nil {
 			slog.Error(
 				"failed to create coordinator",
@@ -196,11 +200,20 @@ func main() {
 		dataServerOption.Observability.Metric.Enabled = &constant.FlagFalse
 		dataServerOption.Storage.Database.Dir = filepath.Join(dataDir, thisNode, "db")
 		dataServerOption.Storage.WAL.Dir = filepath.Join(dataDir, thisNode, "wal")
-		_, err := dataserver.NewWithGrpcProvider(
+		manifest, err := manifestpkg.NewManifest(dataServerOption.Storage.Database.Dir)
+		if err != nil {
+			slog.Error(
+				"failed to create dataserver manifest",
+				slog.Any("error", err),
+			)
+			os.Exit(1)
+		}
+		_, err = dataserver.NewWithGrpcProvider(
 			context.Background(),
 			commonoption.NewWatch(dataServerOption),
 			grpcProvider,
 			replicationGrpcProvider,
+			manifest,
 			true,
 		)
 		if err != nil {

--- a/oxiad/maelstrom/main.go
+++ b/oxiad/maelstrom/main.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/oxia-db/oxia/oxiad/coordinator/rpc"
 
 	commonoption "github.com/oxia-db/oxia/oxiad/common/option"
 

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -48,7 +48,12 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -106,7 +111,12 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -164,7 +174,12 @@ func TestLeaderHintListWithClient(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -213,7 +228,12 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -271,7 +291,12 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -324,7 +349,12 @@ func TestLeaderHintWithClient(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 

--- a/tests/assignments/leader_hint_test.go
+++ b/tests/assignments/leader_hint_test.go
@@ -52,7 +52,7 @@ func TestLeaderHintWithoutClient(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
@@ -115,7 +115,7 @@ func TestLeaderHintListWithoutClient(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
@@ -178,7 +178,7 @@ func TestLeaderHintListWithClient(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
@@ -232,7 +232,7 @@ func TestLeaderHintRangeScanWithoutClient(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
@@ -295,7 +295,7 @@ func TestLeaderHintRangeScanWithClient(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
@@ -353,7 +353,7 @@ func TestLeaderHintWithClient(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oxia-db/oxia/common/proto"
-	clientrpc "github.com/oxia-db/oxia/common/rpc"
 	"github.com/oxia-db/oxia/oxia"
 	"github.com/oxia-db/oxia/oxiad/coordinator"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
@@ -56,7 +55,12 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 

--- a/tests/control/control_request_test.go
+++ b/tests/control/control_request_test.go
@@ -59,7 +59,7 @@ func TestControlRequestFeatureEnabled(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oxia-db/oxia/common/proto"
-	clientrpc "github.com/oxia-db/oxia/common/rpc"
 	"github.com/oxia-db/oxia/oxia"
 	"github.com/oxia-db/oxia/oxiad/common/metric"
 	commonoption "github.com/oxia-db/oxia/oxiad/common/option"
@@ -77,7 +76,12 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc.NewRpcProvider(clientrpc.NewClientPool(nil, nil)))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 

--- a/tests/control/record_checksum_test.go
+++ b/tests/control/record_checksum_test.go
@@ -80,7 +80,7 @@ func TestControlRequestRecordChecksum(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc.NewRpcProvider(nil, rpc.InstanceIDFromMetadata(metadataProvider)),
+		rpc.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -16,6 +16,7 @@ package coordinator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -77,7 +78,7 @@ func TestCoordinatorE2E(t *testing.T) {
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -115,7 +116,7 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -167,7 +168,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -198,10 +199,21 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 		slog.Any("follower", follower),
 	)
 
-	client, err := oxia.NewSyncClient(follower.Public)
-	assert.NoError(t, err)
-
 	ctx := context.Background()
+
+	assert.Eventually(t, func() bool {
+		probeClient, err := oxia.NewSyncClient(follower.Public, oxia.WithRequestTimeout(1*time.Second))
+		if err != nil {
+			return false
+		}
+		defer probeClient.Close()
+
+		_, _, _, err = probeClient.Get(ctx, "my-key")
+		return errors.Is(err, oxia.ErrKeyNotFound)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	client, err := oxia.NewSyncClient(follower.Public, oxia.WithRequestTimeout(1*time.Second))
+	assert.NoError(t, err)
 
 	_, version1, err := client.Put(ctx, "my-key", []byte("my-value"))
 	assert.NoError(t, err)
@@ -225,11 +237,18 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 
 	// Wait for the client to receive the updated assignment list
 	assert.Eventually(t, func() bool {
-		client, _ = oxia.NewSyncClient(follower.Public)
-		_, _, _, err := client.Get(ctx, "my-key")
+		probeClient, err := oxia.NewSyncClient(follower.Public, oxia.WithRequestTimeout(1*time.Second))
+		if err != nil {
+			return false
+		}
+		defer probeClient.Close()
+
+		_, _, _, err = probeClient.Get(ctx, "my-key")
 		return err == nil
 	}, 10*time.Second, 10*time.Millisecond)
 
+	client, err = oxia.NewSyncClient(follower.Public, oxia.WithRequestTimeout(1*time.Second))
+	assert.NoError(t, err)
 	_, res, version3, err := client.Get(ctx, "my-key")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("my-value"), res)
@@ -271,7 +290,7 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -362,7 +381,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -410,7 +429,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}
 
 	slog.Info("Restarting coordinator")
-	coordinatorInstance, err = coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return newClusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err = coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return newClusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource = coordinatorInstance.StatusResource()
@@ -453,7 +472,7 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		return clusterConfig, nil
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -543,7 +562,7 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	}
 
 	configChangesCh := make(chan any)
-	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	assert.Equal(t, 3, len(c.NodeControllers()))
@@ -603,7 +622,7 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 	}
 
 	configChangesCh := make(chan any)
-	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := c.StatusResource()
@@ -679,7 +698,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	c, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) {
 		return clusterConfig, nil
 	}, configChangesCh,
-		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+		rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	statusResource := c.StatusResource()

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -210,7 +210,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 
 		_, _, _, err = probeClient.Get(ctx, "my-key")
 		return errors.Is(err, oxia.ErrKeyNotFound)
-	}, 10*time.Second, 100*time.Millisecond)
+	}, 30*time.Second, 1*time.Second)
 
 	client, err := oxia.NewSyncClient(follower.Public, oxia.WithRequestTimeout(1*time.Second))
 	assert.NoError(t, err)
@@ -245,7 +245,7 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 
 		_, _, _, err = probeClient.Get(ctx, "my-key")
 		return err == nil
-	}, 10*time.Second, 10*time.Millisecond)
+	}, 30*time.Second, 1*time.Second)
 
 	client, err = oxia.NewSyncClient(follower.Public, oxia.WithRequestTimeout(1*time.Second))
 	assert.NoError(t, err)

--- a/tests/coordinator/coordinator_e2e_test.go
+++ b/tests/coordinator/coordinator_e2e_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver"
 
 	"github.com/oxia-db/oxia/common/constant"
-	"github.com/oxia-db/oxia/common/rpc"
 	"github.com/oxia-db/oxia/oxia"
 )
 
@@ -77,9 +76,8 @@ func TestCoordinatorE2E(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -96,7 +94,6 @@ func TestCoordinatorE2E(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	assert.NoError(t, coordinatorInstance.Close())
-	assert.NoError(t, clientPool.Close())
 
 	assert.NoError(t, s1.Close())
 	assert.NoError(t, s2.Close())
@@ -117,9 +114,8 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -145,7 +141,6 @@ func TestCoordinatorE2E_ShardsRanges(t *testing.T) {
 	assert.EqualValues(t, math.MaxUint32, nsStatus.Shards[3].Int32HashRange.Max)
 
 	assert.NoError(t, coordinatorInstance.Close())
-	assert.NoError(t, clientPool.Close())
 
 	assert.NoError(t, s1.Close())
 	assert.NoError(t, s2.Close())
@@ -171,9 +166,8 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -243,7 +237,6 @@ func TestCoordinator_LeaderFailover(t *testing.T) {
 	assert.NoError(t, client.Close())
 
 	assert.NoError(t, coordinatorInstance.Close())
-	assert.NoError(t, clientPool.Close())
 
 	for _, serverObj := range servers {
 		assert.NoError(t, serverObj.Close())
@@ -277,9 +270,8 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -344,7 +336,6 @@ func TestCoordinator_MultipleNamespaces(t *testing.T) {
 	assert.EqualValues(t, 0, version3.ModificationsCount)
 
 	assert.NoError(t, coordinatorInstance.Close())
-	assert.NoError(t, clientPool.Close())
 
 	for _, serverObj := range servers {
 		assert.NoError(t, serverObj.Close())
@@ -370,9 +361,8 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -420,7 +410,7 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}
 
 	slog.Info("Restarting coordinator")
-	coordinatorInstance, err = coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return newClusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err = coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return newClusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource = coordinatorInstance.StatusResource()
@@ -432,7 +422,6 @@ func TestCoordinator_DeleteNamespace(t *testing.T) {
 	}, 10*time.Second, 10*time.Millisecond)
 
 	assert.NoError(t, coordinatorInstance.Close())
-	assert.NoError(t, clientPool.Close())
 
 	for _, serverObj := range servers {
 		assert.NoError(t, serverObj.Close())
@@ -458,14 +447,13 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
 	configChangesCh := make(chan any)
 	configProvider := func() (model.ClusterConfig, error) {
 		return clusterConfig, nil
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := coordinatorInstance.StatusResource()
@@ -520,7 +508,6 @@ func TestCoordinator_DynamicallAddNamespace(t *testing.T) {
 	assert.EqualValues(t, 1, ns1Status.ReplicationFactor)
 
 	assert.NoError(t, coordinatorInstance.Close())
-	assert.NoError(t, clientPool.Close())
 
 	for _, serverObj := range servers {
 		assert.NoError(t, serverObj.Close())
@@ -550,14 +537,13 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
 	configProvider := func() (model.ClusterConfig, error) {
 		return clusterConfig, nil
 	}
 
 	configChangesCh := make(chan any)
-	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(clientPool))
+	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	assert.Equal(t, 3, len(c.NodeControllers()))
@@ -584,7 +570,6 @@ func TestCoordinator_AddRemoveNodes(t *testing.T) {
 	assert.True(t, ok)
 
 	assert.NoError(t, c.Close())
-	assert.NoError(t, clientPool.Close())
 
 	for _, serverObj := range servers {
 		assert.NoError(t, serverObj.Close())
@@ -612,14 +597,13 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3, sa4},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
 	configProvider := func() (model.ClusterConfig, error) {
 		return clusterConfig, nil
 	}
 
 	configChangesCh := make(chan any)
-	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(clientPool))
+	c, err := coordinator.NewCoordinator(metadataProvider, configProvider, configChangesCh, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := c.StatusResource()
@@ -671,7 +655,6 @@ func TestCoordinator_ShrinkCluster(t *testing.T) {
 
 	assert.NoError(t, client.Close())
 	assert.NoError(t, c.Close())
-	assert.NoError(t, clientPool.Close())
 
 	for _, serverObj := range servers {
 		assert.NoError(t, serverObj.Close())
@@ -696,7 +679,7 @@ func TestCoordinator_RefreshServerInfo(t *testing.T) {
 	c, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) {
 		return clusterConfig, nil
 	}, configChangesCh,
-		rpc2.NewRpcProvider(rpc.NewClientPool(nil, nil)))
+		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	statusResource := c.StatusResource()

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -47,7 +47,7 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)),
+		rpc2.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()

--- a/tests/coordinator/coordinator_test.go
+++ b/tests/coordinator/coordinator_test.go
@@ -23,8 +23,6 @@ import (
 	metadata2 "github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
-
-	"github.com/oxia-db/oxia/common/rpc"
 )
 
 func TestCoordinatorInitiateLeaderElection(t *testing.T) {
@@ -44,9 +42,13 @@ func TestCoordinatorInitiateLeaderElection(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return clusterConfig, nil },
+		nil,
+		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)),
+	)
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -68,7 +68,7 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)),
+		rpc2.NewRpcProviderFactory(nil),
 	)
 	require.NoError(t, err)
 	clientPool := rpc.NewClientPool(nil, nil)
@@ -333,7 +333,7 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)),
+		rpc2.NewRpcProviderFactory(nil),
 	)
 	require.NoError(t, err)
 
@@ -855,7 +855,7 @@ func TestCoordinator_KeySorting(t *testing.T) {
 				Servers: []model.Server{sa1},
 			}
 
-			coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+			coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 			assert.NoError(t, err)
 
 			statusResource := coordinatorInstance.StatusResource()

--- a/tests/coordinator/split_e2e_test.go
+++ b/tests/coordinator/split_e2e_test.go
@@ -63,15 +63,15 @@ func TestCoordinator_ShardSplit(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
 	coordinatorInstance, err := coordinator.NewCoordinator(
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc2.NewRpcProvider(clientPool),
+		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)),
 	)
 	require.NoError(t, err)
+	clientPool := rpc.NewClientPool(nil, nil)
 
 	statusResource := coordinatorInstance.StatusResource()
 
@@ -302,7 +302,6 @@ type splitTestCluster struct {
 	sa1                 model.Server
 	coordinator         coordinator.Coordinator
 	statusResource      resource.StatusResource
-	clientPool          rpc.ClientPool
 	leftChild           int64
 	rightChild          int64
 	leftMeta, rightMeta model.ShardMetadata
@@ -329,13 +328,12 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
 
 	coordinatorInstance, err := coordinator.NewCoordinator(
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
 		nil,
-		rpc2.NewRpcProvider(clientPool),
+		rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)),
 	)
 	require.NoError(t, err)
 
@@ -351,7 +349,6 @@ func setupSplitCluster(t *testing.T) *splitTestCluster {
 		sa1:            sa1,
 		coordinator:    coordinatorInstance,
 		statusResource: statusResource,
-		clientPool:     clientPool,
 	}
 }
 
@@ -423,7 +420,6 @@ func (c *splitTestCluster) reconnectClient(t *testing.T, old oxia.SyncClient, te
 func (c *splitTestCluster) close(t *testing.T) {
 	t.Helper()
 	assert.NoError(t, c.coordinator.Close())
-	assert.NoError(t, c.clientPool.Close())
 	for _, s := range c.servers {
 		assert.NoError(t, s.Close())
 	}
@@ -858,9 +854,8 @@ func TestCoordinator_KeySorting(t *testing.T) {
 				}},
 				Servers: []model.Server{sa1},
 			}
-			clientPool := rpc.NewClientPool(nil, nil)
 
-			coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+			coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 			assert.NoError(t, err)
 
 			statusResource := coordinatorInstance.StatusResource()
@@ -895,7 +890,6 @@ func TestCoordinator_KeySorting(t *testing.T) {
 
 			assert.NoError(t, client.Close())
 			assert.NoError(t, coordinatorInstance.Close())
-			assert.NoError(t, clientPool.Close())
 
 			assert.NoError(t, s1.Close())
 		})

--- a/tests/mock/coordinator.go
+++ b/tests/mock/coordinator.go
@@ -17,21 +17,24 @@ package mock
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
 	"github.com/oxia-db/oxia/oxiad/coordinator/model"
 	rpc2 "github.com/oxia-db/oxia/oxiad/coordinator/rpc"
-
-	"github.com/oxia-db/oxia/common/rpc"
 )
 
 func NewCoordinator(t *testing.T, config *model.ClusterConfig, clusterConfigNotificationCh chan any) coordinator.Coordinator {
 	t.Helper()
 	metadataProvider := metadata.NewMetadataProviderMemory()
-	clientPool := rpc.NewClientPool(nil, nil)
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return *config, nil }, clusterConfigNotificationCh, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(
+		metadataProvider,
+		func() (model.ClusterConfig, error) { return *config, nil },
+		clusterConfigNotificationCh,
+		rpc2.NewRpcProvider(nil, uuid.NewString()),
+	)
 	assert.NoError(t, err)
 	return coordinatorInstance
 }

--- a/tests/mock/coordinator.go
+++ b/tests/mock/coordinator.go
@@ -17,7 +17,6 @@ package mock
 import (
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/oxia-db/oxia/oxiad/coordinator"
@@ -33,7 +32,7 @@ func NewCoordinator(t *testing.T, config *model.ClusterConfig, clusterConfigNoti
 		metadataProvider,
 		func() (model.ClusterConfig, error) { return *config, nil },
 		clusterConfigNotificationCh,
-		rpc2.NewRpcProvider(nil, uuid.NewString()),
+		rpc2.NewRpcProviderFactory(nil),
 	)
 	assert.NoError(t, err)
 	return coordinatorInstance

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/oxia-db/oxia/common/constant"
-	clientrpc "github.com/oxia-db/oxia/common/rpc"
 	"github.com/oxia-db/oxia/oxia"
 	"github.com/oxia-db/oxia/oxiad/coordinator"
 	"github.com/oxia-db/oxia/oxiad/coordinator/metadata"
@@ -39,7 +38,6 @@ type testCluster struct {
 	name        string
 	authority   string
 	coordinator coordinator.Coordinator
-	clientPool  clientrpc.ClientPool
 	servers     map[string]*dataserver.Server
 	addresses   []model.Server
 }
@@ -64,10 +62,10 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 		cluster.addresses = append(cluster.addresses, addr)
 	}
 
-	cluster.clientPool = clientrpc.NewClientPool(nil, nil)
+	metadataProvider := metadata.NewMetadataProviderMemory()
 	var err error
 	cluster.coordinator, err = coordinator.NewCoordinator(
-		metadata.NewMetadataProviderMemory(),
+		metadataProvider,
 		func() (model.ClusterConfig, error) {
 			return model.ClusterConfig{
 				Namespaces: []model.NamespaceConfig{{
@@ -80,7 +78,7 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 			}, nil
 		},
 		nil,
-		coordinatorrpc.NewRpcProvider(cluster.clientPool),
+		coordinatorrpc.NewRpcProvider(nil, coordinatorrpc.InstanceIDFromMetadata(metadataProvider)),
 	)
 	require.NoError(t, err)
 
@@ -96,9 +94,6 @@ func (c *testCluster) close(t *testing.T) {
 	t.Helper()
 	if c.coordinator != nil {
 		assert.NoError(t, c.coordinator.Close())
-	}
-	if c.clientPool != nil {
-		assert.NoError(t, c.clientPool.Close())
 	}
 	for _, server := range c.servers {
 		assert.NoError(t, server.Close())

--- a/tests/resolver/target_ip_flip_test.go
+++ b/tests/resolver/target_ip_flip_test.go
@@ -78,7 +78,7 @@ func newCoordinatorCluster(t *testing.T, prefix string, serverCount int) *testCl
 			}, nil
 		},
 		nil,
-		coordinatorrpc.NewRpcProvider(nil, coordinatorrpc.InstanceIDFromMetadata(metadataProvider)),
+		coordinatorrpc.NewRpcProviderFactory(nil),
 	)
 	require.NoError(t, err)
 

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver"
 
 	"github.com/oxia-db/oxia/common/constant"
-	"github.com/oxia-db/oxia/common/rpc"
 
 	"github.com/oxia-db/oxia/oxia"
 
@@ -115,11 +114,9 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 		Servers: []model.Server{s1Addr, s2Addr, s3Addr},
 	}
 
-	clientPool := rpc.NewClientPool(nil, nil)
-
 	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProvider(clientPool))
+		nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 
 	return s1Addr.Public, func() {
@@ -127,7 +124,6 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 		s2.Close()
 		s3.Close()
 
-		clientPool.Close()
 		coordinatorInstance.Close()
 	}
 }
@@ -314,12 +310,9 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 		Servers: []model.Server{s1Addr, s2Addr, s3Addr},
 	}
 
-	clientPool := rpc.NewClientPool(nil, nil)
-	defer clientPool.Close()
-
 	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProvider(clientPool))
+		nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -475,12 +468,9 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 		Servers: []model.Server{s1Addr, s2Addr, s3Addr},
 	}
 
-	clientPool := rpc.NewClientPool(nil, nil)
-	defer clientPool.Close()
-
 	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProvider(clientPool))
+		nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 

--- a/tests/security/auth/auth_oidc_test.go
+++ b/tests/security/auth/auth_oidc_test.go
@@ -116,7 +116,7 @@ func newOxiaClusterWithAuth(t *testing.T, issueURL string, audiences string) (ad
 
 	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+		nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 
 	return s1Addr.Public, func() {
@@ -312,7 +312,7 @@ func TestOIDCWithPerIssuerConfig(t *testing.T) {
 
 	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+		nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -470,7 +470,7 @@ func TestOIDCWithStaticKeyFile(t *testing.T) {
 
 	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider,
 		func() (model.ClusterConfig, error) { return clusterConfig, nil },
-		nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+		nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/oxia-db/oxia/oxiad/dataserver"
 
 	"github.com/oxia-db/oxia/common/constant"
-	"github.com/oxia-db/oxia/common/rpc"
 
 	"github.com/oxia-db/oxia/common/security"
 	"github.com/oxia-db/oxia/oxia"
@@ -133,10 +132,7 @@ func TestClusterHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	clientPool := rpc.NewClientPool(tlsConf, nil)
-	defer clientPool.Close()
-
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 }
@@ -163,10 +159,7 @@ func TestClientHandshakeFailByNoTlsConfig(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	clientPool := rpc.NewClientPool(tlsConf, nil)
-	defer clientPool.Close()
-
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -197,10 +190,7 @@ func TestClientHandshakeByAuthFail(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	clientPool := rpc.NewClientPool(tlsConf, nil)
-	defer clientPool.Close()
-
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -237,10 +227,7 @@ func TestClientHandshakeWithInsecure(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	clientPool := rpc.NewClientPool(tlsConf, nil)
-	defer clientPool.Close()
-
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -278,10 +265,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	clientPool := rpc.NewClientPool(tlsConf, nil)
-	defer clientPool.Close()
-
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -315,10 +299,8 @@ func TestOnlyEnablePublicTls(t *testing.T) {
 		}},
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
-	clientPool := rpc.NewClientPool(nil, nil)
-	defer clientPool.Close()
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(clientPool))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 

--- a/tests/security/tls/tls_encryption_test.go
+++ b/tests/security/tls/tls_encryption_test.go
@@ -132,7 +132,7 @@ func TestClusterHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 }
@@ -159,7 +159,7 @@ func TestClientHandshakeFailByNoTlsConfig(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -190,7 +190,7 @@ func TestClientHandshakeByAuthFail(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -227,7 +227,7 @@ func TestClientHandshakeWithInsecure(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -265,7 +265,7 @@ func TestClientHandshakeSuccess(t *testing.T) {
 	tlsConf, err := option.TryIntoClientTLSConf()
 	assert.NoError(t, err)
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(tlsConf, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(tlsConf))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 
@@ -300,7 +300,7 @@ func TestOnlyEnablePublicTls(t *testing.T) {
 		Servers: []model.Server{sa1, sa2, sa3},
 	}
 
-	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProvider(nil, rpc2.InstanceIDFromMetadata(metadataProvider)))
+	coordinatorInstance, err := coordinator.NewCoordinator(metadataProvider, func() (model.ClusterConfig, error) { return clusterConfig, nil }, nil, rpc2.NewRpcProviderFactory(nil))
 	assert.NoError(t, err)
 	defer coordinatorInstance.Close()
 


### PR DESCRIPTION
## Motivation
- prevent internal coordination and replication RPCs from crossing coordinator instances after dataservers have local state
- bind each dataserver to a coordinator-owned persisted `instance_id` instead of relying on endpoint authority for internal traffic
- keep rolling upgrades working while moving dataserver initialization away from `GetInfo`

## Modifications
- added `Handshake` to the coordination RPC API, deprecated `GetInfo` for removal in the next major version, and persisted a cluster-wide `instance_id` in coordinator status
- added a dataserver `MANIFEST` file to persist the bound `instance_id`, with dataservers staying uninitialized until handshake succeeds
- validated internal coordination and replication RPCs with `instance-id` metadata, while keeping health and handshake open for bootstrap
- moved coordinator RPC clients to factory-based construction and updated tests, mocks, and helpers to use the new provider ownership model
- kept rolling-upgrade compatibility by falling back from `Handshake` to deprecated `GetInfo` when talking to older dataservers

## Testing
- `go test ./common/rpc -count=1`
- `go test ./tests/coordinator -run 'TestCoordinatorE2E$|TestCoordinatorE2E_ShardsRanges$|TestCoordinator_LeaderFailover$' -count=1 -timeout 180s`
- `go test ./tests/assignments ./tests/control ./tests/resolver -count=1 -timeout 180s`
- `go test ./tests/security/auth ./tests/security/tls -count=1 -timeout 180s`
- `go test ./common/... ./oxiad/... -count=1`
